### PR TITLE
case when使わない

### DIFF
--- a/src/infrastructure/station_repository.rs
+++ b/src/infrastructure/station_repository.rs
@@ -324,7 +324,7 @@ impl InternalStationRepository {
                   LEFT OUTER JOIN `types` AS t ON t.type_cd = sst.type_cd
                 WHERE
                   s.line_cd = ?
-                  AND CASE WHEN sst.station_cd THEN s.station_cd = sst.station_cd ELSE s.station_cd = s.station_cd END
+                  AND (s.station_cd = sst.station_cd OR s.station_cd = s.station_cd)
                   AND s.line_cd = l.line_cd
                   AND s.e_status = 0
                 ORDER BY
@@ -553,7 +553,7 @@ impl InternalStationRepository {
                       OR station_name_zh LIKE ?
                       OR station_name_ko LIKE ?
                     )
-                    AND CASE WHEN sst.station_cd THEN s.station_cd = sst.station_cd ELSE s.station_cd = s.station_cd END
+                    AND (s.station_cd = sst.station_cd OR s.station_cd = s.station_cd)
                     AND s.line_cd = l.line_cd
                     AND s.e_status = 0
                   LIMIT


### PR DESCRIPTION
![simulator_screenshot_33466A0F-5861-405A-8E9C-C9036BF005AD](https://github.com/TrainLCD/StationAPI/assets/32848922/32d88fa3-eefb-40c9-ab57-3b5f5c1d4a96)

上記画像の通り駅名検索で静岡に設定して駅名がおかしくなるバグの対応
