### PR TITLE
tmp.sqlのみでマイグレ出来るようにした

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN mkdir /app/migrations
 COPY --from=builder /app/tmp.sql .
 COPY --from=builder /app/scripts/start.sh ./scripts
 COPY --from=builder /app/scripts/migration.sh ./scripts
-COPY --from=builder /app/migrations/create_table.sql ./migrations
 COPY --from=builder /app/target/release/stationapi /usr/local/bin/stationapi
 RUN apt-get update && \
     apt-get install -y --quiet mysql-client && \

--- a/migrations/create_table.sql
+++ b/migrations/create_table.sql
@@ -1,5 +1,3 @@
-BEGIN;
-
 -- MySQL dump 10.13  Distrib 8.1.0, for macos13 (arm64)
 --
 -- Host: localhost    Database: stationapi
@@ -210,5 +208,3 @@ CREATE TABLE `types` (
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
 -- Dump completed on 2023-10-06  9:53:34
-
-COMMIT;

--- a/scripts/migration.sh
+++ b/scripts/migration.sh
@@ -1,5 +1,2 @@
 #!/bin/bash
-set -e
-mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -S$MYSQL_SOCKET $MYSQL_DATABASE < ./migrations/create_table.sql
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD --default-character-set=utf8 -S$MYSQL_SOCKET $MYSQL_DATABASE < ./tmp.sql
-set +e


### PR DESCRIPTION
#775

実際は `create_table.sql` を[sqlgen](https://github.com/TrainLCD/sqlgen)で使うのでSQLファイルは不要ではない