### PR TITLE
メモ化でパフォーマンス改善

### DIFF
--- a/src/presentation/controller/grpc.rs
+++ b/src/presentation/controller/grpc.rs
@@ -20,7 +20,7 @@ use crate::{
     use_case::{interactor::query::QueryInteractor, traits::query::QueryUseCase},
 };
 
-const CACHE_SIZE: usize = 10_000;
+const CACHE_SIZE: usize = 100_000;
 
 pub struct GrpcRouter {
     query_use_case: QueryInteractor<

--- a/src/presentation/controller/grpc.rs
+++ b/src/presentation/controller/grpc.rs
@@ -21,7 +21,7 @@ use crate::{
     use_case::{interactor::query::QueryInteractor, traits::query::QueryUseCase},
 };
 
-const CACHE_SIZE: usize = 100_000;
+const CACHE_SIZE: usize = 10_000;
 
 pub struct GrpcRouter {
     station_list_cache: Cache<String, Arc<Vec<StationEntity>>>,
@@ -46,6 +46,7 @@ impl GrpcRouter {
             line_repository,
             train_type_repository,
             company_repository,
+            attributes_cache: Cache::new(CACHE_SIZE.to_u64().unwrap()),
         };
 
         Self {

--- a/src/presentation/controller/grpc.rs
+++ b/src/presentation/controller/grpc.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tonic::Response;
 
 use crate::{
-    domain::entity::{line::Line, train_type::TrainType},
+    domain::entity::{station::Station as StationEntity, train_type::TrainType as TrainTypeEntity},
     infrastructure::{
         company_repository::MyCompanyRepository, line_repository::MyLineRepository,
         station_repository::MyStationRepository, train_type_repository::MyTrainTypeRepository,
@@ -14,7 +14,8 @@ use crate::{
         station_api_server::StationApi, GetStationByCoordinatesRequest, GetStationByGroupIdRequest,
         GetStationByIdRequest, GetStationByLineIdRequest, GetStationsByLineGroupIdRequest,
         GetStationsByNameRequest, GetTrainTypesByStationIdRequest, MultipleStationResponse,
-        MultipleTrainTypeResponse, SingleStationResponse,
+        MultipleTrainTypeResponse, SingleStationResponse, Station as PbStation,
+        TrainType as PbTrainType,
     },
     presentation::error::PresentationalError,
     use_case::{interactor::query::QueryInteractor, traits::query::QueryUseCase},
@@ -23,6 +24,8 @@ use crate::{
 const CACHE_SIZE: usize = 100_000;
 
 pub struct GrpcRouter {
+    station_list_cache: Cache<String, Arc<Vec<StationEntity>>>,
+    train_types_cache: Cache<String, Arc<Vec<TrainTypeEntity>>>,
     query_use_case: QueryInteractor<
         MyStationRepository,
         MyLineRepository,
@@ -33,20 +36,10 @@ pub struct GrpcRouter {
 
 impl GrpcRouter {
     pub fn new(pool: Pool<MySql>) -> Self {
-        let station_repository_cache = Cache::new(CACHE_SIZE.to_u64().unwrap());
-        let station_repository = MyStationRepository::new(pool.clone(), station_repository_cache);
-
-        let line_repository_cache =
-            Cache::<String, Arc<Vec<Line>>>::new(CACHE_SIZE.to_u64().unwrap());
-        let line_repository = MyLineRepository::new(pool.clone(), line_repository_cache);
-
-        let train_type_repository_cache =
-            Cache::<String, Arc<Vec<TrainType>>>::new(CACHE_SIZE.to_u64().unwrap());
-        let train_type_repository =
-            MyTrainTypeRepository::new(pool.clone(), train_type_repository_cache);
-
-        let company_repository_cache = Cache::new(CACHE_SIZE.to_u64().unwrap());
-        let company_repository = MyCompanyRepository::new(pool, company_repository_cache);
+        let station_repository = MyStationRepository::new(pool.clone());
+        let line_repository = MyLineRepository::new(pool.clone());
+        let train_type_repository = MyTrainTypeRepository::new(pool.clone());
+        let company_repository = MyCompanyRepository::new(pool);
 
         let query_use_case = QueryInteractor {
             station_repository,
@@ -54,7 +47,12 @@ impl GrpcRouter {
             train_type_repository,
             company_repository,
         };
-        Self { query_use_case }
+
+        Self {
+            query_use_case,
+            station_list_cache: Cache::new(CACHE_SIZE.to_u64().unwrap()),
+            train_types_cache: Cache::new(CACHE_SIZE.to_u64().unwrap()),
+        }
     }
 }
 
@@ -65,6 +63,19 @@ impl StationApi for GrpcRouter {
         request: tonic::Request<GetStationByIdRequest>,
     ) -> Result<tonic::Response<SingleStationResponse>, tonic::Status> {
         let station_id = request.get_ref().id;
+
+        let cache = self.station_list_cache.clone();
+        let cache_key = format!("station:get_station_by_id:{}", station_id);
+        if let Some(cache_data) = cache.get(&cache_key) {
+            return Ok(Response::new(SingleStationResponse {
+                station: Some(
+                    cache_data
+                        .first()
+                        .map(|station| station.clone().into())
+                        .unwrap(),
+                ),
+            }));
+        };
 
         let station = match self.query_use_case.find_station_by_id(station_id).await {
             Ok(Some(station)) => station,
@@ -80,6 +91,10 @@ impl StationApi for GrpcRouter {
             }
         };
 
+        self.station_list_cache
+            .insert(cache_key, Arc::new(vec![station.clone()]))
+            .await;
+
         Ok(Response::new(SingleStationResponse {
             station: Some(station.into()),
         }))
@@ -88,14 +103,27 @@ impl StationApi for GrpcRouter {
         &self,
         request: tonic::Request<GetStationByGroupIdRequest>,
     ) -> Result<tonic::Response<MultipleStationResponse>, tonic::Status> {
-        match self
-            .query_use_case
-            .get_stations_by_group_id(request.get_ref().group_id)
-            .await
-        {
-            Ok(stations) => Ok(Response::new(MultipleStationResponse {
-                stations: stations.into_iter().map(|station| station.into()).collect(),
-            })),
+        let group_id = request.get_ref().group_id;
+
+        let cache_key = format!("stations:group_id:{}", group_id);
+        if let Some(cache_data) = self.station_list_cache.get(&cache_key) {
+            if let Some(stations) = Arc::into_inner(Arc::clone(&cache_data)) {
+                let stations: Vec<PbStation> =
+                    stations.into_iter().map(|station| station.into()).collect();
+                return Ok(Response::new(MultipleStationResponse { stations }));
+            }
+        };
+
+        match self.query_use_case.get_stations_by_group_id(group_id).await {
+            Ok(stations) => {
+                self.station_list_cache
+                    .insert(cache_key, Arc::new(stations.clone()))
+                    .await;
+
+                return Ok(Response::new(MultipleStationResponse {
+                    stations: stations.into_iter().map(|station| station.into()).collect(),
+                }));
+            }
             Err(err) => return Err(PresentationalError::from(err).into()),
         }
     }
@@ -126,8 +154,22 @@ impl StationApi for GrpcRouter {
     ) -> Result<tonic::Response<MultipleStationResponse>, tonic::Status> {
         let line_id = request.get_ref().line_id;
 
+        let cache = self.station_list_cache.clone();
+
+        let cache_key = format!("stations:line_id:{}", line_id);
+        if let Some(stations) = cache.get(&cache_key) {
+            let stations = stations.to_vec();
+            return Ok(Response::new(MultipleStationResponse {
+                stations: stations.into_iter().map(|station| station.into()).collect(),
+            }));
+        };
+
         match self.query_use_case.get_stations_by_line_id(line_id).await {
             Ok(stations) => {
+                self.station_list_cache
+                    .insert(cache_key, Arc::new(stations.clone()))
+                    .await;
+
                 return Ok(Response::new(MultipleStationResponse {
                     stations: stations.into_iter().map(|station| station.into()).collect(),
                 }));
@@ -141,16 +183,34 @@ impl StationApi for GrpcRouter {
     ) -> Result<tonic::Response<MultipleStationResponse>, tonic::Status> {
         let request_ref = request.get_ref();
         let query_station_name = request_ref.station_name.clone();
-        let limit = request_ref.limit;
+        let query_limit = request_ref.limit;
+
+        let cache_key = format!(
+            "stations:station_name:{}:limit:{:?}",
+            query_station_name,
+            query_limit.to_owned()
+        );
+        if let Some(cache_data) = self.station_list_cache.get(&cache_key) {
+            let stations = cache_data.to_vec();
+            let stations: Vec<PbStation> =
+                stations.into_iter().map(|station| station.into()).collect();
+            return Ok(Response::new(MultipleStationResponse { stations }));
+        };
 
         match self
             .query_use_case
-            .get_stations_by_name(query_station_name, limit)
+            .get_stations_by_name(query_station_name, query_limit)
             .await
         {
-            Ok(stations) => Ok(Response::new(MultipleStationResponse {
-                stations: stations.into_iter().map(|station| station.into()).collect(),
-            })),
+            Ok(stations) => {
+                self.station_list_cache
+                    .insert(cache_key, Arc::new(stations.clone()))
+                    .await;
+
+                return Ok(Response::new(MultipleStationResponse {
+                    stations: stations.into_iter().map(|station| station.into()).collect(),
+                }));
+            }
             Err(err) => Err(PresentationalError::from(err).into()),
         }
     }
@@ -162,14 +222,30 @@ impl StationApi for GrpcRouter {
         let request_ref = request.get_ref();
         let query_line_group_id = request_ref.line_group_id;
 
+        let cache = self.station_list_cache.clone();
+
+        let cache_key = format!("stations:line_group_id:{}", query_line_group_id);
+        if let Some(cache_data) = cache.get(&cache_key) {
+            let stations = cache_data.to_vec();
+            let stations: Vec<PbStation> =
+                stations.into_iter().map(|station| station.into()).collect();
+            return Ok(Response::new(MultipleStationResponse { stations }));
+        };
+
         match self
             .query_use_case
             .get_stations_by_line_group_id(query_line_group_id)
             .await
         {
-            Ok(stations) => Ok(Response::new(MultipleStationResponse {
-                stations: stations.into_iter().map(|station| station.into()).collect(),
-            })),
+            Ok(stations) => {
+                self.station_list_cache
+                    .insert(cache_key, Arc::new(stations.clone()))
+                    .await;
+
+                return Ok(Response::new(MultipleStationResponse {
+                    stations: stations.into_iter().map(|station| station.into()).collect(),
+                }));
+            }
             Err(err) => Err(PresentationalError::from(err).into()),
         }
     }
@@ -181,14 +257,30 @@ impl StationApi for GrpcRouter {
         let request_ref: &GetTrainTypesByStationIdRequest = request.get_ref();
         let query_station_id = request_ref.station_id;
 
+        let cache_key = format!("train_types:station_id:{:?}", query_station_id);
+        if let Some(cache_data) = self.train_types_cache.get(&cache_key) {
+            let train_types = cache_data.to_vec();
+            let train_types: Vec<PbTrainType> = train_types
+                .into_iter()
+                .map(|station| station.into())
+                .collect();
+            return Ok(Response::new(MultipleTrainTypeResponse { train_types }));
+        };
+
         match self
             .query_use_case
             .get_train_types_by_station_id(query_station_id)
             .await
         {
-            Ok(train_types) => Ok(Response::new(MultipleTrainTypeResponse {
-                train_types: train_types.into_iter().map(|tt| tt.into()).collect(),
-            })),
+            Ok(train_types) => {
+                self.train_types_cache
+                    .insert(cache_key, Arc::new(train_types.clone()))
+                    .await;
+
+                Ok(Response::new(MultipleTrainTypeResponse {
+                    train_types: train_types.into_iter().map(|tt| tt.into()).collect(),
+                }))
+            }
             Err(err) => Err(PresentationalError::from(err).into()),
         }
     }

--- a/src/use_case/dto/train_type.rs
+++ b/src/use_case/dto/train_type.rs
@@ -7,7 +7,7 @@ impl From<TrainType> for GrpcTrainType {
             station_cd: _,
             type_cd,
             line_group_cd,
-            pass: _a,
+            pass: _,
             type_name,
             type_name_k,
             type_name_r,

--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -39,7 +39,7 @@ where
         let Some( station) = self.station_repository.find_by_id(station_id).await? else {
             return Ok(None);
         };
-        let station = self.get_station_with_attributes(station, false).await?;
+        let station = self.get_station_with_attributes(station).await?;
         Ok(Some(station))
     }
 
@@ -55,7 +55,7 @@ where
         let mut result: Vec<Station> = Vec::with_capacity(stations.len());
 
         for station in stations.into_iter() {
-            let station = self.get_station_with_attributes(station, false).await?;
+            let station = self.get_station_with_attributes(station).await?;
             result.push(station);
         }
 
@@ -75,7 +75,7 @@ where
         let mut result: Vec<Station> = Vec::with_capacity(stations.len());
 
         for station in stations.into_iter() {
-            let station = self.get_station_with_attributes(station, false).await?;
+            let station = self.get_station_with_attributes(station).await?;
             result.push(station);
         }
 
@@ -87,7 +87,7 @@ where
         let mut result: Vec<Station> = Vec::with_capacity(stations.len());
 
         for station in stations.into_iter() {
-            let station = self.get_station_with_attributes(station, false).await?;
+            let station = self.get_station_with_attributes(station).await?;
             result.push(station);
         }
 
@@ -105,7 +105,7 @@ where
         let mut result: Vec<Station> = Vec::with_capacity(stations.len());
 
         for station in stations.into_iter() {
-            let station = self.get_station_with_attributes(station, false).await?;
+            let station = self.get_station_with_attributes(station).await?;
             result.push(station);
         }
 
@@ -123,11 +123,7 @@ where
         Ok(Some(company))
     }
 
-    async fn get_station_with_attributes(
-        &self,
-        station: Station,
-        shallow: bool,
-    ) -> Result<Station, UseCaseError> {
+    async fn get_station_with_attributes(&self, station: Station) -> Result<Station, UseCaseError> {
         let cloned_station = station.clone();
         let mut mutable_station = station;
 
@@ -154,19 +150,17 @@ where
             .await?;
 
         for ref mut line in lines.into_iter() {
-            if !shallow {
-                for station in stations.iter_mut() {
-                    if station.line_cd == line.line_cd {
-                        station.station_numbers = self.get_station_numbers(
-                            Box::new(station.to_owned()),
-                            Box::new(line.to_owned()),
-                        );
+            for station in stations.iter_mut() {
+                if station.line_cd == line.line_cd {
+                    station.station_numbers = self.get_station_numbers(
+                        Box::new(station.to_owned()),
+                        Box::new(line.to_owned()),
+                    );
 
-                        let company = self.find_company_by_id(line.company_cd).await?;
-                        line.company = company;
+                    let company = self.find_company_by_id(line.company_cd).await?;
+                    line.company = company;
 
-                        line.station = Some(station.to_owned());
-                    }
+                    line.station = Some(station.to_owned());
                 }
             }
 
@@ -217,7 +211,7 @@ where
         let mut result: Vec<Station> = Vec::with_capacity(stations.len());
 
         for station in stations.into_iter() {
-            let station = self.get_station_with_attributes(station, false).await?;
+            let station = self.get_station_with_attributes(station).await?;
             result.push(station);
         }
 

--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -143,13 +143,13 @@ where
 
         let mut lines_tmp: Vec<Option<Line>> = Vec::with_capacity(lines.len());
 
+        let mut stations = self
+            .station_repository
+            .get_by_station_group_id(station.station_g_cd)
+            .await?;
+
         for ref mut line in lines.into_iter() {
             if !shallow {
-                let mut stations = self
-                    .station_repository
-                    .get_by_station_group_id(station.station_g_cd)
-                    .await?;
-
                 for station in stations.iter_mut() {
                     if station.line_cd == line.line_cd {
                         station.station_numbers = self.get_station_numbers(

--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -52,7 +52,7 @@ where
             .get_by_station_group_id(station_group_id)
             .await?;
 
-        let mut result: Vec<Station> = vec![];
+        let mut result: Vec<Station> = Vec::with_capacity(stations.len());
 
         for mut station in stations.into_iter() {
             self.update_station_with_attributes(&mut station, false)
@@ -73,7 +73,7 @@ where
             .get_by_coordinates(latitude, longitude, limit)
             .await?;
 
-        let mut result: Vec<Station> = vec![];
+        let mut result: Vec<Station> = Vec::with_capacity(stations.len());
 
         for mut station in stations.into_iter() {
             self.update_station_with_attributes(&mut station, false)
@@ -86,7 +86,7 @@ where
 
     async fn get_stations_by_line_id(&self, line_id: u32) -> Result<Vec<Station>, UseCaseError> {
         let stations = self.station_repository.get_by_line_id(line_id).await?;
-        let mut result: Vec<Station> = vec![];
+        let mut result: Vec<Station> = Vec::with_capacity(stations.len());
 
         for mut station in stations.into_iter() {
             self.update_station_with_attributes(&mut station, false)
@@ -105,7 +105,7 @@ where
             .station_repository
             .get_by_name(station_name, limit)
             .await?;
-        let mut result: Vec<Station> = vec![];
+        let mut result: Vec<Station> = Vec::with_capacity(stations.len());
 
         for mut station in stations.into_iter() {
             self.update_station_with_attributes(&mut station, false)
@@ -140,9 +140,10 @@ where
         let lines = self
             .get_lines_by_station_group_id(station.station_g_cd)
             .await?;
-        let mut lines_tmp: Vec<Option<Line>> = vec![None; lines.len()];
 
-        for (index, ref mut line) in lines.into_iter().enumerate() {
+        let mut lines_tmp: Vec<Option<Line>> = Vec::with_capacity(lines.len());
+
+        for ref mut line in lines.into_iter() {
             if !shallow {
                 let mut stations = self
                     .station_repository
@@ -165,7 +166,7 @@ where
             }
 
             line.line_symbols = self.get_line_symbols(line);
-            lines_tmp[index] = Some(line.clone());
+            lines_tmp.push(Some(line.clone()));
         }
 
         station.lines = lines_tmp.into_iter().flatten().collect();
@@ -206,7 +207,7 @@ where
             .get_by_line_group_id(line_group_id)
             .await?;
 
-        let mut result: Vec<Station> = vec![];
+        let mut result: Vec<Station> = Vec::with_capacity(stations.len());
 
         for mut station in stations.into_iter() {
             self.update_station_with_attributes(&mut station, false)

--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -128,7 +128,10 @@ where
         let mut mutable_station = station;
 
         let cache = self.attributes_cache.clone();
-        let cache_key = format!("station_with_attributes:id:{}", cloned_station.station_cd);
+        let cache_key = format!(
+            "station_with_attributes:id:{}:pass:{}",
+            cloned_station.station_cd, cloned_station.pass
+        );
         if let Some(ref mut cache_data) = cache.get(&cache_key) {
             return Ok(cache_data.clone());
         }

--- a/src/use_case/traits/query.rs
+++ b/src/use_case/traits/query.rs
@@ -31,11 +31,11 @@ pub trait QueryUseCase: Send + Sync + 'static {
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn find_line_by_id(&self, line_id: u32) -> Result<Option<Line>, UseCaseError>;
     async fn find_company_by_id(&self, company_id: u32) -> Result<Option<Company>, UseCaseError>;
-    async fn update_station_with_attributes(
+    async fn get_station_with_attributes(
         &self,
-        station: &mut Station,
+        station: Station,
         shallow: bool,
-    ) -> Result<(), UseCaseError>;
+    ) -> Result<Station, UseCaseError>;
     async fn get_lines_by_station_group_id(
         &self,
         station_group_id: u32,

--- a/src/use_case/traits/query.rs
+++ b/src/use_case/traits/query.rs
@@ -31,11 +31,7 @@ pub trait QueryUseCase: Send + Sync + 'static {
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn find_line_by_id(&self, line_id: u32) -> Result<Option<Line>, UseCaseError>;
     async fn find_company_by_id(&self, company_id: u32) -> Result<Option<Company>, UseCaseError>;
-    async fn get_station_with_attributes(
-        &self,
-        station: Station,
-        shallow: bool,
-    ) -> Result<Station, UseCaseError>;
+    async fn get_station_with_attributes(&self, station: Station) -> Result<Station, UseCaseError>;
     async fn get_lines_by_station_group_id(
         &self,
         station_group_id: u32,


### PR DESCRIPTION
今まで愚直にDBの返り値をキャッシュしているだけだったが、DBの取得処理自体遅くなってしまうのでDBのキャッシュは辞めてrpcハンドラごとのメモ化の設定をした
結果ヒットすればM2 MacBook Airで10分の1くらいのレスポンス速度になった(Postmanで検証)