### PR TITLE
路線に紐づく駅のフィールド追加

### DIFF
--- a/proto/stationapi.proto
+++ b/proto/stationapi.proto
@@ -188,6 +188,7 @@ message LineResponse {
     CompanyResponse company = 10;
     repeated LineSymbol line_symbols = 11;
     OperationStatus status = 12;
+    StationResponse station = 13;
 }
 
 message SingleLineResponse {

--- a/proto/stationapi.proto
+++ b/proto/stationapi.proto
@@ -94,12 +94,12 @@ message StationNumber {
 }
 
 enum StopCondition {
-    ALL = 0;
-    NOT = 1;
-    PARTIAL = 2;
-    WEEKDAY = 3;
-    HOLIDAY = 4;
-    PARTIAL_STOP = 5;
+    All = 0;
+    Not = 1;
+    Partial = 2;
+    Weekday = 3;
+    Holiday = 4;
+    PartialStop = 5;
   
 }
 

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -153,7 +153,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -165,7 +165,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -177,7 +177,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -189,7 +189,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -201,7 +201,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -225,7 +225,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -237,7 +237,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -336,6 +336,291 @@
       }
     },
     "query": "SELECT *\n        FROM `lines`\n        WHERE line_cd = ?\n        AND e_status = 0\n        LIMIT 1"
