### PR TITLE
GetStationsByLineId 駅IDが指定されない場合は路線でのすべての駅を返す

### DIFF
--- a/src/infrastructure/station_repository.rs
+++ b/src/infrastructure/station_repository.rs
@@ -320,7 +320,7 @@ impl InternalStationRepository {
                       AND s.station_cd = sst.station_cd
                       AND CASE WHEN ? IS NOT NULL
                         THEN s.station_cd = ?
-                        ELSE s.station_cd = s.station_cd
+                        ELSE 1 <> 1
                       END
                     LIMIT 1
                   )


### PR DESCRIPTION
静岡で駅名検索して東海道本線にて静岡を経由**しない**駅リストが返るので、 `station_station_types` での駅リスト検索をしない