### PR TITLE
一つの駅グループに同じ路線IDのデータが入り込まないように修正

### DIFF
--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -220,11 +220,16 @@ where
                 station.train_type = Some(tt);
             };
 
+            let mut seen_line_cds = std::collections::HashSet::new();
             let mut lines: Vec<Line> = lines
                 .iter()
-                .filter(|&l| l.station_g_cd.unwrap_or(0) == station.station_g_cd)
+                .filter(|&l| {
+                    l.station_g_cd.unwrap_or(0) == station.station_g_cd
+                        && seen_line_cds.insert(l.line_cd)
+                })
                 .cloned()
                 .collect();
+
             for line in lines.iter_mut() {
                 line.company = companies
                     .iter()


### PR DESCRIPTION
富山駅とか都庁前駅が前からバグってた。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 駅に関連付けられる路線リストから、重複する路線コードを除外し、同じ路線が複数回表示されないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->