### PR TITLE
station_station_typesのidをNULL許容に変更

### DIFF
--- a/.sqlx/query-0a1c6e15355fdf6363a083a43fec27a04b91b946ae7fdc192a721f9b6923e690.json
+++ b/.sqlx/query-0a1c6e15355fdf6363a083a43fec27a04b91b946ae7fdc192a721f9b6923e690.json
@@ -1,0 +1,190 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT l.line_cd,\n            l.company_cd,\n            l.line_type,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            l.e_status,\n            l.e_sort,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            s.station_cd,\n            s.station_g_cd,\n            sst.line_group_cd,\n            sst.type_cd,\n            COALESCE(alias_data.line_name, l.line_name) AS line_name,\n            COALESCE(alias_data.line_name_k, l.line_name_k) AS line_name_k,\n            COALESCE(alias_data.line_name_h, l.line_name_h) AS line_name_h,\n            COALESCE(alias_data.line_name_r, l.line_name_r) AS line_name_r,\n            COALESCE(alias_data.line_name_zh, l.line_name_zh) AS line_name_zh,\n            COALESCE(alias_data.line_name_ko, l.line_name_ko) AS line_name_ko,\n            COALESCE(alias_data.line_color_c, l.line_color_c) AS line_color_c\n        FROM lines AS l\n            JOIN stations AS s ON s.station_cd = $1\n            JOIN station_station_types AS sst ON sst.station_cd = s.station_cd AND sst.pass <> 1\n            LEFT JOIN (\n                SELECT DISTINCT ON (la.station_cd) \n                    la.station_cd,\n                    a.line_name,\n                    a.line_name_k,\n                    a.line_name_h,\n                    a.line_name_r,\n                    a.line_name_zh,\n                    a.line_name_ko,\n                    a.line_color_c\n                FROM line_aliases AS la\n                JOIN aliases AS a ON la.alias_cd = a.id\n                WHERE la.station_cd = $1\n                LIMIT 1\n            ) AS alias_data ON alias_data.station_cd = s.station_cd\n        WHERE l.line_cd = s.line_cd",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 17,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 19,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 20,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 21,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 23,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_color_c",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      null,
+      false,
+      false,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "0a1c6e15355fdf6363a083a43fec27a04b91b946ae7fdc192a721f9b6923e690"
+}

--- a/.sqlx/query-1ffa93b133de68b60a7e0a6663f212f613c175a35beb700a0001efb82f184d10.json
+++ b/.sqlx/query-1ffa93b133de68b60a7e0a6663f212f613c175a35beb700a0001efb82f184d10.json
@@ -1,0 +1,195 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT \n            l.line_cd,\n            l.company_cd,\n            l.line_type,\n            l.line_name,\n            l.line_name_k,\n            l.line_name_h,\n            l.line_name_r,\n            l.line_name_zh,\n            l.line_name_ko,\n            l.line_color_c,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            l.e_status,\n            l.e_sort,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            CAST(NULL AS INTEGER) AS line_group_cd,\n            CAST(NULL AS INTEGER) AS station_cd,\n            CAST(NULL AS INTEGER) AS station_g_cd,\n            CAST(NULL AS INTEGER) AS type_cd\n            FROM lines AS l\n            WHERE (\n                    l.line_name LIKE $1\n                    OR l.line_name_rn LIKE $2\n                    OR l.line_name_k LIKE $3\n                    OR l.line_name_zh LIKE $4\n                    OR l.line_name_ko LIKE $5\n                )\n                AND l.e_status = 0\n            LIMIT $6",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 18,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 19,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 26,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 27,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 28,
+        "name": "type_cd",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "1ffa93b133de68b60a7e0a6663f212f613c175a35beb700a0001efb82f184d10"
+}

