### PR TITLE
直通JR判定削除＆同じ路線名の直通省略

### DIFF
--- a/src/utils/jr.ts
+++ b/src/utils/jr.ts
@@ -1,4 +1,0 @@
-const JR_LINE_MAX_ID = 6;
-
-export const isJRLine = (companyId: number): boolean =>
-  companyId <= JR_LINE_MAX_ID;


### PR DESCRIPTION
- JRでも他の私鉄と同じように直通名処理する
- JR常磐線/JR常磐線みたいな感じに出ないようになる