### PR TITLE
GetStationsByLineId 駅IDが指定されない場合は路線でのすべての駅を返す

### DIFF
--- a/src/infrastructure/station_repository.rs
+++ b/src/infrastructure/station_repository.rs
@@ -320,7 +320,7 @@ impl InternalStationRepository {
                       AND s.station_cd = sst.station_cd
                       AND CASE WHEN ? IS NOT NULL
                         THEN s.station_cd = ?
-                        ELSE s.station_cd = s.station_cd
+                        ELSE 1 <> 1
                       END
                     LIMIT 1
                   )


### PR DESCRIPTION
経緯: https://github.com/TrainLCD/StationAPI/pull/832

だいぶ乱暴な方法ではあるが、経由しない駅リストが返るよりはマシかと