--- a/.sqlx/query-217b99932d995eff26a2eb16abab5dd05c27b6b77f78f169ca2049f45cf432ce.json
+++ b/.sqlx/query-217b99932d995eff26a2eb16abab5dd05c27b6b77f78f169ca2049f45cf432ce.json
@@ -1,0 +1,365 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH\n                from_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $1\n                        AND s.e_status = 0\n                ),\n                to_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $2\n                        AND s.e_status = 0\n                ),\n                sst_cte_c1 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN from_cte ON sst.station_cd = from_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte_c2 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN to_cte ON sst.station_cd = to_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte AS (\n                    SELECT\n                        sst.id,\n                        sst.station_cd,\n                        sst.type_cd,\n                        sst.line_group_cd,\n                        sst.pass\n                    FROM\n                        station_station_types AS sst\n                        JOIN sst_cte_c1 ON sst.line_group_cd = sst_cte_c1.line_group_cd\n                        JOIN sst_cte_c2 ON sst.line_group_cd = sst_cte_c2.line_group_cd\n                )\n            SELECT\n                sta.station_cd,\n                sta.station_g_cd,\n                sta.station_name,\n                sta.station_name_k,\n                sta.station_name_r,\n                sta.station_name_rn,\n                sta.station_name_zh,\n                sta.station_name_ko,\n                sta.station_number1,\n                sta.station_number2,\n                sta.station_number3,\n                sta.station_number4,\n                sta.three_letter_code,\n                sta.line_cd,\n                sta.pref_cd,\n                sta.post,\n                sta.address,\n                sta.lon,\n                sta.lat,\n                sta.open_ymd,\n                sta.close_ymd,\n                sta.e_status,\n                sta.e_sort,\n                lin.company_cd,\n                COALESCE(NULLIF(COALESCE(a.line_name, lin.line_name), ''), NULL) AS line_name,\n                COALESCE(NULLIF(COALESCE(a.line_name_k, lin.line_name_k), ''), NULL) AS line_name_k,\n                COALESCE(NULLIF(COALESCE(a.line_name_h, lin.line_name_h), ''), NULL) AS line_name_h,\n                COALESCE(NULLIF(COALESCE(a.line_name_r, lin.line_name_r), ''), NULL) AS line_name_r,\n                COALESCE(NULLIF(COALESCE(a.line_name_zh, lin.line_name_zh), ''), NULL) AS line_name_zh,\n                COALESCE(NULLIF(COALESCE(a.line_name_ko, lin.line_name_ko), ''), NULL) AS line_name_ko,\n                COALESCE(NULLIF(COALESCE(a.line_color_c, lin.line_color_c), ''), NULL) AS line_color_c,\n                lin.line_type,\n                lin.line_symbol1,\n                lin.line_symbol2,\n                lin.line_symbol3,\n                lin.line_symbol4,\n                lin.line_symbol1_color,\n                lin.line_symbol2_color,\n                lin.line_symbol3_color,\n                lin.line_symbol4_color,\n                lin.line_symbol1_shape,\n                lin.line_symbol2_shape,\n                lin.line_symbol3_shape,\n                lin.line_symbol4_shape,\n                COALESCE(lin.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n                tt.id AS type_id,\n                sst.id AS sst_id,\n                sst.type_cd,\n                sst.line_group_cd,\n                sst.pass,\n                tt.type_name,\n                tt.type_name_k,\n                tt.type_name_r,\n                tt.type_name_zh,\n                tt.type_name_ko,\n                tt.color,\n                tt.direction,\n                tt.kind\n            FROM\n                stations AS sta\n                LEFT JOIN sst_cte AS sst ON sst.station_cd = sta.station_cd\n                JOIN types AS tt ON tt.type_cd = sst.type_cd\n                JOIN lines AS lin ON lin.line_cd = sta.line_cd AND lin.e_status = 0\n                LEFT JOIN line_aliases AS la ON la.station_cd = sta.station_cd\n                LEFT JOIN aliases AS a ON a.id = la.alias_cd\n            WHERE\n                sta.e_status = 0\n            ORDER BY sst.id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "station_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "station_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "station_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "station_name_rn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "station_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "station_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "station_number1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_number2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "station_number3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "station_number4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "three_letter_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "pref_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "post",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "lon",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "lat",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 19,
+        "name": "open_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "close_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 30,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 31,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 32,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 33,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 34,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 35,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 36,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 37,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 38,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 39,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 40,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 41,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 42,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 43,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 44,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 45,
+        "name": "type_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 46,
+        "name": "sst_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 47,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 48,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 49,
+        "name": "pass",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 50,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 51,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 52,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 53,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 54,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 55,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 56,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 57,
+        "name": "kind",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "217b99932d995eff26a2eb16abab5dd05c27b6b77f78f169ca2049f45cf432ce"
+}

--- a/.sqlx/query-3ec853ec90f7ed1b17658087c6b57da19ad084925a8cfc39d91297548ae25f8c.json
+++ b/.sqlx/query-3ec853ec90f7ed1b17658087c6b57da19ad084925a8cfc39d91297548ae25f8c.json
@@ -1,0 +1,190 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT \n            l.line_cd,\n            l.company_cd,\n            l.line_type,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            l.e_status,\n            l.e_sort,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            s.station_cd,\n            s.station_g_cd,\n            sst.line_group_cd,\n            sst.type_cd,\n            l.line_name,\n            l.line_name_k,\n            l.line_name_h,\n            l.line_name_r,\n            l.line_name_zh,\n            l.line_name_ko,\n            l.line_color_c\n        FROM lines AS l\n            JOIN station_station_types AS sst ON sst.line_group_cd = $1 AND sst.pass <> 1\n            JOIN stations AS s ON s.station_cd = sst.station_cd\n            AND s.e_status = 0\n            AND l.line_cd = s.line_cd\n            LEFT JOIN line_aliases AS la ON la.station_cd = s.station_cd\n            LEFT JOIN aliases AS a ON la.alias_cd = a.id\n        WHERE l.e_status = 0",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 17,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 19,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 20,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 21,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 23,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_color_c",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      null,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "3ec853ec90f7ed1b17658087c6b57da19ad084925a8cfc39d91297548ae25f8c"
+}

--- a/.sqlx/query-4c514298af7222e5c7085857d72370a5eab2f9ac56bb450e0d2303807abfb849.json
+++ b/.sqlx/query-4c514298af7222e5c7085857d72370a5eab2f9ac56bb450e0d2303807abfb849.json
@@ -1,0 +1,364 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT s.station_cd,\n            s.station_g_cd,\n            s.station_name,\n            s.station_name_k,\n            s.station_name_r,\n            s.station_name_rn,\n            s.station_name_zh,\n            s.station_name_ko,\n            s.station_number1,\n            s.station_number2,\n            s.station_number3,\n            s.station_number4,\n            s.three_letter_code,\n            s.line_cd,\n            s.pref_cd,\n            s.post,\n            s.address,\n            s.lon,\n            s.lat,\n            s.open_ymd,\n            s.close_ymd,\n            s.e_status,\n            s.e_sort,\n            l.company_cd,\n            COALESCE(NULLIF(COALESCE(a.line_name, l.line_name), ''), NULL) AS line_name,\n            COALESCE(NULLIF(COALESCE(a.line_name_k, l.line_name_k), ''), NULL) AS line_name_k,\n            COALESCE(NULLIF(COALESCE(a.line_name_h, l.line_name_h), ''), NULL) AS line_name_h,\n            COALESCE(NULLIF(COALESCE(a.line_name_r, l.line_name_r), ''), NULL) AS line_name_r,\n            COALESCE(NULLIF(COALESCE(a.line_name_zh, l.line_name_zh), ''), NULL) AS line_name_zh,\n            COALESCE(NULLIF(COALESCE(a.line_name_ko, l.line_name_ko), ''), NULL) AS line_name_ko,\n            COALESCE(NULLIF(COALESCE(a.line_color_c, l.line_color_c), ''), NULL) AS line_color_c,\n            l.line_type,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            t.id AS type_id,\n            sst.id AS sst_id,\n            sst.type_cd,\n            sst.line_group_cd,\n            sst.pass,\n            t.type_name,\n            t.type_name_k,\n            t.type_name_r,\n            t.type_name_zh,\n            t.type_name_ko,\n            t.color,\n            t.direction,\n            t.kind\n          FROM stations AS s\n          JOIN lines AS l ON l.line_cd = s.line_cd\n          LEFT JOIN station_station_types AS sst ON sst.station_cd = s.station_cd\n          LEFT JOIN types AS t ON t.type_cd = sst.type_cd\n          LEFT JOIN line_aliases AS la ON la.station_cd = s.station_cd\n          LEFT JOIN aliases AS a ON a.id = la.alias_cd\n          WHERE s.station_cd = $1\n            AND s.e_status = 0\n            AND l.e_status = 0\n          LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "station_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "station_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "station_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "station_name_rn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "station_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "station_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "station_number1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_number2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "station_number3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "station_number4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "three_letter_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "pref_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "post",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "lon",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "lat",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 19,
+        "name": "open_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "close_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 30,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 31,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 32,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 33,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 34,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 35,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 36,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 37,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 38,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 39,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 40,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 41,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 42,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 43,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 44,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 45,
+        "name": "type_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 46,
+        "name": "sst_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 47,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 48,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 49,
+        "name": "pass",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 50,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 51,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 52,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 53,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 54,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 55,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 56,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 57,
+        "name": "kind",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "4c514298af7222e5c7085857d72370a5eab2f9ac56bb450e0d2303807abfb849"
+}