+  },
+  "152108a47fb4dacfceb7d20fd3a0e583db4a834e7d653adfc041d083c9b12221": {
+    "describe": {
+      "columns": [
+        {
+          "name": "station_cd",
+          "ordinal": 0,
+          "type_info": {
+            "char_set": 63,
+            "flags": {
+              "bits": 4131
+            },
+            "max_size": 10,
+            "type": "Long"
+          }
+        },
+        {
+          "name": "station_g_cd",
+          "ordinal": 1,
+          "type_info": {
+            "char_set": 63,
+            "flags": {
+              "bits": 4137
+            },
+            "max_size": 10,
+            "type": "Long"
+          }
+        },
+        {
+          "name": "station_name",
+          "ordinal": 2,
+          "type_info": {
+            "char_set": 224,
+            "flags": {
+              "bits": 4241
+            },
+            "max_size": 262140,
+            "type": "Blob"
+          }
+        },
+        {
+          "name": "station_name_k",
+          "ordinal": 3,
+          "type_info": {
+            "char_set": 224,
+            "flags": {
+              "bits": 4241
+            },
+            "max_size": 262140,
+            "type": "Blob"
+          }
+        },
+        {
+          "name": "station_name_r",
+          "ordinal": 4,
+          "type_info": {
+            "char_set": 224,
+            "flags": {
+              "bits": 4241
+            },
+            "max_size": 262140,
+            "type": "Blob"
+          }
+        },
+        {
+          "name": "station_name_zh",
+          "ordinal": 5,
+          "type_info": {
+            "char_set": 224,
+            "flags": {
+              "bits": 4241
+            },
+            "max_size": 262140,
+            "type": "Blob"
+          }
+        },
+        {
+          "name": "station_name_ko",
+          "ordinal": 6,
+          "type_info": {
+            "char_set": 224,
+            "flags": {
+              "bits": 4241
+            },
+            "max_size": 262140,
+            "type": "Blob"
+          }
+        },
+        {
+          "name": "primary_station_number",
+          "ordinal": 7,
+          "type_info": {
+            "char_set": 224,
+            "flags": {
+              "bits": 144
+            },
+            "max_size": 262140,
+            "type": "Blob"
+          }
+        },
+        {
+          "name": "secondary_station_number",
+          "ordinal": 8,
+          "type_info": {
+            "char_set": 224,
+            "flags": {
+              "bits": 144
+            },
+            "max_size": 262140,
+            "type": "Blob"
+          }
+        },
+        {
+          "name": "extra_station_number",
+          "ordinal": 9,
+          "type_info": {
+            "char_set": 224,
+            "flags": {
+              "bits": 144
+            },
+            "max_size": 262140,
+            "type": "Blob"
+          }
+        },
+        {
+          "name": "three_letter_code",
+          "ordinal": 10,
+          "type_info": {
+            "char_set": 224,
+            "flags": {
+              "bits": 144
+            },
+            "max_size": 262140,
+            "type": "Blob"
+          }
+        },
+        {
+          "name": "line_cd",
+          "ordinal": 11,
+          "type_info": {
+            "char_set": 63,
+            "flags": {
+              "bits": 4137
+            },
+            "max_size": 10,
+            "type": "Long"
+          }
+        },
+        {
+          "name": "pref_cd",
+          "ordinal": 12,
+          "type_info": {
+            "char_set": 63,
+            "flags": {
+              "bits": 4129
+            },
+            "max_size": 10,
+            "type": "Long"
+          }
+        },
+        {
+          "name": "post",
+          "ordinal": 13,
+          "type_info": {
+            "char_set": 224,
+            "flags": {
+              "bits": 4241
+            },
+            "max_size": 262140,
+            "type": "Blob"
+          }
+        },
+        {
+          "name": "address",
+          "ordinal": 14,
+          "type_info": {
+            "char_set": 224,
+            "flags": {
+              "bits": 4241
+            },
+            "max_size": 262140,
+            "type": "Blob"
+          }
+        },
+        {
+          "name": "lon",
+          "ordinal": 15,
+          "type_info": {
+            "char_set": 63,
+            "flags": {
+              "bits": 4129
+            },
+            "max_size": 12,
+            "type": "NewDecimal"
+          }
+        },
+        {
+          "name": "lat",
+          "ordinal": 16,
+          "type_info": {
+            "char_set": 63,
+            "flags": {
+              "bits": 4129
+            },
+            "max_size": 12,
+            "type": "NewDecimal"
+          }
+        },
+        {
+          "name": "open_ymd",
+          "ordinal": 17,
+          "type_info": {
+            "char_set": 224,
+            "flags": {
+              "bits": 4241
+            },
+            "max_size": 262140,
+            "type": "Blob"
+          }
+        },
+        {
+          "name": "close_ymd",
+          "ordinal": 18,
+          "type_info": {
+            "char_set": 224,
+            "flags": {
+              "bits": 4241
+            },
+            "max_size": 262140,
+            "type": "Blob"
+          }
+        },
+        {
+          "name": "e_status",
+          "ordinal": 19,
+          "type_info": {
+            "char_set": 63,
+            "flags": {
+              "bits": 4137
+            },
+            "max_size": 10,
+            "type": "Long"
+          }
+        },
+        {
+          "name": "e_sort",
+          "ordinal": 20,
+          "type_info": {
+            "char_set": 63,
+            "flags": {
+              "bits": 4137
+            },
+            "max_size": 10,
+            "type": "Long"
+          }
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "SELECT * FROM stations WHERE station_g_cd = ? AND line_cd = ?"
   },
   "345201ea03ede9dad96ce9b6f86780984200ed2f22a6e2970f1b2b6779af022f": {
     "describe": {
@@ -490,7 +775,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -502,7 +787,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -514,7 +799,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -526,7 +811,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -538,7 +823,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -562,7 +847,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -574,7 +859,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -1065,7 +1350,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 4113
+              "bits": 4241
             },
             "max_size": 262140,
             "type": "Blob"
@@ -1863,7 +2148,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -1875,7 +2160,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -1887,7 +2172,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -1899,7 +2184,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -1911,7 +2196,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -1935,7 +2220,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"
@@ -1947,7 +2232,7 @@
           "type_info": {
             "char_set": 224,
             "flags": {
-              "bits": 16
+              "bits": 144
             },
             "max_size": 262140,
             "type": "Blob"

--- a/src/entities/line.rs
+++ b/src/entities/line.rs
@@ -45,6 +45,7 @@ impl From<Line> for LineResponse {
             company: None,
             line_symbols: vec![],
             status: value.e_status as i32,
+            station: None,
         }
     }
 }

--- a/src/entities/station.rs
+++ b/src/entities/station.rs
@@ -2,7 +2,7 @@ use bigdecimal::BigDecimal;
 
 use crate::service::StationResponse;
 
-#[derive(sqlx::FromRow, Clone)]
+#[derive(sqlx::FromRow, Clone, Debug)]
 pub struct Station {
     pub station_cd: u32,
     pub station_g_cd: u32,
@@ -104,6 +104,63 @@ impl From<Station> for StationResponse {
             status: value.e_status as i32,
             station_numbers: vec![],
             stop_condition: 0,
+            distance: Some(0.0),
+        }
+    }
+}
+
+impl From<StationWithDistance> for Station {
+    fn from(value: StationWithDistance) -> Self {
+        Station {
+            station_cd: value.station_cd,
+            station_g_cd: value.station_g_cd,
+            station_name: value.station_name,
+            station_name_k: value.station_name_k,
+            station_name_r: value.station_name_r,
+            station_name_zh: value.station_name_zh,
+            station_name_ko: value.station_name_ko,
+            primary_station_number: value.primary_station_number,
+            secondary_station_number: value.secondary_station_number,
+            extra_station_number: value.extra_station_number,
+            three_letter_code: value.three_letter_code,
+            line_cd: value.line_cd,
+            pref_cd: value.pref_cd,
+            post: value.post,
+            address: value.address,
+            lon: value.lon,
+            lat: value.lat,
+            open_ymd: value.open_ymd,
+            close_ymd: value.close_ymd,
+            e_status: value.e_status,
+            e_sort: value.e_sort,
+        }
+    }
+}
+
+impl From<Station> for StationWithDistance {
+    fn from(value: Station) -> Self {
+        StationWithDistance {
+            station_cd: value.station_cd,
+            station_g_cd: value.station_g_cd,
+            station_name: value.station_name,
+            station_name_k: value.station_name_k,
+            station_name_r: value.station_name_r,
+            station_name_zh: value.station_name_zh,
+            station_name_ko: value.station_name_ko,
+            primary_station_number: value.primary_station_number,
+            secondary_station_number: value.secondary_station_number,
+            extra_station_number: value.extra_station_number,
+            three_letter_code: value.three_letter_code,
+            line_cd: value.line_cd,
+            pref_cd: value.pref_cd,
+            post: value.post,
+            address: value.address,
+            lon: value.lon,
+            lat: value.lat,
+            open_ymd: value.open_ymd,
+            close_ymd: value.close_ymd,
+            e_status: value.e_status,
+            e_sort: value.e_sort,
             distance: Some(0.0),
         }
     }

--- a/src/repositories/station.rs
+++ b/src/repositories/station.rs
@@ -1,8 +1,6 @@
 use async_trait::async_trait;
 use sqlx::{MySql, Pool};
 
-use crate::entities::line::Line;
-
 type StationEntity = crate::entities::station::Station;
 type StationWithDistanceEntity = crate::entities::station::StationWithDistance;
 type LineEntity = crate::entities::line::Line;
@@ -125,7 +123,10 @@ impl StationRepository for StationRepositoryImplOnMySQL<'_> {
         }
     }
 
-    async fn get_lines_by_station_id(&self, station_id: u32) -> Result<Vec<Line>, sqlx::Error> {
+    async fn get_lines_by_station_id(
+        &self,
+        station_id: u32,
+    ) -> Result<Vec<LineEntity>, sqlx::Error> {
         let result = sqlx::query_as!(
             LineEntity,
             "SELECT l.* FROM `lines` AS l WHERE EXISTS

--- a/src/server.rs
+++ b/src/server.rs
@@ -46,7 +46,7 @@ impl StationApi for MyApi {
     ) -> Result<Response<MultipleStationResponse>, Status> {
         let req_inner = request.into_inner();
         let resp = get_stations_by_coordinates(
-            StationRepositoryImplOnMySQL { pool: &self.pool },
+            &StationRepositoryImplOnMySQL { pool: &self.pool },
             req_inner.latitude,
             req_inner.longitude,
             req_inner.limit,

--- a/src/server.rs
+++ b/src/server.rs
@@ -29,15 +29,15 @@ impl StationApi for MyApi {
         &self,
         request: Request<GetStationByIdRequest>,
     ) -> Result<Response<SingleStationResponse>, Status> {
-        if let Some(resp) = find_station_by_id(
+        let Some(resp) = find_station_by_id(
             StationRepositoryImplOnMySQL { pool: &self.pool },
             request.into_inner().id,
         )
-        .await
-        {
-            return Ok(Response::new(resp));
-        }
-        Err(Status::not_found("The station is not found"))
+        .await else {
+            return Err(Status::not_found("Requested station is not found"));
+        };
+
+        return Ok(Response::new(resp));
     }
 
     async fn get_station_by_coordinates(

--- a/src/usecases/station.rs
+++ b/src/usecases/station.rs
@@ -1,7 +1,10 @@
 use std::vec;
 
 use crate::{
-    entities::line::Line,
+    entities::{
+        line::Line,
+        station::{Station, StationWithDistance},
+    },
     repositories::station::StationRepository,
     service::{
         LineResponse, LineSymbol, MultipleStationResponse, SingleStationResponse, StationResponse,
@@ -9,6 +12,103 @@ use crate::{
 };
 use bigdecimal::Zero;
 use futures::future::join_all;
+
+async fn get_minimal_station_responses(
+    repository: &impl StationRepository,
+    stations: Vec<StationWithDistance>,
+) -> Vec<StationResponse> {
+    let station_responses: Vec<StationResponse> =
+        stations.clone().into_iter().map(|s| s.into()).collect();
+
+    let station_responses_futures = station_responses.into_iter().map(|s| async {
+        let mut station_response: StationResponse = s;
+
+        let Ok(lines) = repository
+            .get_lines_by_station_id(station_response.id)
+            .await else {
+            return station_response;
+            };
+
+        let line_ids = lines.iter().map(|l| l.line_cd).collect();
+        let companies = repository
+            .get_companies_by_line_ids(line_ids)
+            .await
+            .unwrap();
+
+        let lines: Vec<LineResponse> = lines
+            .iter()
+            .enumerate()
+            .into_iter()
+            .map(|(i, l)| {
+                let mut resp: LineResponse = l.clone().into();
+                let line_symbols = get_line_symbols(&mut l.clone());
+                resp.line_symbols = line_symbols;
+                let Some(company) = companies.get(i) else {
+                    return resp;
+                };
+                resp.company = Some(company.clone().into());
+                resp
+            })
+            .collect();
+
+        let Ok(line) = repository
+            .find_one_line_by_station_id(station_response.id)
+            .await else {
+                return station_response;
+            };
+        let mut line = line;
+        let mut line_response: LineResponse = line.clone().into();
+        let Ok(company) = repository.find_one_company_by_line_id(line_response.id).await else {
+            return station_response;
+        };
+        line_response.company = Some(company.into());
+        let line_symbols = get_line_symbols(&mut line);
+        line_response.line_symbols = line_symbols;
+        station_response.line = Some(Box::new(line_response));
+        station_response.lines = lines;
+        station_response
+    });
+
+    join_all(station_responses_futures).await
+}
+
+async fn get_station_responses(
+    repository: impl StationRepository,
+    stations: Vec<Station>,
+) -> Vec<StationResponse> {
+    let partially_constructed_response =
+        get_minimal_station_responses(&repository, stations.into_iter().map(|s| s.into()).collect())
+            .await;
+
+    let station_responses_futures = partially_constructed_response.into_iter().map(|s| async {
+        let mut station_response: StationResponse = s;
+        let Some(mut line_response) =  station_response.clone().line else {
+            return station_response;
+        };
+        let line_ids: Vec<u32> = station_response.lines.iter().map(|l| l.id).collect();
+        
+
+        let Ok(transferable_stations) = repository
+        .get_transferable_stations(station_response.group_id, line_ids).await else {
+            return station_response;
+        };
+        let Some(transferable_station) = 
+            transferable_stations.iter().find_map(|ts| {
+                if ts.line_cd == line_response.id {
+                    return Some(ts);
+                }
+                None
+            }).cloned() else {
+                return station_response;
+            };
+
+        line_response.station = Some(Box::new(transferable_station.into()));
+        station_response.line = Some(line_response);
+        station_response
+    });
+
+    join_all(station_responses_futures).await
+}
 
 fn get_line_symbols(line: &mut Line) -> Vec<LineSymbol> {
     let mut line_symbols = vec![];
@@ -82,177 +182,41 @@ pub async fn find_station_by_id(
     repository: impl StationRepository,
     id: u32,
 ) -> Option<SingleStationResponse> {
-    let Ok(station) = repository.find_one(id).await else {
+    let Ok(fetched_station) = repository.find_one(id).await else {
         return None
     };
-    let mut station_response: StationResponse = station.clone().into();
 
-    let Ok(lines) = repository
-        .get_lines_by_station_id(station_response.id)
-        .await else {
-        return None;
-        };
-
-    let line_ids: Vec<u32> = lines.iter().map(|l| l.line_cd).collect::<Vec<u32>>();
-    let companies = repository
-        .get_companies_by_line_ids(line_ids)
-        .await
-        .unwrap();
-
-    let lines = lines
-        .into_iter()
-        .enumerate()
-        .map(|(i, mut l)| {
-            let mut resp: LineResponse = l.clone().into();
-            let line_symbols = get_line_symbols(&mut l);
-            resp.line_symbols = line_symbols;
-            let Some(company) = companies.get(i) else {
-                return resp;
-            };
-            resp.company = Some(company.clone().into());
-            resp
-        })
-        .collect();
-    station_response.lines = lines;
-
-    let Ok(line) = repository.find_one_line_by_station_id(id).await else {
-        return Some(SingleStationResponse {
-            station: Some(station_response),
-        });
-    };
-
-    station_response.line = Some(Box::new(line.into()));
+    let stations = get_station_responses(repository, vec![fetched_station]).await;
 
     Some(SingleStationResponse {
-        station: Some(station_response),
+        station: stations.first().cloned(),
     })
 }
+
 pub async fn get_stations_by_group_id(
     repository: impl StationRepository,
     group_id: u32,
 ) -> MultipleStationResponse {
     let stations = repository.get_by_group_id(group_id).await.unwrap();
-    let station_responses: Vec<StationResponse> =
-        stations.clone().into_iter().map(|s| s.into()).collect();
-
-    let station_responses_futures = station_responses.into_iter().map(|s| async {
-        let mut station_response: StationResponse = s;
-
-        let Ok(lines) = repository
-            .get_lines_by_station_id(station_response.id)
-            .await else {
-            return station_response;
-            };
-
-        let line_ids = lines.iter().map(|l| l.line_cd).collect();
-        let companies = repository
-            .get_companies_by_line_ids(line_ids)
-            .await
-            .unwrap();
-
-        let lines = lines
-            .into_iter()
-            .enumerate()
-            .map(|(i, mut l)| {
-                let mut resp: LineResponse = l.clone().into();
-                let line_symbols = get_line_symbols(&mut l);
-                resp.line_symbols = line_symbols;
-                let Some(company) = companies.get(i) else {
-                    return resp;
-                };
-                resp.company = Some(company.clone().into());
-                resp
-            })
-            .collect();
-        let Ok(line) = repository
-            .find_one_line_by_station_id(station_response.id)
-            .await else {
-                return station_response;
-            };
-
-        let mut line = line;
-        let mut line_resp: LineResponse = line.clone().into();
-        let Ok(company) = repository.find_one_company_by_line_id(line_resp.id).await  else{
-            return station_response;
-        };
-        line_resp.company = Some(company.into());
-        let line_symbols = get_line_symbols(&mut line);
-        line_resp.line_symbols = line_symbols;
-        station_response.line = Some(Box::new(line_resp));
-        station_response.lines = lines;
-        station_response
-    });
-
-    let station_responses = join_all(station_responses_futures).await;
 
     MultipleStationResponse {
-        stations: station_responses,
+        stations: get_station_responses(repository, stations).await,
     }
 }
 
 pub async fn get_stations_by_coordinates(
-    repository: impl StationRepository,
+    repository: &impl StationRepository,
     latitude: f64,
     longitude: f64,
     limit: Option<i32>,
 ) -> MultipleStationResponse {
-    let stations = repository
+    let Ok(stations) = repository
         .get_by_coordinates(latitude, longitude, limit)
-        .await
-        .unwrap();
-
-    let station_responses: Vec<StationResponse> =
-        stations.clone().into_iter().map(|s| s.into()).collect();
-    let futures = station_responses.into_iter().map(|s| async {
-        let mut station_response = s;
-        let lines = repository
-            .get_lines_by_station_id(station_response.id)
-            .await
-            .unwrap();
-
-        let line_ids = lines.iter().map(|l| l.line_cd).collect();
-        let companies = repository
-            .get_companies_by_line_ids(line_ids)
-            .await
-            .unwrap();
-
-        let lines: Vec<LineResponse> = lines
-            .into_iter()
-            .enumerate()
-            .map(|(i, mut l)| {
-                let mut resp: LineResponse = l.clone().into();
-                let Some(company) = companies.get(i)  else{
-                    return resp;
-                };
-                resp.company = Some(company.clone().into());
-                let line_symbols = get_line_symbols(&mut l);
-                resp.line_symbols = line_symbols;
-                resp
-            })
-            .collect();
-
-        let Ok(mut line) = repository
-            .find_one_line_by_station_id(station_response.id)
-            .await else {
-                return station_response;
-            };
-
-        let mut line_resp: LineResponse = line.clone().into();
-        let Ok(company) = repository.find_one_company_by_line_id(line_resp.id).await else {
-                return station_response;
-            };
-        line_resp.company = Some(company.into());
-        let line_symbols = get_line_symbols(&mut line);
-        line_resp.line_symbols = line_symbols;
-        station_response.line = Some(Box::new(line_resp));
-
-        station_response.lines = lines;
-        station_response
-    });
-
-    let station_responses = join_all(futures).await;
+        .await else {
+            return MultipleStationResponse { stations: vec![] };
+        };
     MultipleStationResponse {
-        stations: station_responses,
+        stations: get_minimal_station_responses(repository, stations).await,
     }
 }
 
@@ -260,61 +224,11 @@ pub async fn get_stations_by_line_id(
     repository: impl StationRepository,
     line_id: u32,
 ) -> MultipleStationResponse {
-    let stations = repository.get_by_line_id(line_id).await.unwrap();
-    let station_responses: Vec<StationResponse> =
-        stations.clone().into_iter().map(|s| s.into()).collect();
-
-    let station_responses_futures = station_responses.into_iter().map(|s| async {
-        let mut station_response: StationResponse = s;
-
-        let Ok(lines) = repository
-            .get_lines_by_station_id(station_response.id)
-            .await else {
-                return station_response;
-            };
-
-        let line_ids = lines.iter().map(|l| l.line_cd).collect();
-        let companies = repository
-            .get_companies_by_line_ids(line_ids)
-            .await
-            .unwrap();
-
-        let lines = lines
-            .into_iter()
-            .enumerate()
-            .map(|(i, mut l)| {
-                let mut resp: LineResponse = l.clone().into();
-                let line_symbols = get_line_symbols(&mut l);
-                resp.line_symbols = line_symbols;
-                let Some(company) = companies.get(i) else{
-                    return resp;
-                };
-                resp.company = Some(company.clone().into());
-                resp
-            })
-            .collect();
-        let Ok(mut line) = repository
-            .find_one_line_by_station_id(station_response.id)
-            .await else{
-                return station_response;
-            };
-
-        let mut line_resp: LineResponse = line.clone().into();
-        let Ok(company) = repository.find_one_company_by_line_id(line_resp.id).await else {
-            return station_response;
-        };
-        line_resp.company = Some(company.into());
-        let line_symbols = get_line_symbols(&mut line);
-        line_resp.line_symbols = line_symbols;
-        station_response.line = Some(Box::new(line_resp));
-
-        station_response.lines = lines;
-        station_response
-    });
-
-    let station_responses = join_all(station_responses_futures).await;
+    let Ok(stations) = repository.get_by_line_id(line_id).await else {
+        return MultipleStationResponse { stations: vec![] };
+    };
 
     MultipleStationResponse {
-        stations: station_responses,
+        stations: get_station_responses(repository, stations).await,
     }
 }

--- a/src/usecases/station.rs
+++ b/src/usecases/station.rs
@@ -38,7 +38,6 @@ async fn get_minimal_station_responses(
         let lines: Vec<LineResponse> = lines
             .iter()
             .enumerate()
-            .into_iter()
             .map(|(i, l)| {
                 let mut resp: LineResponse = l.clone().into();
                 let line_symbols = get_line_symbols(&mut l.clone());
@@ -94,11 +93,11 @@ async fn get_station_responses(
             return station_response;
         };
         let Some(transferable_station) =
-            transferable_stations.iter().find_map(|ts| {
+            transferable_stations.iter().find(|ts| {
                 if ts.line_cd == line_response.id {
-                    return Some(ts);
+                    return true;
                 }
-                None
+                false
             }).cloned() else {
                 return station_response;
             };

--- a/src/usecases/station.rs
+++ b/src/usecases/station.rs
@@ -76,9 +76,11 @@ async fn get_station_responses(
     repository: impl StationRepository,
     stations: Vec<Station>,
 ) -> Vec<StationResponse> {
-    let partially_constructed_response =
-        get_minimal_station_responses(&repository, stations.into_iter().map(|s| s.into()).collect())
-            .await;
+    let partially_constructed_response = get_minimal_station_responses(
+        &repository,
+        stations.into_iter().map(|s| s.into()).collect(),
+    )
+    .await;
 
     let station_responses_futures = partially_constructed_response.into_iter().map(|s| async {
         let mut station_response: StationResponse = s;
@@ -86,13 +88,12 @@ async fn get_station_responses(
             return station_response;
         };
         let line_ids: Vec<u32> = station_response.lines.iter().map(|l| l.id).collect();
-        
 
         let Ok(transferable_stations) = repository
         .get_transferable_stations(station_response.group_id, line_ids).await else {
             return station_response;
         };
-        let Some(transferable_station) = 
+        let Some(transferable_station) =
             transferable_stations.iter().find_map(|ts| {
                 if ts.line_cd == line_response.id {
                     return Some(ts);


### PR DESCRIPTION
GraphQL APIの `Line.transferStation` と同じようなAPI(`LineResponse.station`)を実装
