### PR TITLE
種別で通過する駅は種別リストに入っちゃ駄目

### DIFF
--- a/src/infrastructure/train_type_repository.rs
+++ b/src/infrastructure/train_type_repository.rs
@@ -222,6 +222,7 @@ impl InternalTrainTypeRepository {
                 sst.type_cd = t.type_cd
             ELSE
                 t.kind IN (0, 1)
+                AND sst.pass <> 1
                 AND sst.type_cd = t.type_cd
             END
             AND s.station_cd = sst.station_cd


### PR DESCRIPTION
中央・総武緩行線の秋葉原駅で富士回遊が選べるようになってた