--- a/.sqlx/query-55bee6b45754d1da9bf555d319f015ce232f8574a41c3ef25b730d11071f8428.json
+++ b/.sqlx/query-55bee6b45754d1da9bf555d319f015ce232f8574a41c3ef25b730d11071f8428.json
@@ -1,0 +1,94 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n            t.type_name,\n            t.type_name_k,\n            t.type_name_r,\n            t.type_name_zh,\n            t.type_name_ko,\n            t.color,\n            t.direction,\n            t.kind,\n            sst.id,\n            sst.station_cd,\n            sst.type_cd,\n            sst.line_group_cd,\n            sst.pass\n            FROM types as t\n            JOIN station_station_types AS sst ON sst.line_group_cd = $1\n            WHERE \n                t.type_cd = sst.type_cd\n            ORDER BY t.kind, sst.id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "kind",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 12,
+        "name": "pass",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "55bee6b45754d1da9bf555d319f015ce232f8574a41c3ef25b730d11071f8428"
+}

--- a/.sqlx/query-587f17667fd03f8f3007ef9e754a168a2a09d30a408f98fdbd6f2b1fa4562a8c.json
+++ b/.sqlx/query-587f17667fd03f8f3007ef9e754a168a2a09d30a408f98fdbd6f2b1fa4562a8c.json
@@ -1,0 +1,364 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT \n              s.station_cd,\n              s.station_g_cd,\n              s.station_name,\n              s.station_name_k,\n              s.station_name_r,\n              s.station_name_rn,\n              s.station_name_zh,\n              s.station_name_ko,\n              s.station_number1,\n              s.station_number2,\n              s.station_number3,\n              s.station_number4,\n              s.three_letter_code,\n              s.line_cd,\n              s.pref_cd,\n              s.post,\n              s.address,\n              s.lon,\n              s.lat,\n              s.open_ymd,\n              s.close_ymd,\n              s.e_status,\n              s.e_sort,\n              l.company_cd,\n              COALESCE(NULLIF(COALESCE(a.line_name, l.line_name), ''), NULL) AS line_name,\n              COALESCE(NULLIF(COALESCE(a.line_name_k, l.line_name_k), ''), NULL) AS line_name_k,\n              COALESCE(NULLIF(COALESCE(a.line_name_h, l.line_name_h), ''), NULL) AS line_name_h,\n              COALESCE(NULLIF(COALESCE(a.line_name_r, l.line_name_r), ''), NULL) AS line_name_r,\n              COALESCE(NULLIF(COALESCE(a.line_name_zh, l.line_name_zh), ''), NULL) AS line_name_zh,\n              COALESCE(NULLIF(COALESCE(a.line_name_ko, l.line_name_ko), ''), NULL) AS line_name_ko,\n              COALESCE(NULLIF(COALESCE(a.line_color_c, l.line_color_c), ''), NULL) AS line_color_c,\n              l.line_type,\n              l.line_symbol1,\n              l.line_symbol2,\n              l.line_symbol3,\n              l.line_symbol4,\n              l.line_symbol1_color,\n              l.line_symbol2_color,\n              l.line_symbol3_color,\n              l.line_symbol4_color,\n              l.line_symbol1_shape,\n              l.line_symbol2_shape,\n              l.line_symbol3_shape,\n              l.line_symbol4_shape,\n              COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n              NULL::int AS type_id,\n              NULL::int AS sst_id,\n              NULL::int AS type_cd,\n              NULL::int AS line_group_cd,\n              NULL::int AS pass,\n              NULL::text AS type_name,\n              NULL::text AS type_name_k,\n              NULL::text AS type_name_r,\n              NULL::text AS type_name_zh,\n              NULL::text AS type_name_ko,\n              NULL::text AS color,\n              NULL::int AS direction,\n              NULL::int AS kind\n              FROM stations AS s\n              JOIN lines AS l ON l.line_cd = s.line_cd\n              LEFT JOIN line_aliases AS la ON la.station_cd = s.station_cd\n              LEFT JOIN aliases AS a ON a.id = la.alias_cd\n            WHERE l.line_cd = $1\n              AND s.e_status = 0\n              AND l.e_status = 0\n            ORDER BY s.e_sort, s.station_cd ASC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "station_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "station_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "station_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "station_name_rn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "station_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "station_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "station_number1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_number2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "station_number3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "station_number4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "three_letter_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "pref_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "post",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "lon",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "lat",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 19,
+        "name": "open_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "close_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 30,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 31,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 32,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 33,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 34,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 35,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 36,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 37,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 38,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 39,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 40,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 41,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 42,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 43,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 44,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 45,
+        "name": "type_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 46,
+        "name": "sst_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 47,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 48,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 49,
+        "name": "pass",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 50,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 51,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 52,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 53,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 54,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 55,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 56,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 57,
+        "name": "kind",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "587f17667fd03f8f3007ef9e754a168a2a09d30a408f98fdbd6f2b1fa4562a8c"
+}

