### PR TITLE
devcontainerにrelease buildは要らない

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -32,7 +32,7 @@ services:
   migration:
     build:
       context: ..
-      dockerfile: ./docker/migration/Dockerfile
+      dockerfile: ./docker/migration/Dockerfile.dev
     command: ["./wait-for-it.sh", "db:3306", "--", "./migration"]
     depends_on:
       - db

--- a/docker/migration/Dockerfile.dev
+++ b/docker/migration/Dockerfile.dev
@@ -1,0 +1,16 @@
+FROM rust:1 AS builder
+WORKDIR /app
+COPY Cargo.toml .
+COPY Cargo.lock .
+COPY migration .
+RUN cargo build -p migration
+
+FROM debian:bookworm-slim
+WORKDIR /app
+RUN apt-get update && \
+    apt-get install -y --quiet default-mysql-client && \
+    rm -rf /var/lib/apt/lists/*
+COPY data /app/data
+COPY --from=builder /app/target/debug/migration .
+COPY ./scripts/wait-for-it.sh .
+CMD ["./migration"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 移行サービスのビルド構成を更新し、開発環境向けの新しいパイプラインを導入しました。  
    この変更により、サービスのビルドと実行の効率が向上し、環境間の一貫性が強化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->