### PR TITLE
get_route_stopsのvia_line_id対応

### DIFF
--- a/.sqlx/query-20b55238238b1655930a5716441ff4944d4e572e97654fc65cb425e5435d337b.json
+++ b/.sqlx/query-20b55238238b1655930a5716441ff4944d4e572e97654fc65cb425e5435d337b.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH\n                from_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $1\n                ),\n                to_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $2\n                ),\n                common_lines AS (\n                    SELECT DISTINCT s1.line_cd\n                    FROM stations s1\n                    WHERE s1.station_g_cd = $3\n                        AND s1.e_status = 0\n                        AND EXISTS (\n                        SELECT 1\n                        FROM stations s2\n                        WHERE s2.station_g_cd = $4\n                            AND s2.e_status = 0\n                            AND s2.line_cd = s1.line_cd\n                        )\n                ),\n                sst_cte_c1 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN from_cte ON sst.station_cd = from_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte_c2 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN to_cte ON sst.station_cd = to_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte AS (\n                    SELECT\n                        sst.id,\n                        sst.station_cd,\n                        sst.type_cd,\n                        sst.line_group_cd,\n                        sst.pass\n                    FROM\n                        station_station_types AS sst\n                        JOIN sst_cte_c1 ON sst.line_group_cd = sst_cte_c1.line_group_cd\n                        JOIN sst_cte_c2 ON sst.line_group_cd = sst_cte_c2.line_group_cd\n                )\n            SELECT\n            sta.station_cd,\n            sta.station_g_cd,\n            sta.station_name,\n            sta.station_name_k,\n            sta.station_name_r,\n            sta.station_name_rn,\n            sta.station_name_zh,\n            sta.station_name_ko,\n            sta.station_number1,\n            sta.station_number2,\n            sta.station_number3,\n            sta.station_number4,\n            sta.three_letter_code,\n            sta.line_cd,\n            sta.pref_cd,\n            sta.post,\n            sta.address,\n            sta.lon,\n            sta.lat,\n            sta.open_ymd,\n            sta.close_ymd,\n            sta.e_status,\n            sta.e_sort,\n            lin.company_cd,\n            COALESCE(NULLIF(COALESCE(a.line_name, lin.line_name), ''), NULL) AS line_name,\n            COALESCE(NULLIF(COALESCE(a.line_name_k, lin.line_name_k), ''), NULL) AS line_name_k,\n            COALESCE(NULLIF(COALESCE(a.line_name_h, lin.line_name_h), ''), NULL) AS line_name_h,\n            COALESCE(NULLIF(COALESCE(a.line_name_r, lin.line_name_r), ''), NULL) AS line_name_r,\n            COALESCE(NULLIF(COALESCE(a.line_name_zh, lin.line_name_zh), ''), NULL) AS line_name_zh,\n            COALESCE(NULLIF(COALESCE(a.line_name_ko, lin.line_name_ko), ''), NULL) AS line_name_ko,\n            COALESCE(NULLIF(COALESCE(a.line_color_c, lin.line_color_c), ''), NULL) AS line_color_c,\n            lin.line_type,\n            lin.line_symbol1,\n            lin.line_symbol2,\n            lin.line_symbol3,\n            lin.line_symbol4,\n            lin.line_symbol1_color,\n            lin.line_symbol2_color,\n            lin.line_symbol3_color,\n            lin.line_symbol4_color,\n            lin.line_symbol1_shape,\n            lin.line_symbol2_shape,\n            lin.line_symbol3_shape,\n            lin.line_symbol4_shape,\n            COALESCE(lin.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            COALESCE(sst.line_group_cd, NULL)::int AS line_group_cd, -- has_train_types用\n            NULL::int AS type_id,\n            NULL::int AS sst_id,\n            NULL::int AS type_cd,\n            NULL::int AS pass,\n            NULL::text AS type_name,\n            NULL::text AS type_name_k,\n            NULL::text AS type_name_r,\n            NULL::text AS type_name_zh,\n            NULL::text AS type_name_ko,\n            NULL::text AS color,\n            NULL::int AS direction,\n            NULL::int AS kind\n            FROM\n                stations AS sta\n\t\t\t\tJOIN common_lines AS cl ON sta.line_cd = cl.line_cd\n\t\t\t\tJOIN lines AS lin ON lin.line_cd = cl.line_cd\n                LEFT JOIN sst_cte AS sst ON sst.station_cd = sta.station_cd\n                LEFT JOIN types AS tt ON tt.type_cd = sst.type_cd\n                LEFT JOIN line_aliases AS la ON la.station_cd = sta.station_cd\n                LEFT JOIN aliases AS a ON a.id = la.alias_cd\n            WHERE\n                sst.line_group_cd IS NULL\n                AND lin.e_status = 0\n                AND sta.e_status = 0\n                ORDER BY sta.e_sort, sta.station_cd",
+  "query": "WITH\n                from_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $1\n                        AND s.e_status = 0\n                ),\n                to_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $2\n                        AND s.e_status = 0\n                ),\n                sst_cte_c1 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN from_cte ON sst.station_cd = from_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte_c2 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN to_cte ON sst.station_cd = to_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte AS (\n                    SELECT\n                        sst.id,\n                        sst.station_cd,\n                        sst.type_cd,\n                        sst.line_group_cd,\n                        sst.pass\n                    FROM\n                        station_station_types AS sst\n                        JOIN sst_cte_c1 ON sst.line_group_cd = sst_cte_c1.line_group_cd\n                        JOIN sst_cte_c2 ON sst.line_group_cd = sst_cte_c2.line_group_cd\n                )\n            SELECT\n                sta.station_cd,\n                sta.station_g_cd,\n                sta.station_name,\n                sta.station_name_k,\n                sta.station_name_r,\n                sta.station_name_rn,\n                sta.station_name_zh,\n                sta.station_name_ko,\n                sta.station_number1,\n                sta.station_number2,\n                sta.station_number3,\n                sta.station_number4,\n                sta.three_letter_code,\n                sta.line_cd,\n                sta.pref_cd,\n                sta.post,\n                sta.address,\n                sta.lon,\n                sta.lat,\n                sta.open_ymd,\n                sta.close_ymd,\n                sta.e_status,\n                sta.e_sort,\n                lin.company_cd,\n                COALESCE(NULLIF(COALESCE(a.line_name, lin.line_name), ''), NULL) AS line_name,\n                COALESCE(NULLIF(COALESCE(a.line_name_k, lin.line_name_k), ''), NULL) AS line_name_k,\n                COALESCE(NULLIF(COALESCE(a.line_name_h, lin.line_name_h), ''), NULL) AS line_name_h,\n                COALESCE(NULLIF(COALESCE(a.line_name_r, lin.line_name_r), ''), NULL) AS line_name_r,\n                COALESCE(NULLIF(COALESCE(a.line_name_zh, lin.line_name_zh), ''), NULL) AS line_name_zh,\n                COALESCE(NULLIF(COALESCE(a.line_name_ko, lin.line_name_ko), ''), NULL) AS line_name_ko,\n                COALESCE(NULLIF(COALESCE(a.line_color_c, lin.line_color_c), ''), NULL) AS line_color_c,\n                lin.line_type,\n                lin.line_symbol1,\n                lin.line_symbol2,\n                lin.line_symbol3,\n                lin.line_symbol4,\n                lin.line_symbol1_color,\n                lin.line_symbol2_color,\n                lin.line_symbol3_color,\n                lin.line_symbol4_color,\n                lin.line_symbol1_shape,\n                lin.line_symbol2_shape,\n                lin.line_symbol3_shape,\n                lin.line_symbol4_shape,\n                COALESCE(lin.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n                tt.id AS type_id,\n                sst.id AS sst_id,\n                sst.type_cd,\n                sst.line_group_cd,\n                sst.pass,\n                tt.type_name,\n                tt.type_name_k,\n                tt.type_name_r,\n                tt.type_name_zh,\n                tt.type_name_ko,\n                tt.color,\n                tt.direction,\n                tt.kind\n            FROM\n                stations AS sta\n                LEFT JOIN sst_cte AS sst ON sst.station_cd = sta.station_cd\n                JOIN types AS tt ON tt.type_cd = sst.type_cd\n                JOIN lines AS lin ON lin.line_cd = sta.line_cd AND lin.e_status = 0\n                LEFT JOIN line_aliases AS la ON la.station_cd = sta.station_cd\n                LEFT JOIN aliases AS a ON a.id = la.alias_cd\n            WHERE\n                sta.e_status = 0\n                AND ($3::int IS NULL OR sta.line_cd = $3)\n            ORDER BY sst.id",
   "describe": {
     "columns": [
       {
@@ -230,22 +230,22 @@
       },
       {
         "ordinal": 45,
-        "name": "line_group_cd",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 46,
         "name": "type_id",
         "type_info": "Int4"
       },
       {
-        "ordinal": 47,
+        "ordinal": 46,
         "name": "sst_id",
         "type_info": "Int4"
       },
       {
-        "ordinal": 48,
+        "ordinal": 47,
         "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 48,
+        "name": "line_group_cd",
         "type_info": "Int4"
       },
       {
@@ -298,7 +298,6 @@
       "Left": [
         "Int4",
         "Int4",
-        "Int4",
         "Int4"
       ]
     },
@@ -348,20 +347,20 @@
       true,
       true,
       null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
     ]
   },
-  "hash": "422bdec51028a86db49d9e2b0babd7f58066d3a2433f5b6416972dfc359540fa"
+  "hash": "20b55238238b1655930a5716441ff4944d4e572e97654fc65cb425e5435d337b"
 }