--- a/.sqlx/query-58899fb950e311e87a33db5142b914a376a60c6cd2650c3723fbdde78beaff12.json
+++ b/.sqlx/query-58899fb950e311e87a33db5142b914a376a60c6cd2650c3723fbdde78beaff12.json
@@ -1,0 +1,367 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH\n                from_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $1\n                ),\n                to_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $2\n                ),\n                common_lines AS (\n                    SELECT DISTINCT s1.line_cd\n                    FROM stations s1\n                    WHERE s1.station_g_cd = $3\n                        AND s1.e_status = 0\n                        AND EXISTS (\n                        SELECT 1\n                        FROM stations s2\n                        WHERE s2.station_g_cd = $4\n                            AND s2.e_status = 0\n                            AND s2.line_cd = s1.line_cd\n                        )\n                ),\n                sst_cte_c1 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN from_cte ON sst.station_cd = from_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte_c2 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN to_cte ON sst.station_cd = to_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte AS (\n                    SELECT\n                        sst.id,\n                        sst.station_cd,\n                        sst.type_cd,\n                        sst.line_group_cd,\n                        sst.pass\n                    FROM\n                        station_station_types AS sst\n                        JOIN sst_cte_c1 ON sst.line_group_cd = sst_cte_c1.line_group_cd\n                        JOIN sst_cte_c2 ON sst.line_group_cd = sst_cte_c2.line_group_cd\n                )\n            SELECT\n            sta.station_cd,\n            sta.station_g_cd,\n            sta.station_name,\n            sta.station_name_k,\n            sta.station_name_r,\n            sta.station_name_rn,\n            sta.station_name_zh,\n            sta.station_name_ko,\n            sta.station_number1,\n            sta.station_number2,\n            sta.station_number3,\n            sta.station_number4,\n            sta.three_letter_code,\n            sta.line_cd,\n            sta.pref_cd,\n            sta.post,\n            sta.address,\n            sta.lon,\n            sta.lat,\n            sta.open_ymd,\n            sta.close_ymd,\n            sta.e_status,\n            sta.e_sort,\n            lin.company_cd,\n            COALESCE(NULLIF(COALESCE(a.line_name, lin.line_name), ''), NULL) AS line_name,\n            COALESCE(NULLIF(COALESCE(a.line_name_k, lin.line_name_k), ''), NULL) AS line_name_k,\n            COALESCE(NULLIF(COALESCE(a.line_name_h, lin.line_name_h), ''), NULL) AS line_name_h,\n            COALESCE(NULLIF(COALESCE(a.line_name_r, lin.line_name_r), ''), NULL) AS line_name_r,\n            COALESCE(NULLIF(COALESCE(a.line_name_zh, lin.line_name_zh), ''), NULL) AS line_name_zh,\n            COALESCE(NULLIF(COALESCE(a.line_name_ko, lin.line_name_ko), ''), NULL) AS line_name_ko,\n            COALESCE(NULLIF(COALESCE(a.line_color_c, lin.line_color_c), ''), NULL) AS line_color_c,\n            lin.line_type,\n            lin.line_symbol1,\n            lin.line_symbol2,\n            lin.line_symbol3,\n            lin.line_symbol4,\n            lin.line_symbol1_color,\n            lin.line_symbol2_color,\n            lin.line_symbol3_color,\n            lin.line_symbol4_color,\n            lin.line_symbol1_shape,\n            lin.line_symbol2_shape,\n            lin.line_symbol3_shape,\n            lin.line_symbol4_shape,\n            COALESCE(lin.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            NULL::int AS type_id,\n            NULL::int AS sst_id,\n            NULL::int AS type_cd,\n            NULL::int AS line_group_cd,\n            NULL::int AS pass,\n            NULL::text AS type_name,\n            NULL::text AS type_name_k,\n            NULL::text AS type_name_r,\n            NULL::text AS type_name_zh,\n            NULL::text AS type_name_ko,\n            NULL::text AS color,\n            NULL::int AS direction,\n            NULL::int AS kind\n            FROM\n                stations AS sta\n\t\t\t\tJOIN common_lines AS cl ON sta.line_cd = cl.line_cd\n\t\t\t\tJOIN lines AS lin ON lin.line_cd = cl.line_cd\n                LEFT JOIN sst_cte AS sst ON sst.station_cd = sta.station_cd\n                LEFT JOIN types AS tt ON tt.type_cd = sst.type_cd\n                LEFT JOIN line_aliases AS la ON la.station_cd = sta.station_cd\n                LEFT JOIN aliases AS a ON a.id = la.alias_cd\n            WHERE\n                sst.line_group_cd IS NULL\n                AND lin.e_status = 0\n                AND sta.e_status = 0\n                ORDER BY sta.e_sort, sta.station_cd",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "station_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "station_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "station_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "station_name_rn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "station_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "station_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "station_number1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_number2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "station_number3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "station_number4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "three_letter_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "pref_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "post",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "lon",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "lat",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 19,
+        "name": "open_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "close_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 30,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 31,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 32,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 33,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 34,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 35,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 36,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 37,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 38,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 39,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 40,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 41,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 42,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 43,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 44,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 45,
+        "name": "type_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 46,
+        "name": "sst_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 47,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 48,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 49,
+        "name": "pass",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 50,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 51,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 52,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 53,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 54,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 55,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 56,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 57,
+        "name": "kind",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "58899fb950e311e87a33db5142b914a376a60c6cd2650c3723fbdde78beaff12"
+}

