### PR TITLE
ルートのREADME.mdにデータ貢献についての項目追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 The gRPC-Web API for provides nearby japanese train station.
 
+## Data Contribution
+
+This project includes a comprehensive dataset of Japanese railway information in the `data/` directory. The data is maintained in CSV format and contributions are primarily targeted at Japanese speakers. For detailed information about data structure and contribution guidelines, please refer to [data/README.md](data/README.md).
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):


### PR DESCRIPTION
related #986 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * READMEに「データ提供」セクションを追加し、日本の鉄道情報データセットの存在と、データ貢献に関する案内を記載しました。データ構造や貢献方法の詳細については、専用のガイドへのリンクを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->