### PR TITLE
駅情報をcoordinatesとnameで取れる情報が違うバグを修正

### DIFF
--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -277,14 +277,14 @@ where
             .map(|station| station.station_g_cd)
             .collect::<Vec<u32>>();
 
-        let station_ids = stations_ref
-            .iter()
-            .map(|station| station.station_cd)
-            .collect::<Vec<u32>>();
-
         let stations_by_group_ids = self
             .get_stations_by_group_id_vec(station_group_ids.clone())
             .await?;
+
+        let station_ids = stations_by_group_ids
+            .iter()
+            .map(|station| station.station_cd)
+            .collect::<Vec<u32>>();
 
         let lines = self
             .get_lines_by_station_group_id_vec(station_group_ids.clone())


### PR DESCRIPTION
TrainLCDアプリで位置情報から駅を取った場合と名前検索で駅を取った場合、前者は位置情報で一番近い駅の情報のみ、後者はすべての路線の情報が取得できてそうなので後者の全取得に合わせる実装にした