--- a/.sqlx/query-5f3a17f24bd4844e46b57d4920a3261ff87dfa6557926fb1b680d96c42ed56d4.json
+++ b/.sqlx/query-5f3a17f24bd4844e46b57d4920a3261ff87dfa6557926fb1b680d96c42ed56d4.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(sst.line_group_cd)::integer AS train_types_count\n            FROM station_station_types AS sst\n                JOIN types AS t ON t.type_cd = sst.type_cd\n            WHERE sst.station_cd = $1\n                AND (\n                    t.kind IN (0, 1)\n                    OR t.priority > 0\n                )",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "train_types_count",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "5f3a17f24bd4844e46b57d4920a3261ff87dfa6557926fb1b680d96c42ed56d4"
+}

--- a/.sqlx/query-648214ea287859e20e4788c48dff2af34f7c31069f036e3a3cfa407f31a9fee5.json
+++ b/.sqlx/query-648214ea287859e20e4788c48dff2af34f7c31069f036e3a3cfa407f31a9fee5.json
@@ -1,0 +1,364 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT s.station_cd,\n            s.station_g_cd,\n            s.station_name,\n            s.station_name_k,\n            s.station_name_r,\n            s.station_name_rn,\n            s.station_name_zh,\n            s.station_name_ko,\n            s.station_number1,\n            s.station_number2,\n            s.station_number3,\n            s.station_number4,\n            s.three_letter_code,\n            s.line_cd,\n            s.pref_cd,\n            s.post,\n            s.address,\n            s.lon,\n            s.lat,\n            s.open_ymd,\n            s.close_ymd,\n            s.e_status,\n            s.e_sort,\n            l.company_cd,\n            l.line_type,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            COALESCE(NULLIF(COALESCE(a.line_name, l.line_name), ''), NULL) AS line_name,\n            COALESCE(NULLIF(COALESCE(a.line_name_k, l.line_name_k), ''), NULL) AS line_name_k,\n            COALESCE(NULLIF(COALESCE(a.line_name_h, l.line_name_h), ''), NULL) AS line_name_h,\n            COALESCE(NULLIF(COALESCE(a.line_name_r, l.line_name_r), ''), NULL) AS line_name_r,\n            COALESCE(NULLIF(COALESCE(a.line_name_zh, l.line_name_zh), ''), NULL) AS line_name_zh,\n            COALESCE(NULLIF(COALESCE(a.line_name_ko, l.line_name_ko), ''), NULL) AS line_name_ko,\n            COALESCE(NULLIF(COALESCE(a.line_color_c, l.line_color_c), ''), NULL) AS line_color_c,\n            sst.id AS sst_id,\n            sst.type_cd,\n            sst.line_group_cd,\n            sst.pass,\n            t.id AS type_id,\n            t.type_name,\n            t.type_name_k,\n            t.type_name_r,\n            t.type_name_zh,\n            t.type_name_ko,\n            t.color,\n            t.direction,\n            t.kind\n          FROM\n            stations AS s\n            JOIN lines AS l ON l.line_cd = s.line_cd\n            LEFT JOIN station_station_types AS sst ON sst.station_cd = s.station_cd\n            LEFT JOIN types AS t ON t.type_cd = sst.type_cd\n            LEFT JOIN line_aliases AS la ON la.station_cd = s.station_cd\n            LEFT JOIN aliases AS a ON a.id = la.alias_cd\n          WHERE\n            s.station_g_cd = $1\n            AND s.line_cd = l.line_cd\n            AND s.e_status = 0\n            AND l.e_status = 0",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "station_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "station_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "station_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "station_name_rn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "station_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "station_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "station_number1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_number2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "station_number3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "station_number4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "three_letter_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "pref_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "post",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "lon",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "lat",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 19,
+        "name": "open_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "close_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 30,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 31,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 32,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 33,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 34,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 35,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 36,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 37,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 38,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 39,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 40,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 41,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 42,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 43,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 44,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 45,
+        "name": "sst_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 46,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 47,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 48,
+        "name": "pass",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 49,
+        "name": "type_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 50,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 51,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 52,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 53,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 54,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 55,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 56,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 57,
+        "name": "kind",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "648214ea287859e20e4788c48dff2af34f7c31069f036e3a3cfa407f31a9fee5"
+}

