### PR TITLE
不要なクエリの削除

### DIFF
--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -672,7 +672,7 @@ where
                 line.train_type = train_type;
             }
 
-            line.train_type = Some(tt.to_owned());
+            line.train_type = Some(tt.clone());
             line.company = companies
                 .iter()
                 .find(|c| c.company_cd == line.company_cd)

--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -672,12 +672,7 @@ where
                 line.train_type = train_type;
             }
 
-            let train_type: Option<TrainType> = self
-                .train_type_repository
-                .find_by_line_group_id_and_line_id(tt.line_group_cd, line.line_cd)
-                .await?;
-
-            line.train_type = train_type;
+            line.train_type = Some(tt.to_owned());
             line.company = companies
                 .iter()
                 .find(|c| c.company_cd == line.company_cd)


### PR DESCRIPTION
ループ内の変数を使えば良いところを新たにループ内でクエリを発行していたのでループ内の変数を使うように修正
TrainLCDアプリでも使用していないフィールドだと思うのでデグレは多分あっても支障をきたさない