### PR TITLE
経路検索パフォチュー

### DIFF
--- a/.sqlx/query-9e59a9dfb13e6a678b0af2db5debdc44c6b65fda6107b1072fdff52350740325.json
+++ b/.sqlx/query-9e59a9dfb13e6a678b0af2db5debdc44c6b65fda6107b1072fdff52350740325.json
@@ -1,6 +1,6 @@
 {
   "db_name": "MySQL",
-  "query": "(\n              SELECT\n                  sta.*,\n                  via_lines.company_cd,\n                  via_lines.line_type,\n                  via_lines.line_symbol_primary,\n                  via_lines.line_symbol_secondary,\n                  via_lines.line_symbol_extra,\n                  via_lines.line_symbol_primary_color,\n                  via_lines.line_symbol_secondary_color,\n                  via_lines.line_symbol_extra_color,\n                  via_lines.line_symbol_primary_shape,\n                  via_lines.line_symbol_secondary_shape,\n                  via_lines.line_symbol_extra_shape,\n                  via_lines.average_distance,\n                  sst.type_cd,\n                  sst.line_group_cd,\n                  sst.pass,\n                  types.id AS type_id,\n                  types.type_name,\n                  types.type_name_k,\n                  types.type_name_r,\n                  types.type_name_zh,\n                  types.type_name_ko,\n                  types.color,\n                  types.direction,\n                  types.kind,\n                  COALESCE(a.line_name, via_lines.line_name) AS line_name,\n                  COALESCE(a.line_name_k, via_lines.line_name_k) AS line_name_k,\n                  COALESCE(a.line_name_h, via_lines.line_name_h) AS line_name_h,\n                  COALESCE(a.line_name_r, via_lines.line_name_r) AS line_name_r,\n                  COALESCE(a.line_name_zh, via_lines.line_name_zh) AS line_name_zh,\n                  COALESCE(a.line_name_ko, via_lines.line_name_ko) AS line_name_ko,\n                  COALESCE(a.line_color_c, via_lines.line_color_c) AS line_color_c,\n                  IFNULL(\n                      sta.station_cd = sst.station_cd,\n                      0\n                  ) AS has_train_types\n              FROM\n                  stations AS sta\n                  JOIN\n                      station_station_types AS sst\n                  ON  sta.station_cd = sst.station_cd\n                  AND sst.line_group_cd IN(\n                          SELECT\n                              _sst.line_group_cd\n                          FROM\n                              station_station_types AS _sst\n                          WHERE\n                              _sst.station_cd IN(\n                                  SELECT\n                                      s.station_cd\n                                  FROM\n                                      stations AS s\n                                  WHERE\n                                      s.station_g_cd = ?\n                              )\n                              AND _sst.pass <> 1\n                      )\n                  AND sst.line_group_cd IN(\n                          SELECT\n                              _sst.line_group_cd\n                          FROM\n                              station_station_types AS _sst\n                          WHERE\n                              _sst.station_cd IN(\n                                  SELECT\n                                      s.station_cd\n                                  FROM\n                                      stations AS s\n                                  WHERE\n                                      s.station_g_cd = ?\n                              )\n                              AND _sst.pass <> 1\n                      )\n                  AND sta.station_cd = sst.station_cd\n                  JOIN\n                      types\n                  ON  sst.type_cd = types.type_cd\n                  JOIN\n                      `lines` AS via_lines\n                  ON  sta.line_cd = via_lines.line_cd\n                  LEFT JOIN\n                      `line_aliases` AS la\n                  ON  la.station_cd = sta.station_cd\n                  LEFT JOIN\n                      `aliases` AS a\n                  ON  a.id = la.alias_cd\n          )\n          UNION\n          (\n              SELECT\n                  sta.*,\n                  via_lines.company_cd,\n                  via_lines.line_type,\n                  via_lines.line_symbol_primary,\n                  via_lines.line_symbol_secondary,\n                  via_lines.line_symbol_extra,\n                  via_lines.line_symbol_primary_color,\n                  via_lines.line_symbol_secondary_color,\n                  via_lines.line_symbol_extra_color,\n                  via_lines.line_symbol_primary_shape,\n                  via_lines.line_symbol_secondary_shape,\n                  via_lines.line_symbol_extra_shape,\n                  via_lines.average_distance,\n                  sst.type_cd,\n                  sst.line_group_cd,\n                  sst.pass,\n                  types.id AS type_id,\n                  types.type_name,\n                  types.type_name_k,\n                  types.type_name_r,\n                  types.type_name_zh,\n                  types.type_name_ko,\n                  types.color,\n                  types.direction,\n                  types.kind,\n                  COALESCE(a.line_name, via_lines.line_name) AS line_name,\n                  COALESCE(a.line_name_k, via_lines.line_name_k) AS line_name_k,\n                  COALESCE(a.line_name_h, via_lines.line_name_h) AS line_name_h,\n                  COALESCE(a.line_name_r, via_lines.line_name_r) AS line_name_r,\n                  COALESCE(a.line_name_zh, via_lines.line_name_zh) AS line_name_zh,\n                  COALESCE(a.line_name_ko, via_lines.line_name_ko) AS line_name_ko,\n                  COALESCE(a.line_color_c, via_lines.line_color_c) AS line_color_c,\n                  IFNULL(\n                      sta.station_cd = sst.station_cd,\n                      0\n                  ) AS has_train_types\n              FROM\n                  stations AS sta\n                  LEFT JOIN\n                      station_station_types AS sst\n                  ON  sst.station_cd = NULL\n                  LEFT JOIN\n                      types\n                  ON  types.type_cd = NULL\n                  JOIN\n                      `lines` AS via_lines\n                  ON  via_lines.line_cd IN(\n                          SELECT\n                              s.line_cd\n                          FROM\n                              stations AS s\n                          WHERE\n                              s.station_g_cd = ?\n                      )\n                  AND via_lines.line_cd IN(\n                          SELECT\n                              s.line_cd\n                          FROM\n                              stations AS s\n                          WHERE\n                              s.station_g_cd = ?\n                      )\n                  LEFT JOIN\n                      `line_aliases` AS la\n                  ON  la.station_cd = sta.station_cd\n                  LEFT JOIN\n                      `aliases` AS a\n                  ON  a.id = la.alias_cd\n              WHERE\n                  sta.line_cd = via_lines.line_cd\n              AND sst.pass <> 1\n              ORDER BY\n                  sta.e_sort,\n                  sta.station_cd\n          )",
+  "query": "SELECT\n            sta.*,\n            via_lines.company_cd,\n            via_lines.line_type,\n            via_lines.line_symbol_primary,\n            via_lines.line_symbol_secondary,\n            via_lines.line_symbol_extra,\n            via_lines.line_symbol_primary_color,\n            via_lines.line_symbol_secondary_color,\n            via_lines.line_symbol_extra_color,\n            via_lines.line_symbol_primary_shape,\n            via_lines.line_symbol_secondary_shape,\n            via_lines.line_symbol_extra_shape,\n            via_lines.average_distance,\n            sst.type_cd,\n            sst.line_group_cd,\n            sst.pass,\n            types.id AS type_id,\n            types.type_name,\n            types.type_name_k,\n            types.type_name_r,\n            types.type_name_zh,\n            types.type_name_ko,\n            types.color,\n            types.direction,\n            types.kind,\n            COALESCE(a.line_name, via_lines.line_name) AS line_name,\n            COALESCE(a.line_name_k, via_lines.line_name_k) AS line_name_k,\n            COALESCE(a.line_name_h, via_lines.line_name_h) AS line_name_h,\n            COALESCE(a.line_name_r, via_lines.line_name_r) AS line_name_r,\n            COALESCE(a.line_name_zh, via_lines.line_name_zh) AS line_name_zh,\n            COALESCE(a.line_name_ko, via_lines.line_name_ko) AS line_name_ko,\n            COALESCE(a.line_color_c, via_lines.line_color_c) AS line_color_c,\n            IFNULL(\n                sta.station_cd = sst.station_cd,\n                0\n            ) AS has_train_types\n            FROM\n            stations AS sta\n            LEFT JOIN\n                station_station_types AS sst\n            ON  sta.station_cd = sst.station_cd\n            AND sst.line_group_cd IN(\n                SELECT\n                    _sst.line_group_cd\n                FROM\n                    station_station_types AS _sst\n                WHERE\n                    _sst.station_cd IN(\n                    SELECT\n                        s.station_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = ?\n                    )\n                AND _sst.pass <> 1\n                )\n            AND sst.line_group_cd IN(\n                SELECT\n                    _sst.line_group_cd\n                FROM\n                    station_station_types AS _sst\n                WHERE\n                    _sst.station_cd IN(\n                    SELECT\n                        s.station_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = ?\n                    )\n                AND _sst.pass <> 1\n                )\n            AND sta.station_cd = sst.station_cd\n            LEFT JOIN\n                types\n            ON  sst.type_cd = types.type_cd\n            JOIN\n                `lines` AS via_lines\n            ON  sta.line_cd = via_lines.line_cd\n            LEFT JOIN\n                `line_aliases` AS la\n            ON  la.station_cd = sta.station_cd\n            LEFT JOIN\n                `aliases` AS a\n            ON  a.id = la.alias_cd\n            WHERE\n            via_lines.line_cd = IF(sst.type_cd IS NULL,(\n                SELECT\n                    l.line_cd\n                FROM\n                    `lines` AS l\n                    JOIN\n                    `stations` AS s1\n                    ON  s1.station_g_cd = ?\n                    JOIN\n                    `stations` AS s2\n                    ON  s2.station_g_cd = ?\n                    AND l.line_cd = s1.line_cd\n                    AND l.line_cd = s2.line_cd\n                ), sta.line_cd)",
   "describe": {
     "columns": [
       {
@@ -8,7 +8,7 @@
         "name": "station_cd",
         "type_info": {
           "type": "Long",
-          "flags": "NOT_NULL | UNSIGNED",
+          "flags": "NOT_NULL | PRIMARY_KEY | UNSIGNED | NO_DEFAULT_VALUE",
           "char_set": 63,
           "max_size": 10
         }
@@ -18,7 +18,7 @@
         "name": "station_g_cd",
         "type_info": {
           "type": "Long",
-          "flags": "NOT_NULL | UNSIGNED",
+          "flags": "NOT_NULL | MULTIPLE_KEY | UNSIGNED | NO_DEFAULT_VALUE",
           "char_set": 63,
           "max_size": 10
         }
@@ -28,7 +28,7 @@
         "name": "station_name",
         "type_info": {
           "type": "VarString",
-          "flags": "NOT_NULL",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
           "char_set": 224,
           "max_size": 1020
         }
@@ -38,7 +38,7 @@
         "name": "station_name_k",
         "type_info": {
           "type": "VarString",
-          "flags": "NOT_NULL",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
           "char_set": 224,
           "max_size": 1020
         }
@@ -118,7 +118,7 @@
         "name": "line_cd",
         "type_info": {
           "type": "Long",
-          "flags": "NOT_NULL | UNSIGNED",
+          "flags": "NOT_NULL | MULTIPLE_KEY | UNSIGNED | NO_DEFAULT_VALUE",
           "char_set": 63,
           "max_size": 10
         }
@@ -128,7 +128,7 @@
         "name": "pref_cd",
         "type_info": {
           "type": "Long",
-          "flags": "NOT_NULL | UNSIGNED",
+          "flags": "NOT_NULL | UNSIGNED | NO_DEFAULT_VALUE",
           "char_set": 63,
           "max_size": 10
         }
@@ -138,7 +138,7 @@
         "name": "post",
         "type_info": {
           "type": "VarString",
-          "flags": "NOT_NULL",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
           "char_set": 224,
           "max_size": 1020
         }
@@ -148,7 +148,7 @@
         "name": "address",
         "type_info": {
           "type": "VarString",
-          "flags": "NOT_NULL",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
           "char_set": 224,
           "max_size": 1020
         }
@@ -158,7 +158,7 @@
         "name": "lon",
         "type_info": {
           "type": "Double",
-          "flags": "NOT_NULL",
+          "flags": "NOT_NULL | UNSIGNED | NO_DEFAULT_VALUE",
           "char_set": 63,
           "max_size": 22
         }
@@ -168,7 +168,7 @@
         "name": "lat",
         "type_info": {
           "type": "Double",
-          "flags": "NOT_NULL",
+          "flags": "NOT_NULL | UNSIGNED | NO_DEFAULT_VALUE",
           "char_set": 63,
           "max_size": 22
         }
@@ -178,7 +178,7 @@
         "name": "open_ymd",
         "type_info": {
           "type": "VarString",
-          "flags": "NOT_NULL",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
           "char_set": 224,
           "max_size": 1020
         }
@@ -188,7 +188,7 @@
         "name": "close_ymd",
         "type_info": {
           "type": "VarString",
-          "flags": "NOT_NULL",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
           "char_set": 224,
           "max_size": 1020
         }
@@ -198,7 +198,7 @@
         "name": "e_status",
         "type_info": {
           "type": "Long",
-          "flags": "NOT_NULL | UNSIGNED",
+          "flags": "NOT_NULL | UNSIGNED | NO_DEFAULT_VALUE",
           "char_set": 63,
           "max_size": 10
         }
@@ -208,7 +208,7 @@
         "name": "e_sort",
         "type_info": {
           "type": "Long",
-          "flags": "NOT_NULL | UNSIGNED",
+          "flags": "NOT_NULL | UNSIGNED | NO_DEFAULT_VALUE",
           "char_set": 63,
           "max_size": 10
         }
@@ -218,7 +218,7 @@
         "name": "company_cd",
         "type_info": {
           "type": "Long",
-          "flags": "NOT_NULL | UNSIGNED",
+          "flags": "NOT_NULL | MULTIPLE_KEY | UNSIGNED | NO_DEFAULT_VALUE",
           "char_set": 63,
           "max_size": 10
         }
@@ -228,7 +228,7 @@
         "name": "line_type",
         "type_info": {
           "type": "Long",
-          "flags": "NOT_NULL | UNSIGNED",
+          "flags": "NOT_NULL | UNSIGNED | NO_DEFAULT_VALUE",
           "char_set": 63,
           "max_size": 10
         }
@@ -328,7 +328,7 @@
         "name": "average_distance",
         "type_info": {
           "type": "Double",
-          "flags": "NOT_NULL",
+          "flags": "NOT_NULL | UNSIGNED | NO_DEFAULT_VALUE",
           "char_set": 63,
           "max_size": 22
         }
@@ -338,7 +338,7 @@
         "name": "type_cd",
         "type_info": {
           "type": "Long",
-          "flags": "UNSIGNED",
+          "flags": "MULTIPLE_KEY | UNSIGNED | NO_DEFAULT_VALUE",
           "char_set": 63,
           "max_size": 10
         }
@@ -348,7 +348,7 @@
         "name": "line_group_cd",
         "type_info": {
           "type": "Long",
-          "flags": "UNSIGNED",
+          "flags": "MULTIPLE_KEY | UNSIGNED | NO_DEFAULT_VALUE",
           "char_set": 63,
           "max_size": 10
         }
@@ -368,7 +368,7 @@
         "name": "type_id",
         "type_info": {
           "type": "Long",
-          "flags": "UNSIGNED",
+          "flags": "PRIMARY_KEY | UNSIGNED | AUTO_INCREMENT",
           "char_set": 63,
           "max_size": 10
         }
@@ -378,7 +378,7 @@
         "name": "type_name",
         "type_info": {
           "type": "VarString",
-          "flags": "",
+          "flags": "NO_DEFAULT_VALUE",
           "char_set": 224,
           "max_size": 1020
         }
@@ -388,7 +388,7 @@
         "name": "type_name_k",
         "type_info": {
           "type": "VarString",
-          "flags": "",
+          "flags": "NO_DEFAULT_VALUE",
           "char_set": 224,
           "max_size": 1020
         }
@@ -398,7 +398,7 @@
         "name": "type_name_r",
         "type_info": {
           "type": "VarString",
-          "flags": "",
+          "flags": "NO_DEFAULT_VALUE",
           "char_set": 224,
           "max_size": 1020
         }
@@ -408,7 +408,7 @@
         "name": "type_name_zh",
         "type_info": {
           "type": "VarString",
-          "flags": "",
+          "flags": "NO_DEFAULT_VALUE",
           "char_set": 224,
           "max_size": 1020
         }
@@ -418,7 +418,7 @@
         "name": "type_name_ko",
         "type_info": {
           "type": "VarString",
-          "flags": "",
+          "flags": "NO_DEFAULT_VALUE",
           "char_set": 224,
           "max_size": 1020
         }
@@ -428,7 +428,7 @@
         "name": "color",
         "type_info": {
           "type": "VarString",
-          "flags": "",
+          "flags": "NO_DEFAULT_VALUE",
           "char_set": 224,
           "max_size": 1020
         }
@@ -528,7 +528,7 @@
         "name": "has_train_types",
         "type_info": {
           "type": "Long",
-          "flags": "NOT_NULL",
+          "flags": "NOT_NULL | BINARY",
           "char_set": 63,
           "max_size": 1
         }
@@ -593,5 +593,5 @@
       false
     ]
   },
-  "hash": "59e1f8dba1741221160ab6fe39545e2314d98b414dfe4c2c0914986ef2111e17"
+  "hash": "9e59a9dfb13e6a678b0af2db5debdc44c6b65fda6107b1072fdff52350740325"
 }

--- a/stationapi/src/infrastructure/station_repository.rs
+++ b/stationapi/src/infrastructure/station_repository.rs
@@ -973,173 +973,108 @@ impl InternalStationRepository {
     ) -> Result<Vec<Station>, DomainError> {
         let rows = sqlx::query_as!(
             StationRow,
-            "(
-              SELECT
-                  sta.*,
-                  via_lines.company_cd,
-                  via_lines.line_type,
-                  via_lines.line_symbol_primary,
-                  via_lines.line_symbol_secondary,
-                  via_lines.line_symbol_extra,
-                  via_lines.line_symbol_primary_color,
-                  via_lines.line_symbol_secondary_color,
-                  via_lines.line_symbol_extra_color,
-                  via_lines.line_symbol_primary_shape,
-                  via_lines.line_symbol_secondary_shape,
-                  via_lines.line_symbol_extra_shape,
-                  via_lines.average_distance,
-                  sst.type_cd,
-                  sst.line_group_cd,
-                  sst.pass,
-                  types.id AS type_id,
-                  types.type_name,
-                  types.type_name_k,
-                  types.type_name_r,
-                  types.type_name_zh,
-                  types.type_name_ko,
-                  types.color,
-                  types.direction,
-                  types.kind,
-                  COALESCE(a.line_name, via_lines.line_name) AS line_name,
-                  COALESCE(a.line_name_k, via_lines.line_name_k) AS line_name_k,
-                  COALESCE(a.line_name_h, via_lines.line_name_h) AS line_name_h,
-                  COALESCE(a.line_name_r, via_lines.line_name_r) AS line_name_r,
-                  COALESCE(a.line_name_zh, via_lines.line_name_zh) AS line_name_zh,
-                  COALESCE(a.line_name_ko, via_lines.line_name_ko) AS line_name_ko,
-                  COALESCE(a.line_color_c, via_lines.line_color_c) AS line_color_c,
-                  IFNULL(
-                      sta.station_cd = sst.station_cd,
-                      0
-                  ) AS has_train_types
-              FROM
-                  stations AS sta
-                  JOIN
-                      station_station_types AS sst
-                  ON  sta.station_cd = sst.station_cd
-                  AND sst.line_group_cd IN(
-                          SELECT
-                              _sst.line_group_cd
-                          FROM
-                              station_station_types AS _sst
-                          WHERE
-                              _sst.station_cd IN(
-                                  SELECT
-                                      s.station_cd
-                                  FROM
-                                      stations AS s
-                                  WHERE
-                                      s.station_g_cd = ?
-                              )
-                              AND _sst.pass <> 1
-                      )
-                  AND sst.line_group_cd IN(
-                          SELECT
-                              _sst.line_group_cd
-                          FROM
-                              station_station_types AS _sst
-                          WHERE
-                              _sst.station_cd IN(
-                                  SELECT
-                                      s.station_cd
-                                  FROM
-                                      stations AS s
-                                  WHERE
-                                      s.station_g_cd = ?
-                              )
-                              AND _sst.pass <> 1
-                      )
-                  AND sta.station_cd = sst.station_cd
-                  JOIN
-                      types
-                  ON  sst.type_cd = types.type_cd
-                  JOIN
-                      `lines` AS via_lines
-                  ON  sta.line_cd = via_lines.line_cd
-                  LEFT JOIN
-                      `line_aliases` AS la
-                  ON  la.station_cd = sta.station_cd
-                  LEFT JOIN
-                      `aliases` AS a
-                  ON  a.id = la.alias_cd
-          )
-          UNION
-          (
-              SELECT
-                  sta.*,
-                  via_lines.company_cd,
-                  via_lines.line_type,
-                  via_lines.line_symbol_primary,
-                  via_lines.line_symbol_secondary,
-                  via_lines.line_symbol_extra,
-                  via_lines.line_symbol_primary_color,
-                  via_lines.line_symbol_secondary_color,
-                  via_lines.line_symbol_extra_color,
-                  via_lines.line_symbol_primary_shape,
-                  via_lines.line_symbol_secondary_shape,
-                  via_lines.line_symbol_extra_shape,
-                  via_lines.average_distance,
-                  sst.type_cd,
-                  sst.line_group_cd,
-                  sst.pass,
-                  types.id AS type_id,
-                  types.type_name,
-                  types.type_name_k,
-                  types.type_name_r,
-                  types.type_name_zh,
-                  types.type_name_ko,
-                  types.color,
-                  types.direction,
-                  types.kind,
-                  COALESCE(a.line_name, via_lines.line_name) AS line_name,
-                  COALESCE(a.line_name_k, via_lines.line_name_k) AS line_name_k,
-                  COALESCE(a.line_name_h, via_lines.line_name_h) AS line_name_h,
-                  COALESCE(a.line_name_r, via_lines.line_name_r) AS line_name_r,
-                  COALESCE(a.line_name_zh, via_lines.line_name_zh) AS line_name_zh,
-                  COALESCE(a.line_name_ko, via_lines.line_name_ko) AS line_name_ko,
-                  COALESCE(a.line_color_c, via_lines.line_color_c) AS line_color_c,
-                  IFNULL(
-                      sta.station_cd = sst.station_cd,
-                      0
-                  ) AS has_train_types
-              FROM
-                  stations AS sta
-                  LEFT JOIN
-                      station_station_types AS sst
-                  ON  sst.station_cd = NULL
-                  LEFT JOIN
-                      types
-                  ON  types.type_cd = NULL
-                  JOIN
-                      `lines` AS via_lines
-                  ON  via_lines.line_cd IN(
-                          SELECT
-                              s.line_cd
-                          FROM
-                              stations AS s
-                          WHERE
-                              s.station_g_cd = ?
-                      )
-                  AND via_lines.line_cd IN(
-                          SELECT
-                              s.line_cd
-                          FROM
-                              stations AS s
-                          WHERE
-                              s.station_g_cd = ?
-                      )
-                  LEFT JOIN
-                      `line_aliases` AS la
-                  ON  la.station_cd = sta.station_cd
-                  LEFT JOIN
-                      `aliases` AS a
-                  ON  a.id = la.alias_cd
-              WHERE
-                  sta.line_cd = via_lines.line_cd
-              AND sst.pass <> 1
-              ORDER BY
-                  sta.e_sort,
-                  sta.station_cd
-          )",
+            "SELECT
+            sta.*,
+            via_lines.company_cd,
+            via_lines.line_type,
+            via_lines.line_symbol_primary,
+            via_lines.line_symbol_secondary,
+            via_lines.line_symbol_extra,
+            via_lines.line_symbol_primary_color,
+            via_lines.line_symbol_secondary_color,
+            via_lines.line_symbol_extra_color,
+            via_lines.line_symbol_primary_shape,
+            via_lines.line_symbol_secondary_shape,
+            via_lines.line_symbol_extra_shape,
+            via_lines.average_distance,
+            sst.type_cd,
+            sst.line_group_cd,
+            sst.pass,
+            types.id AS type_id,
+            types.type_name,
+            types.type_name_k,
+            types.type_name_r,
+            types.type_name_zh,
+            types.type_name_ko,
+            types.color,
+            types.direction,
+            types.kind,
+            COALESCE(a.line_name, via_lines.line_name) AS line_name,
+            COALESCE(a.line_name_k, via_lines.line_name_k) AS line_name_k,
+            COALESCE(a.line_name_h, via_lines.line_name_h) AS line_name_h,
+            COALESCE(a.line_name_r, via_lines.line_name_r) AS line_name_r,
+            COALESCE(a.line_name_zh, via_lines.line_name_zh) AS line_name_zh,
+            COALESCE(a.line_name_ko, via_lines.line_name_ko) AS line_name_ko,
+            COALESCE(a.line_color_c, via_lines.line_color_c) AS line_color_c,
+            IFNULL(
+                sta.station_cd = sst.station_cd,
+                0
+            ) AS has_train_types
+            FROM
+            stations AS sta
+            LEFT JOIN
+                station_station_types AS sst
+            ON  sta.station_cd = sst.station_cd
+            AND sst.line_group_cd IN(
+                SELECT
+                    _sst.line_group_cd
+                FROM
+                    station_station_types AS _sst
+                WHERE
+                    _sst.station_cd IN(
+                    SELECT
+                        s.station_cd
+                    FROM
+                        stations AS s
+                    WHERE
+                        s.station_g_cd = ?
+                    )
+                AND _sst.pass <> 1
+                )
+            AND sst.line_group_cd IN(
+                SELECT
+                    _sst.line_group_cd
+                FROM
+                    station_station_types AS _sst
+                WHERE
+                    _sst.station_cd IN(
+                    SELECT
+                        s.station_cd
+                    FROM
+                        stations AS s
+                    WHERE
+                        s.station_g_cd = ?
+                    )
+                AND _sst.pass <> 1
+                )
+            AND sta.station_cd = sst.station_cd
+            LEFT JOIN
+                types
+            ON  sst.type_cd = types.type_cd
+            JOIN
+                `lines` AS via_lines
+            ON  sta.line_cd = via_lines.line_cd
+            LEFT JOIN
+                `line_aliases` AS la
+            ON  la.station_cd = sta.station_cd
+            LEFT JOIN
+                `aliases` AS a
+            ON  a.id = la.alias_cd
+            WHERE
+            via_lines.line_cd = IF(sst.type_cd IS NULL,(
+                SELECT
+                    l.line_cd
+                FROM
+                    `lines` AS l
+                    JOIN
+                    `stations` AS s1
+                    ON  s1.station_g_cd = ?
+                    JOIN
+                    `stations` AS s2
+                    ON  s2.station_g_cd = ?
+                    AND l.line_cd = s1.line_cd
+                    AND l.line_cd = s2.line_cd
+                ), sta.line_cd)",
             from_station_id,
             to_station_id,
             from_station_id,

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -592,7 +592,7 @@ where
                 let stops = stops
                     .iter()
                     .map(|row| {
-                        let extracted_line = Arc::new(self.extract_line_from_station(&row));
+                        let extracted_line = Arc::new(self.extract_line_from_station(row));
 
                         let locked_tt_lines = &tt_lines.lock().unwrap();
 
@@ -667,7 +667,7 @@ where
                             station_name_r: row.station_name_r.clone(),
                             station_name_zh: row.station_name_zh.clone(),
                             station_name_ko: row.station_name_ko.clone(),
-                            station_numbers: self.get_station_numbers(&row),
+                            station_numbers: self.get_station_numbers(row),
                             primary_station_number: row.primary_station_number.clone(),
                             secondary_station_number: row.secondary_station_number.clone(),
                             extra_station_number: row.extra_station_number.clone(),


### PR DESCRIPTION
新宿三丁目->元町・中華街でPostman検証
`{"from_station_group_id": 2800217,"to_station_group_id": 9931006}`

# dev
376.43 ms
529.5 ms
409.12 ms

# fix/search-perf
~~427.99 ms~~
~~392.75 ms~~
~~453.53 ms~~

~~devとそんなに変わらないように見えるが500msを超える頻度が減っているので効果ないわけではなさそう~~

https://github.com/TrainLCD/StationAPI/pull/992/commits/6309b4f52daf2b62e1d0515f66c8e9d1b385c8b6
↑の対応後400ms以下のレスポンスが続いた

358.78 ms
359.28 ms
358.46 ms