--- a/.sqlx/query-6711dff69e3c8d999743db687be404ee34f4b081e2662661873c44b6e3be1c43.json
+++ b/.sqlx/query-6711dff69e3c8d999743db687be404ee34f4b081e2662661873c44b6e3be1c43.json
@@ -1,0 +1,364 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n            s.station_cd,\n            s.station_g_cd,\n            s.station_name,\n            s.station_name_k,\n            s.station_name_r,\n            s.station_name_rn,\n            s.station_name_zh,\n            s.station_name_ko,\n            s.station_number1,\n            s.station_number2,\n            s.station_number3,\n            s.station_number4,\n            s.three_letter_code,\n            s.line_cd,\n            s.pref_cd,\n            s.post,\n            s.address,\n            s.lon,\n            s.lat,\n            s.open_ymd,\n            s.close_ymd,\n            s.e_status,\n            s.e_sort,\n            COALESCE(NULLIF(COALESCE(a.line_name, l.line_name), ''), NULL) AS line_name,\n            COALESCE(NULLIF(COALESCE(a.line_name_k, l.line_name_k), ''), NULL) AS line_name_k,\n            COALESCE(NULLIF(COALESCE(a.line_name_h, l.line_name_h), ''), NULL) AS line_name_h,\n            COALESCE(NULLIF(COALESCE(a.line_name_r, l.line_name_r), ''), NULL) AS line_name_r,\n            COALESCE(NULLIF(COALESCE(a.line_name_zh, l.line_name_zh), ''), NULL) AS line_name_zh,\n            COALESCE(NULLIF(COALESCE(a.line_name_ko, l.line_name_ko), ''), NULL) AS line_name_ko,\n            COALESCE(NULLIF(COALESCE(a.line_color_c, l.line_color_c), ''), NULL) AS line_color_c,\n            l.company_cd,\n            l.line_type,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            sst.id AS sst_id,\n            sst.type_cd,\n            sst.line_group_cd,\n            sst.pass,\n            t.id AS type_id,\n            t.type_name,\n            t.type_name_k,\n            t.type_name_r,\n            t.type_name_zh,\n            t.type_name_ko,\n            t.color,\n            t.direction,\n            t.kind\n          FROM stations AS s\n          JOIN lines AS l ON l.line_cd = s.line_cd AND l.e_status = 0\n          LEFT JOIN station_station_types AS sst ON sst.line_group_cd = $1\n          LEFT JOIN types AS t ON t.type_cd = sst.type_cd\n          LEFT JOIN line_aliases AS la ON la.station_cd = s.station_cd\n          LEFT JOIN aliases AS a ON a.id = la.alias_cd\n          WHERE\n            s.line_cd = l.line_cd\n            AND s.station_cd = sst.station_cd\n            AND s.e_status = 0\n          ORDER BY sst.id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "station_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "station_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "station_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "station_name_rn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "station_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "station_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "station_number1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_number2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "station_number3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "station_number4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "three_letter_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "pref_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "post",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "lon",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "lat",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 19,
+        "name": "open_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "close_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 30,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 31,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 32,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 33,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 34,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 35,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 36,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 37,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 38,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 39,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 40,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 41,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 42,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 43,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 44,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 45,
+        "name": "sst_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 46,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 47,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 48,
+        "name": "pass",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 49,
+        "name": "type_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 50,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 51,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 52,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 53,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 54,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 55,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 56,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 57,
+        "name": "kind",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "6711dff69e3c8d999743db687be404ee34f4b081e2662661873c44b6e3be1c43"
+}

--- a/.sqlx/query-7428cc69d3756a749121a1ad5eee1603aa5e7ee3fc30071a142f9a15502da031.json
+++ b/.sqlx/query-7428cc69d3756a749121a1ad5eee1603aa5e7ee3fc30071a142f9a15502da031.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(stations.station_cd) <> 0 AS alive FROM stations",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "alive",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "7428cc69d3756a749121a1ad5eee1603aa5e7ee3fc30071a142f9a15502da031"
+}

--- a/.sqlx/query-7a7492b76cb13f18b36cc3b488c0b3448c8ca29cbdb5e6f2390d2b22b886f81e.json
+++ b/.sqlx/query-7a7492b76cb13f18b36cc3b488c0b3448c8ca29cbdb5e6f2390d2b22b886f81e.json
@@ -1,0 +1,190 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT DISTINCT l.line_cd,\n            l.line_name,\n            l.line_name_k,\n            l.line_name_h,\n            l.line_name_r,\n            l.line_name_zh,\n            l.line_name_ko,\n            l.line_color_c,\n            l.company_cd,\n            l.line_type,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            l.e_status,\n            l.e_sort,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            sst.line_group_cd,\n            sst.type_cd,\n            s.station_cd,\n            s.station_g_cd\n        FROM lines AS l\n        JOIN stations AS s ON s.station_g_cd = $1\n            AND s.e_status = 0\n        JOIN station_station_types AS sst ON sst.station_cd = s.station_cd AND sst.pass <> 1\n        WHERE l.line_cd = s.line_cd\n            AND l.e_status = 0",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 18,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 19,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 26,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 27,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 28,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      null,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7a7492b76cb13f18b36cc3b488c0b3448c8ca29cbdb5e6f2390d2b22b886f81e"
+}

--- a/.sqlx/query-85c490dd8992db5950dfd6c141b02048f361c5e9ac82cb7503fd8e75266cc06f.json
+++ b/.sqlx/query-85c490dd8992db5950dfd6c141b02048f361c5e9ac82cb7503fd8e75266cc06f.json
@@ -1,0 +1,190 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT \n            l.line_cd,\n            l.company_cd,\n            l.line_type,\n            l.line_name,\n            l.line_name_k,\n            l.line_name_h,\n            l.line_name_r,\n            l.line_name_zh,\n            l.line_name_ko,\n            l.line_color_c,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            l.e_status,\n            l.e_sort,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            CAST(NULL AS INTEGER) AS line_group_cd,\n            CAST(NULL AS INTEGER) AS station_cd,\n            CAST(NULL AS INTEGER) AS station_g_cd,\n            CAST(NULL AS INTEGER) AS type_cd\n            FROM lines AS l\n            WHERE l.line_cd = $1\n            AND l.e_status = 0",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 18,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 19,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 26,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 27,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 28,
+        "name": "type_cd",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "85c490dd8992db5950dfd6c141b02048f361c5e9ac82cb7503fd8e75266cc06f"
+}

