### PR TITLE
gRPC-Web無効化のフロー改善

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -10,7 +10,7 @@ services:
       - ..:/workspace:cached
     environment:
       DATABASE_URL: mariadb://stationapi:password@db-dc/stationapi
-      ACCEPT_HTTP1: true
+      DISABLE_GRPC_WEB: false
       HOST: 0.0.0.0
     ports:
       - 50051:50051

--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 ## API
 DATABASE_URL=mysql://root:password@localhost:3306/stationapi
-ACCEPT_HTTP1=false
+DISABLE_GRPC_WEB=false
 
 ## Migration
 MYSQL_USER=

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -10,7 +10,7 @@ services:
       - migration
     environment:
       DATABASE_URL: mysql://stationapi:password@db/stationapi
-      ACCEPT_HTTP1: true
+      DISABLE_GRPC_WEB: false
       HOST: 0.0.0.0
     ports:
       - 50051:50051

--- a/compose.yml
+++ b/compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: ./docker/api/Dockerfile.dev
-    command: bacon run -- --bin stationapi
+    command: cargo watch -s "cargo run -p stationapi"
     depends_on:
       - db
     volumes:

--- a/compose.yml
+++ b/compose.yml
@@ -5,15 +5,14 @@ services:
     build:
       context: .
       dockerfile: ./docker/api/Dockerfile.dev
-    command: cargo watch -s "cargo run -p stationapi"
+    command: bacon run -- --bin stationapi
     depends_on:
       - db
     volumes:
       - .:/app
     environment:
       DATABASE_URL: mariadb://stationapi:password@db/stationapi
-      ACCEPT_HTTP1: true
-      ENABLE_ALL_STATIONS_RPC: true
+      DISABLE_GRPC_WEB: false
       HOST: 0.0.0.0
     ports:
       - 50051:50051

--- a/stationapi/src/main.rs
+++ b/stationapi/src/main.rs
@@ -76,7 +76,7 @@ async fn run() -> std::result::Result<(), anyhow::Error> {
 
     info!("StationAPI Server listening on {}", addr);
 
-    if disable_grpc_web == true {
+    if disable_grpc_web {
         Server::builder()
             .add_service(health_service)
             .add_service(svc)


### PR DESCRIPTION
HTTP1を許可しない処理の代わりにHTTP1を使わない時はgRPC-Webも無効化する処理に置き換えた
実質TrainLCDアプリとかgRPC-Webを使う用途でしか使っていないのに `ACCEPT_HTTP1` を `true` にする環境変数を追加しなくて良くなる