### PR TITLE
普通・各停種別自動選択復活

### DIFF
--- a/src/domain/repository/station_repository.rs
+++ b/src/domain/repository/station_repository.rs
@@ -5,7 +5,11 @@ use crate::domain::{entity::station::Station, error::DomainError};
 #[async_trait]
 pub trait StationRepository: Send + Sync + 'static {
     async fn find_by_id(&self, id: u32) -> Result<Option<Station>, DomainError>;
-    async fn get_by_line_id(&self, line_id: u32) -> Result<Vec<Station>, DomainError>;
+    async fn get_by_line_id(
+        &self,
+        line_id: u32,
+        station_id: Option<u32>,
+    ) -> Result<Vec<Station>, DomainError>;
     async fn get_by_station_group_id(
         &self,
         station_group_id: u32,

--- a/src/infrastructure/station_repository.rs
+++ b/src/infrastructure/station_repository.rs
@@ -508,11 +508,6 @@ impl InternalStationRepository {
             "SELECT
                     DISTINCT l.*,
                     s.*,
-                    t.*,
-                    sst.id,
-                    sst.type_cd,
-                    sst.line_group_cd,
-                    sst.pass,
                     COALESCE(a.line_name, l.line_name) AS line_name,
                     COALESCE(a.line_name_k, l.line_name_k) AS line_name_k,
                     COALESCE(a.line_name_h, l.line_name_h) AS line_name_h,
@@ -533,18 +528,6 @@ impl InternalStationRepository {
                     (`stations` AS s, `lines` AS l)
                     LEFT OUTER JOIN `line_aliases` AS la ON la.station_cd = s.station_cd
                     LEFT OUTER JOIN `aliases` AS a ON la.alias_cd = a.id
-                    LEFT OUTER JOIN `station_station_types` AS sst ON sst.line_group_cd = (
-                      SELECT
-                        sst.line_group_cd
-                      FROM
-                        `station_station_types` AS sst
-                      WHERE
-                        sst.type_cd IN (100, 101, 300, 301)
-                        AND sst.station_cd = s.station_cd
-                      LIMIT
-                        1
-                    )
-                    LEFT OUTER JOIN `types` AS t ON t.type_cd = sst.type_cd
                   WHERE
                     (
                       station_name LIKE ?
@@ -553,7 +536,6 @@ impl InternalStationRepository {
                       OR station_name_zh LIKE ?
                       OR station_name_ko LIKE ?
                     )
-                    AND (s.station_cd = sst.station_cd OR s.station_cd = s.station_cd)
                     AND s.line_cd = l.line_cd
                     AND s.e_status = 0
                   LIMIT

--- a/src/infrastructure/station_repository.rs
+++ b/src/infrastructure/station_repository.rs
@@ -300,7 +300,7 @@ impl InternalStationRepository {
                     SELECT
                       COUNT(sst.line_group_cd)
                     FROM
-                      station_station_types AS sst
+                      `station_station_types` AS sst
                     WHERE
                       s.station_cd = sst.station_cd
                       AND sst.pass <> 1
@@ -309,7 +309,10 @@ impl InternalStationRepository {
                   (`stations` AS s, `lines` AS l)
                   LEFT OUTER JOIN `line_aliases` AS la ON la.station_cd = s.station_cd
                   LEFT OUTER JOIN `aliases` AS a ON la.alias_cd = a.id
-                  LEFT OUTER JOIN `station_station_types` AS sst ON sst.line_group_cd = (
+                  LEFT OUTER JOIN `station_station_types` AS sst ON sst.station_cd = s.station_cd
+                  LEFT OUTER JOIN `types` AS t ON t.type_cd = sst.type_cd
+                WHERE
+                  CASE WHEN EXISTS (
                     SELECT
                       sst.line_group_cd
                     FROM
@@ -317,20 +320,34 @@ impl InternalStationRepository {
                       `stations` AS s
                     WHERE
                       s.line_cd = ?
+                      AND s.station_cd = sst.station_cd
                       AND sst.type_cd IN (100, 101, 300, 301)
-                      AND sst.station_cd = s.station_cd
-                    LIMIT 1
                   )
-                  LEFT OUTER JOIN `types` AS t ON t.type_cd = sst.type_cd
-                WHERE
-                  s.line_cd = ?
-                  AND (s.station_cd = sst.station_cd OR s.station_cd = s.station_cd)
+                    THEN
+                      sst.line_group_cd = (
+                        SELECT _sst.line_group_cd
+                        FROM
+                          `station_station_types` AS _sst,
+                          `stations` AS _s
+                        WHERE
+                          _s.line_cd = ?
+                          AND _sst.type_cd IN (100, 101, 300, 301)
+                          AND _s.station_cd = _sst.station_cd
+                        LIMIT 1
+                      )
+                      AND s.station_cd = sst.station_cd
+                      AND sst.type_cd = t.type_cd
+                    ELSE l.line_cd = ?
+                  END
                   AND s.line_cd = l.line_cd
                   AND s.e_status = 0
                 ORDER BY
-                  s.e_sort,
-                  s.station_cd",
+                  CASE WHEN sst.line_group_cd IS NULL
+                    THEN CONCAT(s.e_sort, s.station_cd)
+                    ELSE sst.id
+                  END",
         )
+        .bind(line_id)
         .bind(line_id)
         .bind(line_id)
         .fetch_all(conn)

--- a/src/presentation/controller/grpc.rs
+++ b/src/presentation/controller/grpc.rs
@@ -147,8 +147,13 @@ impl StationApi for GrpcRouter {
         request: tonic::Request<GetStationByLineIdRequest>,
     ) -> Result<tonic::Response<MultipleStationResponse>, tonic::Status> {
         let line_id = request.get_ref().line_id;
+        let station_id = request.get_ref().station_id;
 
-        let cache_key = format!("stations:line_id:{}", line_id,);
+        let cache_key = format!(
+            "stations:line_id:{}:station_id:{}",
+            line_id,
+            station_id.unwrap_or(0)
+        );
         if let Ok(Some(cache_value)) = self.cache_client.get::<String>(cache_key.as_str()) {
             let stations =
                 serde_json::from_str::<Vec<Station>>(&cache_value).expect("Failed to parse JSON");
@@ -157,7 +162,11 @@ impl StationApi for GrpcRouter {
             }));
         };
 
-        match self.query_use_case.get_stations_by_line_id(line_id).await {
+        match self
+            .query_use_case
+            .get_stations_by_line_id(line_id, station_id)
+            .await
+        {
             Ok(stations) => {
                 if let Ok(station_str) = serde_json::to_string(&stations) {
                     self.cache_client.set(&cache_key, station_str, 0).unwrap();

--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -170,8 +170,16 @@ where
         Ok(stations)
     }
 
-    async fn get_stations_by_line_id(&self, line_id: u32) -> Result<Vec<Station>, UseCaseError> {
-        let cache_key = format!("stations_by_line_id:line_id:{}", line_id);
+    async fn get_stations_by_line_id(
+        &self,
+        line_id: u32,
+        station_id: Option<u32>,
+    ) -> Result<Vec<Station>, UseCaseError> {
+        let cache_key = format!(
+            "stations_by_line_id:line_id:{}:station_id:{}",
+            line_id,
+            station_id.unwrap_or(0)
+        );
         if let Ok(Some(cache_value)) = self.cache_client.get::<String>(cache_key.as_str()) {
             let stations =
                 serde_json::from_str::<Vec<Station>>(&cache_value).expect("Failed to parse JSON");
@@ -179,7 +187,10 @@ where
             return Ok(stations);
         };
 
-        let mut stations = self.station_repository.get_by_line_id(line_id).await?;
+        let mut stations = self
+            .station_repository
+            .get_by_line_id(line_id, station_id)
+            .await?;
 
         self.update_station_vec_with_attributes(&mut stations)
             .await?;

--- a/src/use_case/traits/query.rs
+++ b/src/use_case/traits/query.rs
@@ -25,7 +25,11 @@ pub trait QueryUseCase: Send + Sync + 'static {
         longitude: f64,
         limit: Option<u32>,
     ) -> Result<Vec<Station>, UseCaseError>;
-    async fn get_stations_by_line_id(&self, line_id: u32) -> Result<Vec<Station>, UseCaseError>;
+    async fn get_stations_by_line_id(
+        &self,
+        line_id: u32,
+        station_id: Option<u32>,
+    ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_stations_by_name(
         &self,
         station_name: String,


### PR DESCRIPTION
`stationsByLineId`を叩くときアプリ側で駅IDを指定する必要がある