--- a/.sqlx/query-8fd35acd42a42b730854a2f1b9ffa0fd2f8384b457e7945d4070d976ecd9594f.json
+++ b/.sqlx/query-8fd35acd42a42b730854a2f1b9ffa0fd2f8384b457e7945d4070d976ecd9594f.json
@@ -1,0 +1,94 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n            t.type_name,\n            t.type_name_k,\n            t.type_name_r,\n            t.type_name_zh,\n            t.type_name_ko,\n            t.color,\n            t.direction,\n            t.kind,\n            sst.id,\n            sst.station_cd,\n            sst.type_cd,\n            sst.line_group_cd,\n            sst.pass\n            FROM  types AS t\n            JOIN stations AS s ON s.station_cd = $1 AND s.e_status = 0\n            JOIN station_station_types AS sst ON sst.station_cd = s.station_cd AND sst.type_cd = t.type_cd AND sst.pass <> 1\n            ORDER BY sst.id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "kind",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 12,
+        "name": "pass",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "8fd35acd42a42b730854a2f1b9ffa0fd2f8384b457e7945d4070d976ecd9594f"
+}

--- a/.sqlx/query-b4769060ba658a2746a186f46d4ca4f0f690fe2fd7521ee8645193b364b6896a.json
+++ b/.sqlx/query-b4769060ba658a2746a186f46d4ca4f0f690fe2fd7521ee8645193b364b6896a.json
@@ -1,0 +1,364 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH target_line_group AS (\n                            SELECT sst_inner.line_group_cd\n                            FROM station_station_types AS sst_inner\n                              LEFT JOIN types AS t_inner ON sst_inner.type_cd = t_inner.type_cd\n                            WHERE sst_inner.station_cd = $1\n                            AND (\n                                (t_inner.priority > 0 AND sst_inner.pass <> 1 AND sst_inner.type_cd = t_inner.type_cd)\n                                OR (NOT (t_inner.priority > 0 AND sst_inner.pass <> 1) AND t_inner.kind IN (0,1))\n                              )\n                            ORDER BY t_inner.priority DESC\n                            LIMIT 1\n                          )\n                          SELECT s.station_cd,\n                          s.station_g_cd,\n                          s.station_name,\n                          s.station_name_k,\n                          s.station_name_r,\n                          s.station_name_rn,\n                          s.station_name_zh,\n                          s.station_name_ko,\n                          s.station_number1,\n                          s.station_number2,\n                          s.station_number3,\n                          s.station_number4,\n                          s.three_letter_code,\n                          s.line_cd,\n                          s.pref_cd,\n                          s.post,\n                          s.address,\n                          s.lon,\n                          s.lat,\n                          s.open_ymd,\n                          s.close_ymd,\n                          s.e_status,\n                          s.e_sort,\n                          l.company_cd,\n                          l.line_type,\n                          l.line_symbol1,\n                          l.line_symbol2,\n                          l.line_symbol3,\n                          l.line_symbol4,\n                          l.line_symbol1_color,\n                          l.line_symbol2_color,\n                          l.line_symbol3_color,\n                          l.line_symbol4_color,\n                          l.line_symbol1_shape,\n                          l.line_symbol2_shape,\n                          l.line_symbol3_shape,\n                          l.line_symbol4_shape,\n                          COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n                          COALESCE(NULLIF(COALESCE(a.line_name, l.line_name), ''), NULL) AS line_name,\n                          COALESCE(NULLIF(COALESCE(a.line_name_k, l.line_name_k), ''), NULL) AS line_name_k,\n                          COALESCE(NULLIF(COALESCE(a.line_name_h, l.line_name_h), ''), NULL) AS line_name_h,\n                          COALESCE(NULLIF(COALESCE(a.line_name_r, l.line_name_r), ''), NULL) AS line_name_r,\n                          COALESCE(NULLIF(COALESCE(a.line_name_zh, l.line_name_zh), ''), NULL) AS line_name_zh,\n                          COALESCE(NULLIF(COALESCE(a.line_name_ko, l.line_name_ko), ''), NULL) AS line_name_ko,\n                          COALESCE(NULLIF(COALESCE(a.line_color_c, l.line_color_c), ''), NULL) AS line_color_c,\n                          t.id AS type_id,\n                          t.type_cd,\n                          t.color,\n                          t.type_name,\n                          t.type_name_k,\n                          t.type_name_r,\n                          t.type_name_zh,\n                          t.type_name_ko,\n                          t.direction,\n                          t.kind,\n                          sst.id AS sst_id,\n                          sst.line_group_cd,\n                          sst.pass\n                          FROM stations AS s\n                          JOIN station_station_types AS sst ON sst.line_group_cd = (SELECT line_group_cd FROM target_line_group) AND sst.station_cd = s.station_cd\n                          JOIN types AS t ON t.type_cd = sst.type_cd\n                          JOIN lines AS l ON l.line_cd = s.line_cd\n                          LEFT JOIN line_aliases AS la ON la.station_cd = s.station_cd\n                          LEFT JOIN aliases AS a ON a.id = la.alias_cd\n                          WHERE s.e_status = 0\n                            AND l.e_status = 0\n                          ORDER BY sst.id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "station_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "station_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "station_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "station_name_rn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "station_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "station_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "station_number1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_number2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "station_number3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "station_number4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "three_letter_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "pref_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "post",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "lon",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "lat",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 19,
+        "name": "open_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "close_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 30,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 31,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 32,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 33,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 34,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 35,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 36,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 37,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 38,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 39,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 40,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 41,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 42,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 43,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 44,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 45,
+        "name": "type_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 46,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 47,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 48,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 49,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 50,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 51,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 52,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 53,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 54,
+        "name": "kind",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 55,
+        "name": "sst_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 56,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 57,
+        "name": "pass",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "b4769060ba658a2746a186f46d4ca4f0f690fe2fd7521ee8645193b364b6896a"
+}

