### PR TITLE
station_number(n)の例が不適切だった

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -94,10 +94,10 @@
 | `station_name_rn`   | 文字列 | -    | 駅名（ローマ字、正規化版）                  | `Tokyo`                         |
 | `station_name_zh`   | 文字列 | -    | 駅名（中国語）                              | `东京`                          |
 | `station_name_ko`   | 文字列 | -    | 駅名（韓国語）                              | `도쿄`                          |
-| `station_number1`   | 文字列 | -    | 駅番号・駅記号 1                            | `JR01`, `T01`                   |
-| `station_number2`   | 文字列 | -    | 駅番号・駅記号 2                            | -                               |
-| `station_number3`   | 文字列 | -    | 駅番号・駅記号 3                            | -                               |
-| `station_number4`   | 文字列 | -    | 駅番号・駅記号 4                            | -                               |
+| `station_number1`   | 文字列 | -    | 駅番号・駅記号 1                            | `01`                            |
+| `station_number2`   | 文字列 | -    | 駅番号・駅記号 2                            | `09`                            |
+| `station_number3`   | 文字列 | -    | 駅番号・駅記号 3                            | `11`                            |
+| `station_number4`   | 文字列 | -    | 駅番号・駅記号 4                            | `14`                            |
 | `three_letter_code` | 文字列 | -    | スリーレターコード                          | `TYO`                           |
 | `line_cd`           | 数値   | ✓    | 路線コード（lines テーブルとリンク）        | `1002`                          |
 | `pref_cd`           | 数値   | ✓    | 都道府県コード                              | `13`                            |

--- a/data/README.md
+++ b/data/README.md
@@ -94,10 +94,10 @@
 | `station_name_rn`   | 文字列 | -    | 駅名（ローマ字、正規化版）                  | `Tokyo`                         |
 | `station_name_zh`   | 文字列 | -    | 駅名（中国語）                              | `东京`                          |
 | `station_name_ko`   | 文字列 | -    | 駅名（韓国語）                              | `도쿄`                          |
-| `station_number1`   | 文字列 | -    | 駅番号・駅記号 1                            | `01`                            |
-| `station_number2`   | 文字列 | -    | 駅番号・駅記号 2                            | `09`                            |
-| `station_number3`   | 文字列 | -    | 駅番号・駅記号 3                            | `11`                            |
-| `station_number4`   | 文字列 | -    | 駅番号・駅記号 4                            | `14`                            |
+| `station_number1`   | 文字列 | -    | 駅番号 1                                    | `01`                            |
+| `station_number2`   | 文字列 | -    | 駅番号 2                                    | `09`                            |
+| `station_number3`   | 文字列 | -    | 駅番号 3                                    | `11`                            |
+| `station_number4`   | 文字列 | -    | 駅番号 4                                    | `14`                            |
 | `three_letter_code` | 文字列 | -    | スリーレターコード                          | `TYO`                           |
 | `line_cd`           | 数値   | ✓    | 路線コード（lines テーブルとリンク）        | `1002`                          |
 | `pref_cd`           | 数値   | ✓    | 都道府県コード                              | `13`                            |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * `station_number1`〜`station_number4`の説明と例を、駅記号を含まない数値のみの内容に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->