### PR TITLE
駅に路線記号がない時ハイフンを省略する

### DIFF
--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -80,9 +80,9 @@ export const convertStation = (
         num && {
           lineSymbol: lineSymbolsRaw[idx] ?? null,
           lineSymbolColor: lineSymbolColorsRaw[idx] ?? null,
-          stationNumber: `${lineSymbolsRaw[idx] ?? ''}-${
-            stationNumbersRaw[idx]
-          }`,
+          stationNumber: lineSymbolsRaw[idx]
+            ? `${lineSymbolsRaw[idx]}-${stationNumbersRaw[idx]}`
+            : stationNumbersRaw[idx],
         },
     )
     .filter((num) => num)


### PR DESCRIPTION
closes #454 