### PR TITLE
駅名検索と位置情報検索でのデフォルト最大件数を100件に変更

### DIFF
--- a/src/application/line_service.rs
+++ b/src/application/line_service.rs
@@ -31,6 +31,7 @@ impl From<Line> for LineResponse {
             company_id: value.company_cd,
             line_symbols: vec![],
             status: value.e_status as i32,
+            station: None,
         }
     }
 }

--- a/src/application/station_service.rs
+++ b/src/application/station_service.rs
@@ -153,7 +153,7 @@ impl<T: StationRepository> StationService<T> {
         &self,
         latitude: f64,
         longitude: f64,
-        limit: Option<i32>,
+        limit: &Option<u32>,
     ) -> Result<Vec<Station>> {
         match self
             .station_repository
@@ -177,8 +177,12 @@ impl<T: StationRepository> StationService<T> {
             )),
         }
     }
-    pub async fn get_stations_by_name(&self, name: &str) -> Result<Vec<Station>> {
-        match self.station_repository.find_by_name(name).await {
+    pub async fn get_stations_by_name(
+        &self,
+        name: &str,
+        limit: &Option<u32>,
+    ) -> Result<Vec<Station>> {
+        match self.station_repository.find_by_name(name, limit).await {
             Ok(value) => Ok(value),
             Err(_) => Err(anyhow::anyhow!(
                 "Could not find the station. Provided Station Name: {:?}",

--- a/src/domain/models/station/station_repository.rs
+++ b/src/domain/models/station/station_repository.rs
@@ -9,11 +9,11 @@ pub trait StationRepository {
     async fn find_by_id(&self, id: u32) -> Result<Station>;
     async fn find_by_group_id(&self, group_id: u32) -> Result<Vec<Station>>;
     async fn find_by_line_id(&self, line_id: u32) -> Result<Vec<Station>>;
-    async fn find_by_name(&self, name: &str) -> Result<Vec<Station>>;
+    async fn find_by_name(&self, name: &str, limit: &Option<u32>) -> Result<Vec<Station>>;
     async fn find_by_coordinates(
         &self,
         latitude: f64,
         longitude: f64,
-        limit: Option<i32>,
+        limit: &Option<u32>,
     ) -> Result<Vec<Station>>;
 }

--- a/src/infra/grpc/handlers.rs
+++ b/src/infra/grpc/handlers.rs
@@ -40,7 +40,7 @@ pub async fn get_station_by_id(
     station_response.lines = lines_response;
     let line_symbols = line_service.get_line_symbols(&mut station_line);
     line_response.line_symbols = line_symbols;
-    station_response.line = Some(line_response);
+    station_response.line = Some(Box::new(line_response));
 
     station_service.update_station_numbers(&mut station_response, &data, &station_line);
 
@@ -96,7 +96,7 @@ pub async fn get_station_by_group_id(
                 let line_symbols = line_service.get_line_symbols(&mut station_line.clone());
                 line_response.line_symbols = line_symbols;
 
-                station_response.line = Some(line_response);
+                station_response.line = Some(Box::new(line_response));
                 station_response.lines = station_lines_response;
 
                 station_service.update_station_numbers(
@@ -122,7 +122,7 @@ pub async fn get_station_by_coordinates(
 
     let latitude = request.get_ref().latitude;
     let longitude = request.get_ref().longitude;
-    let limit = request.get_ref().limit;
+    let limit = &request.get_ref().limit;
     let stations = station_service
         .get_station_by_coordinates(latitude, longitude, limit)
         .await?;
@@ -166,7 +166,7 @@ pub async fn get_station_by_coordinates(
 
                 line_response.line_symbols = line_symbols;
 
-                station_response.line = Some(line_response);
+                station_response.line = Some(Box::new(line_response));
                 station_response.lines = station_lines_response;
 
                 station_service.update_station_numbers(
@@ -232,7 +232,7 @@ pub async fn get_stations_by_line_id(
                 let line_symbols = line_service.get_line_symbols(&mut station_line.clone());
                 line_response.line_symbols = line_symbols;
 
-                station_response.line = Some(line_response);
+                station_response.line = Some(Box::new(line_response));
                 station_response.lines = station_lines_response;
 
                 station_service.update_station_numbers(
@@ -257,7 +257,10 @@ pub async fn get_stations_by_station_name(
     let line_service = LineService::new(ctx.line_repository());
 
     let station_name = &request.get_ref().station_name;
-    let stations = station_service.get_stations_by_name(station_name).await?;
+    let limit = &request.get_ref().limit;
+    let stations = station_service
+        .get_stations_by_name(station_name, limit)
+        .await?;
     let station_group_ids: Vec<u32> = stations
         .iter()
         .map(|station| station.station_g_cd)
@@ -297,7 +300,7 @@ pub async fn get_stations_by_station_name(
                 let line_symbols = line_service.get_line_symbols(&mut station_line.clone());
                 line_response.line_symbols = line_symbols;
 
-                station_response.line = Some(line_response);
+                station_response.line = Some(Box::new(line_response));
                 station_response.lines = station_lines_response;
 
                 station_service.update_station_numbers(

--- a/tests/station_service.rs
+++ b/tests/station_service.rs
@@ -62,12 +62,16 @@ async fn test_find_by_line_id() -> Result<()> {
 #[tokio::test]
 async fn test_find_by_name() -> Result<()> {
     let mut station_repo = MockStationRepository::new();
-    let actual_station = get_station_fixture();
+    let station_fixture = get_station_fixture();
     station_repo
         .expect_find_by_name()
-        .return_once(move |_| Box::pin(future::ready(Ok(vec![actual_station]))));
+        .return_once(move |_, limit| {
+            let mut fixture_vec = Vec::with_capacity(limit.unwrap().try_into().unwrap());
+            fixture_vec.fill(station_fixture);
+            Box::pin(future::ready(Ok(fixture_vec)))
+        });
     let service: StationService<MockStationRepository> = StationService::new(station_repo);
-    let actual = service.get_stations_by_name("稚内", Some(1)).await?;
+    let actual = service.get_stations_by_name("稚内", &Some(1)).await?;
 
     let expected_station = get_station_fixture();
     actual.iter().for_each(|station| {
@@ -86,7 +90,7 @@ async fn test_find_by_coordinates() -> Result<()> {
         .return_once(move |_, _, _| Box::pin(future::ready(Ok(vec![actual_station]))));
     let service: StationService<MockStationRepository> = StationService::new(station_repo);
     let actual = service
-        .get_station_by_coordinates(0.0, 0.0, Some(1))
+        .get_station_by_coordinates(0.0, 0.0, &Some(1))
         .await?;
 
     let expected_station = get_station_fixture();

--- a/tests/station_service.rs
+++ b/tests/station_service.rs
@@ -67,7 +67,7 @@ async fn test_find_by_name() -> Result<()> {
         .expect_find_by_name()
         .return_once(move |_| Box::pin(future::ready(Ok(vec![actual_station]))));
     let service: StationService<MockStationRepository> = StationService::new(station_repo);
-    let actual = service.get_stations_by_name("稚内").await?;
+    let actual = service.get_stations_by_name("稚内", Some(1)).await?;
 
     let expected_station = get_station_fixture();
     actual.iter().for_each(|station| {


### PR DESCRIPTION
closes #131

えげつない件数を返すことがありえる名前検索と位置情報検索での返却された駅データをデフォルト100件最大に絞った
100件以上取りたい場合はlimitを100以上にするといい