--- a/.sqlx/query-64004f2e2ea8f34594c230fe82d5502911473ecef28265350576cd8bee64f7f8.json
+++ b/.sqlx/query-64004f2e2ea8f34594c230fe82d5502911473ecef28265350576cd8bee64f7f8.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH\n                from_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $1\n                        AND s.e_status = 0\n                ),\n                to_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $2\n                        AND s.e_status = 0\n                ),\n                sst_cte_c1 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN from_cte ON sst.station_cd = from_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte_c2 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN to_cte ON sst.station_cd = to_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte AS (\n                    SELECT\n                        sst.id,\n                        sst.station_cd,\n                        sst.type_cd,\n                        sst.line_group_cd,\n                        sst.pass\n                    FROM\n                        station_station_types AS sst\n                        JOIN sst_cte_c1 ON sst.line_group_cd = sst_cte_c1.line_group_cd\n                        JOIN sst_cte_c2 ON sst.line_group_cd = sst_cte_c2.line_group_cd\n                )\n            SELECT\n                sta.station_cd,\n                sta.station_g_cd,\n                sta.station_name,\n                sta.station_name_k,\n                sta.station_name_r,\n                sta.station_name_rn,\n                sta.station_name_zh,\n                sta.station_name_ko,\n                sta.station_number1,\n                sta.station_number2,\n                sta.station_number3,\n                sta.station_number4,\n                sta.three_letter_code,\n                sta.line_cd,\n                sta.pref_cd,\n                sta.post,\n                sta.address,\n                sta.lon,\n                sta.lat,\n                sta.open_ymd,\n                sta.close_ymd,\n                sta.e_status,\n                sta.e_sort,\n                lin.company_cd,\n                COALESCE(NULLIF(COALESCE(a.line_name, lin.line_name), ''), NULL) AS line_name,\n                COALESCE(NULLIF(COALESCE(a.line_name_k, lin.line_name_k), ''), NULL) AS line_name_k,\n                COALESCE(NULLIF(COALESCE(a.line_name_h, lin.line_name_h), ''), NULL) AS line_name_h,\n                COALESCE(NULLIF(COALESCE(a.line_name_r, lin.line_name_r), ''), NULL) AS line_name_r,\n                COALESCE(NULLIF(COALESCE(a.line_name_zh, lin.line_name_zh), ''), NULL) AS line_name_zh,\n                COALESCE(NULLIF(COALESCE(a.line_name_ko, lin.line_name_ko), ''), NULL) AS line_name_ko,\n                COALESCE(NULLIF(COALESCE(a.line_color_c, lin.line_color_c), ''), NULL) AS line_color_c,\n                lin.line_type,\n                lin.line_symbol1,\n                lin.line_symbol2,\n                lin.line_symbol3,\n                lin.line_symbol4,\n                lin.line_symbol1_color,\n                lin.line_symbol2_color,\n                lin.line_symbol3_color,\n                lin.line_symbol4_color,\n                lin.line_symbol1_shape,\n                lin.line_symbol2_shape,\n                lin.line_symbol3_shape,\n                lin.line_symbol4_shape,\n                COALESCE(lin.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n                tt.id AS type_id,\n                sst.id AS sst_id,\n                sst.type_cd,\n                sst.line_group_cd,\n                sst.pass,\n                tt.type_name,\n                tt.type_name_k,\n                tt.type_name_r,\n                tt.type_name_zh,\n                tt.type_name_ko,\n                tt.color,\n                tt.direction,\n                tt.kind\n            FROM\n                stations AS sta\n                LEFT JOIN sst_cte AS sst ON sst.station_cd = sta.station_cd\n                JOIN types AS tt ON tt.type_cd = sst.type_cd\n                JOIN lines AS lin ON lin.line_cd = sta.line_cd AND lin.e_status = 0\n                LEFT JOIN line_aliases AS la ON la.station_cd = sta.station_cd\n                LEFT JOIN aliases AS a ON a.id = la.alias_cd\n            WHERE\n                sta.e_status = 0\n            ORDER BY sst.id",
+  "query": "WITH\n                from_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $1\n                ),\n                to_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $2\n                ),\n                common_lines AS (\n                    SELECT DISTINCT s1.line_cd\n                    FROM stations s1\n                    WHERE s1.station_g_cd = $3\n                        AND s1.e_status = 0\n                        AND ($5::int IS NULL OR s1.line_cd = $5)\n                        AND EXISTS (\n                        SELECT 1\n                        FROM stations s2\n                        WHERE s2.station_g_cd = $4\n                            AND s2.e_status = 0\n                            AND s2.line_cd = s1.line_cd\n                        )\n                ),\n                sst_cte_c1 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN from_cte ON sst.station_cd = from_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte_c2 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN to_cte ON sst.station_cd = to_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte AS (\n                    SELECT\n                        sst.id,\n                        sst.station_cd,\n                        sst.type_cd,\n                        sst.line_group_cd,\n                        sst.pass\n                    FROM\n                        station_station_types AS sst\n                        JOIN sst_cte_c1 ON sst.line_group_cd = sst_cte_c1.line_group_cd\n                        JOIN sst_cte_c2 ON sst.line_group_cd = sst_cte_c2.line_group_cd\n                )\n            SELECT\n            sta.station_cd,\n            sta.station_g_cd,\n            sta.station_name,\n            sta.station_name_k,\n            sta.station_name_r,\n            sta.station_name_rn,\n            sta.station_name_zh,\n            sta.station_name_ko,\n            sta.station_number1,\n            sta.station_number2,\n            sta.station_number3,\n            sta.station_number4,\n            sta.three_letter_code,\n            sta.line_cd,\n            sta.pref_cd,\n            sta.post,\n            sta.address,\n            sta.lon,\n            sta.lat,\n            sta.open_ymd,\n            sta.close_ymd,\n            sta.e_status,\n            sta.e_sort,\n            lin.company_cd,\n            COALESCE(NULLIF(COALESCE(a.line_name, lin.line_name), ''), NULL) AS line_name,\n            COALESCE(NULLIF(COALESCE(a.line_name_k, lin.line_name_k), ''), NULL) AS line_name_k,\n            COALESCE(NULLIF(COALESCE(a.line_name_h, lin.line_name_h), ''), NULL) AS line_name_h,\n            COALESCE(NULLIF(COALESCE(a.line_name_r, lin.line_name_r), ''), NULL) AS line_name_r,\n            COALESCE(NULLIF(COALESCE(a.line_name_zh, lin.line_name_zh), ''), NULL) AS line_name_zh,\n            COALESCE(NULLIF(COALESCE(a.line_name_ko, lin.line_name_ko), ''), NULL) AS line_name_ko,\n            COALESCE(NULLIF(COALESCE(a.line_color_c, lin.line_color_c), ''), NULL) AS line_color_c,\n            lin.line_type,\n            lin.line_symbol1,\n            lin.line_symbol2,\n            lin.line_symbol3,\n            lin.line_symbol4,\n            lin.line_symbol1_color,\n            lin.line_symbol2_color,\n            lin.line_symbol3_color,\n            lin.line_symbol4_color,\n            lin.line_symbol1_shape,\n            lin.line_symbol2_shape,\n            lin.line_symbol3_shape,\n            lin.line_symbol4_shape,\n            COALESCE(lin.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            COALESCE(sst.line_group_cd, NULL)::int AS line_group_cd, -- has_train_types用\n            NULL::int AS type_id,\n            NULL::int AS sst_id,\n            NULL::int AS type_cd,\n            NULL::int AS pass,\n            NULL::text AS type_name,\n            NULL::text AS type_name_k,\n            NULL::text AS type_name_r,\n            NULL::text AS type_name_zh,\n            NULL::text AS type_name_ko,\n            NULL::text AS color,\n            NULL::int AS direction,\n            NULL::int AS kind\n            FROM\n                stations AS sta\n\t\t\t\tJOIN common_lines AS cl ON sta.line_cd = cl.line_cd\n\t\t\t\tJOIN lines AS lin ON lin.line_cd = cl.line_cd\n                LEFT JOIN sst_cte AS sst ON sst.station_cd = sta.station_cd\n                LEFT JOIN types AS tt ON tt.type_cd = sst.type_cd\n                LEFT JOIN line_aliases AS la ON la.station_cd = sta.station_cd\n                LEFT JOIN aliases AS a ON a.id = la.alias_cd\n            WHERE\n                sst.line_group_cd IS NULL\n                AND lin.e_status = 0\n                AND sta.e_status = 0\n                ORDER BY sta.e_sort, sta.station_cd",
   "describe": {
     "columns": [
       {
@@ -230,22 +230,22 @@
       },
       {
         "ordinal": 45,
-        "name": "type_id",
+        "name": "line_group_cd",
         "type_info": "Int4"
       },
       {
         "ordinal": 46,
-        "name": "sst_id",
+        "name": "type_id",
         "type_info": "Int4"
       },
       {
         "ordinal": 47,
-        "name": "type_cd",
+        "name": "sst_id",
         "type_info": "Int4"
       },
       {
         "ordinal": 48,
-        "name": "line_group_cd",
+        "name": "type_cd",
         "type_info": "Int4"
       },
       {
@@ -297,6 +297,9 @@
     "parameters": {
       "Left": [
         "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
         "Int4"
       ]
     },
@@ -346,20 +349,20 @@
       true,
       true,
       null,
-      false,
-      false,
-      false,
-      false,
-      true,
-      false,
-      false,
-      false,
-      false,
-      false,
-      false,
-      true,
-      true
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
     ]
   },
-  "hash": "217b99932d995eff26a2eb16abab5dd05c27b6b77f78f169ca2049f45cf432ce"
+  "hash": "64004f2e2ea8f34594c230fe82d5502911473ecef28265350576cd8bee64f7f8"
 }

--- a/stationapi/src/domain/repository/station_repository.rs
+++ b/stationapi/src/domain/repository/station_repository.rs
@@ -36,6 +36,7 @@ pub trait StationRepository: Send + Sync + 'static {
         &self,
         from_station_id: u32,
         to_station_id: u32,
+        via_line_id: Option<u32>,
     ) -> Result<Vec<Station>, DomainError>;
 }
 