--- a/.sqlx/query-e19a25a597098f5d6c5f83992e6eb3a916d2256e346b93c1ad31cc26f9a705a2.json
+++ b/.sqlx/query-e19a25a597098f5d6c5f83992e6eb3a916d2256e346b93c1ad31cc26f9a705a2.json
@@ -1,0 +1,370 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH from_stations AS (\n                SELECT\n                    s.station_cd,\n                    s.line_cd\n                FROM stations AS s\n                WHERE s.station_g_cd = $1\n                AND s.e_status = 0\n            )\n            SELECT\n                s.station_cd,\n                s.station_g_cd,\n                s.station_name,\n                s.station_name_k,\n                s.station_name_r,\n                s.station_name_rn,\n                s.station_name_zh,\n                s.station_name_ko,\n                s.station_number1,\n                s.station_number2,\n                s.station_number3,\n                s.station_number4,\n                s.three_letter_code,\n                s.line_cd,\n                s.pref_cd,\n                s.post,\n                s.address,\n                s.lon,\n                s.lat,\n                s.open_ymd,\n                s.close_ymd,\n                s.e_status,\n                s.e_sort,\n                l.company_cd,\n                COALESCE(NULLIF(COALESCE(a.line_name, l.line_name), ''), NULL) AS line_name,\n                COALESCE(NULLIF(COALESCE(a.line_name_k, l.line_name_k), ''), NULL) AS line_name_k,\n                COALESCE(NULLIF(COALESCE(a.line_name_h, l.line_name_h), ''), NULL) AS line_name_h,\n                COALESCE(NULLIF(COALESCE(a.line_name_r, l.line_name_r), ''), NULL) AS line_name_r,\n                COALESCE(NULLIF(COALESCE(a.line_name_zh, l.line_name_zh), ''), NULL) AS line_name_zh,\n                COALESCE(NULLIF(COALESCE(a.line_name_ko, l.line_name_ko), ''), NULL) AS line_name_ko,\n                COALESCE(NULLIF(COALESCE(a.line_color_c, l.line_color_c), ''), NULL) AS line_color_c,\n                l.line_type,\n                l.line_symbol1,\n                l.line_symbol2,\n                l.line_symbol3,\n                l.line_symbol4,\n                l.line_symbol1_color,\n                l.line_symbol2_color,\n                l.line_symbol3_color,\n                l.line_symbol4_color,\n                l.line_symbol1_shape,\n                l.line_symbol2_shape,\n                l.line_symbol3_shape,\n                l.line_symbol4_shape,\n                COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n                NULL::int AS type_id,\n                NULL::int AS sst_id,\n                NULL::int AS type_cd,\n                NULL::int AS line_group_cd,\n                NULL::int AS pass,\n                NULL::text AS type_name,\n                NULL::text AS type_name_k,\n                NULL::text AS type_name_r,\n                NULL::text AS type_name_zh,\n                NULL::text AS type_name_ko,\n                NULL::text AS color,\n                NULL::int AS direction,\n                NULL::int AS kind\n            FROM stations AS s\n                LEFT JOIN from_stations AS fs\n                    ON fs.station_cd IS NOT NULL\n                LEFT JOIN station_station_types AS from_sst\n                    ON from_sst.station_cd = fs.station_cd\n                LEFT JOIN station_station_types AS dst_sst\n                    ON dst_sst.station_cd = s.station_cd\n                LEFT JOIN types AS t\n                    ON t.type_cd = dst_sst.type_cd\n                LEFT JOIN line_aliases AS la\n                    ON la.station_cd = s.station_cd\n                LEFT JOIN aliases AS a\n                    ON la.alias_cd = a.id\n                JOIN lines AS l\n                    ON l.line_cd = s.line_cd\n                    AND l.e_status = 0\n            WHERE\n                (\n                    s.station_name   LIKE $2\n                    OR s.station_name_rn LIKE $3\n                    OR s.station_name_k LIKE $4\n                    OR s.station_name_zh LIKE $5\n                    OR s.station_name_ko LIKE $6\n                )\n                AND s.e_status = 0\n                AND (\n                    (\n                        from_sst.id IS NOT NULL\n                        AND dst_sst.id IS NOT NULL\n                        AND from_sst.line_group_cd = dst_sst.line_group_cd\n                        AND dst_sst.pass <> 1\n                    )\n                    OR\n                    (\n                        (from_sst.id IS NULL OR dst_sst.id IS NULL)\n                        AND s.line_cd = COALESCE(fs.line_cd, s.line_cd)\n                    )\n                )\n            ORDER BY s.station_g_cd, s.station_name\n            LIMIT $7",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "station_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "station_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "station_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "station_name_rn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "station_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "station_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "station_number1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_number2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "station_number3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "station_number4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "three_letter_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "pref_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "post",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "lon",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "lat",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 19,
+        "name": "open_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "close_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 30,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 31,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 32,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 33,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 34,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 35,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 36,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 37,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 38,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 39,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 40,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 41,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 42,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 43,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 44,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 45,
+        "name": "type_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 46,
+        "name": "sst_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 47,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 48,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 49,
+        "name": "pass",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 50,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 51,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 52,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 53,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 54,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 55,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 56,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 57,
+        "name": "kind",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "e19a25a597098f5d6c5f83992e6eb3a916d2256e346b93c1ad31cc26f9a705a2"
+}

--- a/data/create_table.sql
+++ b/data/create_table.sql
@@ -190,7 +190,7 @@ ALTER TABLE public.lines OWNER TO stationapi;
 --
 
 CREATE UNLOGGED TABLE public.station_station_types (
-    id integer NOT NULL,
+    id integer,
     station_cd integer NOT NULL,
     type_cd integer NOT NULL,
     line_group_cd integer NOT NULL,


### PR DESCRIPTION
5!station_station_types.csvのid列を指定せずとも連番idが入るようにした

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 駅や路線、種別情報の詳細取得や検索に対応する複数の新しいクエリを追加しました。これにより、多言語対応やエイリアス名の取得、グループや種別による柔軟な絞り込みが可能となりました。
  * 駅や路線の存在確認、種別数のカウントなどの新しい集計クエリを追加しました。

* **データベース**
  * 駅種別情報テーブルの「id」カラムがNULLを許容するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->