### PR TITLE
ナンバリングシンボルがないナンバリング対応

### DIFF
--- a/src/raw/raw.service.ts
+++ b/src/raw/raw.service.ts
@@ -63,7 +63,7 @@ export class RawService {
         (num, idx) =>
           num && {
             lineSymbol: lineSymbolsRaw[idx] ?? null,
-            lineSymbolColor: lineSymbolColorsRaw[idx] || null,
+            lineSymbolColor: lineSymbolColorsRaw[idx] ?? null,
             stationNumber: `${lineSymbolsRaw[idx] ?? ''}-${
               stationNumbersRaw[idx]
             }`,

--- a/src/raw/raw.service.ts
+++ b/src/raw/raw.service.ts
@@ -61,11 +61,12 @@ export class RawService {
     const fullStationNumbers: StationNumber[] = stationNumbersRaw
       .map(
         (num, idx) =>
-          num &&
-          lineSymbolsRaw[idx] && {
-            lineSymbol: lineSymbolsRaw[idx],
+          num && {
+            lineSymbol: lineSymbolsRaw[idx] ?? null,
             lineSymbolColor: lineSymbolColorsRaw[idx] || null,
-            stationNumber: `${lineSymbolsRaw[idx]}-${stationNumbersRaw[idx]}`,
+            stationNumber: `${lineSymbolsRaw[idx] ?? ''}-${
+              stationNumbersRaw[idx]
+            }`,
           },
       )
       .filter((num) => num)


### PR DESCRIPTION
ナンバリングシンボル（丸ノ内線だったらM、山手線だったらJYなど）がデータとして登録されていないとそもそもナンバリングそのものが登録されていないように振る舞う実装になっていたので、シンボルが存在しない時 `lineSymbol`をnullに、`stationNumber`をたとえば駅番号が01であれば`-01`を返すように修正
最初のハイフンがないとアプリ側ではナンバリング番号と識別できないため今のところはつけている