--- a/stationapi/src/domain/repository/station_repository.rs
+++ b/stationapi/src/domain/repository/station_repository.rs
@@ -193,15 +193,28 @@ mod tests {
             &self,
             from_station_id: u32,
             to_station_id: u32,
+            via_line_id: Option<u32>,
         ) -> Result<Vec<Station>, DomainError> {
-            // 簡単なルート検索のモック実装
+            // シンプルなルート検索のモック実装。via_line_id が指定されている場合は
+            // 両駅がその路線に属していることを条件にする。
             let mut result = Vec::new();
 
-            if let Some(from_station) = self.stations.get(&from_station_id) {
+            let from_station = self.stations.get(&from_station_id);
+            let to_station = self.stations.get(&to_station_id);
+
+            if let Some(required_line) = via_line_id {
+                let line_match = |s: &Station| s.line_cd as u32 == required_line;
+                if !from_station.map_or(false, line_match) || !to_station.map_or(false, line_match)
+                {
+                    return Ok(result);
+                }
+            }
+
+            if let Some(from_station) = from_station {
                 result.push(from_station.clone());
             }
 
-            if let Some(to_station) = self.stations.get(&to_station_id) {
+            if let Some(to_station) = to_station {
                 if from_station_id != to_station_id {
                     result.push(to_station.clone());
                 }
@@ -381,7 +394,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_route_stops() {
         let repo = MockStationRepository::new();
-        let result = repo.get_route_stops(1, 2).await.unwrap();
+        let result = repo.get_route_stops(1, 2, None).await.unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].station_cd, 1);
         assert_eq!(result[1].station_cd, 2);
@@ -390,7 +403,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_route_stops_same_station() {
         let repo = MockStationRepository::new();
-        let result = repo.get_route_stops(1, 1).await.unwrap();
+        let result = repo.get_route_stops(1, 1, None).await.unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].station_cd, 1);
     }
@@ -398,7 +411,25 @@ mod tests {
     #[tokio::test]
     async fn test_get_route_stops_not_found() {
         let repo = MockStationRepository::new();
-        let result = repo.get_route_stops(999, 1000).await.unwrap();
+        let result = repo.get_route_stops(999, 1000, None).await.unwrap();
         assert_eq!(result.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_get_route_stops_with_via_line_id_match() {
+        let repo = MockStationRepository::new();
+        // 東京駅(1) と 品川駅(4) は line_cd=1001 で一致する
+        let result = repo.get_route_stops(1, 4, Some(1001)).await.unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].station_cd, 1);
+        assert_eq!(result[1].station_cd, 4);
+    }
+
+    #[tokio::test]
+    async fn test_get_route_stops_with_via_line_id_mismatch() {
+        let repo = MockStationRepository::new();
+        // line_cd が一致しないためルートは返さない
+        let result = repo.get_route_stops(1, 2, Some(1001)).await.unwrap();
+        assert!(result.is_empty());
     }
 }

--- a/stationapi/src/presentation/controller/grpc.rs
+++ b/stationapi/src/presentation/controller/grpc.rs
@@ -202,8 +202,13 @@ impl StationApi for MyApi {
     ) -> Result<tonic::Response<RouteResponse>, tonic::Status> {
         let from_id = request.get_ref().from_station_group_id;
         let to_id = request.get_ref().to_station_group_id;
+        let via_line_id = request.get_ref().via_line_id;
 
-        match self.query_use_case.get_routes(from_id, to_id).await {
+        match self
+            .query_use_case
+            .get_routes(from_id, to_id, via_line_id)
+            .await
+        {
             Ok(routes) => {
                 return Ok(Response::new(RouteResponse {
                     routes,
@@ -220,8 +225,13 @@ impl StationApi for MyApi {
     ) -> Result<tonic::Response<RouteMinimalResponse>, tonic::Status> {
         let from_id = request.get_ref().from_station_group_id;
         let to_id = request.get_ref().to_station_group_id;
+        let via_line_id = request.get_ref().via_line_id;
 
-        match self.query_use_case.get_routes_minimal(from_id, to_id).await {
+        match self
+            .query_use_case
+            .get_routes_minimal(from_id, to_id, via_line_id)
+            .await
+        {
             Ok(response) => {
                 return Ok(Response::new(response));
             }
@@ -235,8 +245,13 @@ impl StationApi for MyApi {
     ) -> Result<tonic::Response<RouteTypeResponse>, tonic::Status> {
         let from_id = request.get_ref().from_station_group_id;
         let to_id = request.get_ref().to_station_group_id;
+        let via_line_id = request.get_ref().via_line_id;
 
-        match self.query_use_case.get_train_types(from_id, to_id).await {
+        match self
+            .query_use_case
+            .get_train_types(from_id, to_id, via_line_id)
+            .await
+        {
             Ok(train_types) => {
                 return Ok(Response::new(RouteTypeResponse {
                     train_types: train_types.into_iter().map(|t| t.into()).collect(),

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -520,10 +520,11 @@ where
         &self,
         from_station_id: u32,
         to_station_id: u32,
+        via_line_id: Option<u32>,
     ) -> Result<Vec<Route>, UseCaseError> {
         let stops = self
             .station_repository
-            .get_route_stops(from_station_id, to_station_id)
+            .get_route_stops(from_station_id, to_station_id, via_line_id)
             .await?;
 
         let route_row_tree_map = self.build_route_tree_map(&stops);
@@ -620,10 +621,11 @@ where
         &self,
         from_station_id: u32,
         to_station_id: u32,
+        via_line_id: Option<u32>,
     ) -> Result<proto::RouteMinimalResponse, UseCaseError> {
         let stops = self
             .station_repository
-            .get_route_stops(from_station_id, to_station_id)
+            .get_route_stops(from_station_id, to_station_id, via_line_id)
             .await?;
 
         let route_row_tree_map = self.build_route_tree_map(&stops);
@@ -722,10 +724,11 @@ where
         &self,
         from_station_id: u32,
         to_station_id: u32,
+        via_line_id: Option<u32>,
     ) -> Result<Vec<TrainType>, UseCaseError> {
         let stops = self
             .station_repository
-            .get_route_stops(from_station_id, to_station_id)
+            .get_route_stops(from_station_id, to_station_id, via_line_id)
             .await?;
 
         let line_group_id_vec: Vec<u32> = stops

--- a/stationapi/src/use_case/traits/query.rs
+++ b/stationapi/src/use_case/traits/query.rs
@@ -78,16 +78,19 @@ pub trait QueryUseCase: Send + Sync + 'static {
         &self,
         from_station_id: u32,
         to_station_id: u32,
+        via_line_id: Option<u32>,
     ) -> Result<Vec<Route>, UseCaseError>;
     async fn get_routes_minimal(
         &self,
         from_station_id: u32,
         to_station_id: u32,
+        via_line_id: Option<u32>,
     ) -> Result<RouteMinimalResponse, UseCaseError>;
     async fn get_train_types(
         &self,
         from_station_id: u32,
         to_station_id: u32,
+        via_line_id: Option<u32>,
     ) -> Result<Vec<TrainType>, UseCaseError>;
     async fn find_line_by_id(&self, line_id: u32) -> Result<Option<Line>, UseCaseError>;
     async fn get_lines_by_id_vec(&self, line_ids: &[u32]) -> Result<Vec<Line>, UseCaseError>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新機能

* ルート検索時に特定の線区を指定してフィルタリングできるようになりました。指定された線区経由のルートのみを検索できます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->