### PR TITLE
駅から半径300m以内のバス停を乗換可能バス停とする

### DIFF
--- a/.sqlx/query-01a96a6f40ab08c532b4e7f3cc493906213e6ec80d495a2fe569ccf1d94b4834.json
+++ b/.sqlx/query-01a96a6f40ab08c532b4e7f3cc493906213e6ec80d495a2fe569ccf1d94b4834.json
@@ -1,0 +1,196 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT \n            l.line_cd,\n            l.company_cd,\n            l.line_type,\n            l.line_name,\n            l.line_name_k,\n            l.line_name_h,\n            l.line_name_r,\n            l.line_name_zh,\n            l.line_name_ko,\n            l.line_color_c,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            l.e_status,\n            l.e_sort,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            CAST(NULL AS INTEGER) AS line_group_cd,\n            CAST(NULL AS INTEGER) AS station_cd,\n            CAST(NULL AS INTEGER) AS station_g_cd,\n            CAST(NULL AS INTEGER) AS type_cd,\n            l.transport_type\n            FROM lines AS l\n            WHERE l.line_cd = $1\n            AND l.e_status = 0",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 18,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 19,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 26,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 27,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 28,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 29,
+        "name": "transport_type",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false
+    ]
+  },
+  "hash": "01a96a6f40ab08c532b4e7f3cc493906213e6ec80d495a2fe569ccf1d94b4834"
+}

--- a/.sqlx/query-0bd668d4bac8ff6e3df4eff660f112043461a1461884f8461dfc6235208825a6.json
+++ b/.sqlx/query-0bd668d4bac8ff6e3df4eff660f112043461a1461884f8461dfc6235208825a6.json
@@ -1,0 +1,196 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT DISTINCT l.line_cd,\n            l.line_name,\n            l.line_name_k,\n            l.line_name_h,\n            l.line_name_r,\n            l.line_name_zh,\n            l.line_name_ko,\n            l.line_color_c,\n            l.company_cd,\n            l.line_type,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            l.e_status,\n            l.e_sort,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            sst.line_group_cd,\n            sst.type_cd,\n            s.station_cd,\n            s.station_g_cd,\n            l.transport_type\n        FROM lines AS l\n        JOIN stations AS s ON s.station_g_cd = $1\n            AND s.e_status = 0\n        LEFT JOIN station_station_types AS sst ON sst.station_cd = s.station_cd AND sst.pass <> 1\n        WHERE l.line_cd = s.line_cd\n            AND l.e_status = 0",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 18,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 19,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 26,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 27,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 28,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 29,
+        "name": "transport_type",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      null,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0bd668d4bac8ff6e3df4eff660f112043461a1461884f8461dfc6235208825a6"
+}

--- a/.sqlx/query-16b301ca5df4be89b803987fd71cc41b55e885ccd4bd3ca4bcae1f7336742d3f.json
+++ b/.sqlx/query-16b301ca5df4be89b803987fd71cc41b55e885ccd4bd3ca4bcae1f7336742d3f.json
@@ -1,0 +1,377 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH from_stations AS (\n                SELECT\n                    s.station_cd,\n                    s.line_cd\n                FROM stations AS s\n                WHERE s.station_g_cd = $1\n                AND s.e_status = 0\n            ),\n            filtered AS (\n                SELECT DISTINCT ON (s.station_cd)\n                    s.station_cd,\n                    s.station_g_cd,\n                    s.station_name,\n                    s.station_name_k,\n                    s.station_name_r,\n                    s.station_name_rn,\n                    s.station_name_zh,\n                    s.station_name_ko,\n                    s.station_number1,\n                    s.station_number2,\n                    s.station_number3,\n                    s.station_number4,\n                    s.three_letter_code,\n                    s.line_cd,\n                    s.pref_cd,\n                    s.post,\n                    s.address,\n                    s.lon,\n                    s.lat,\n                    s.open_ymd,\n                    s.close_ymd,\n                    s.e_status,\n                    s.e_sort,\n                    l.company_cd,\n                    COALESCE(NULLIF(COALESCE(a.line_name, l.line_name), ''), NULL) AS line_name,\n                    COALESCE(NULLIF(COALESCE(a.line_name_k, l.line_name_k), ''), NULL) AS line_name_k,\n                    COALESCE(NULLIF(COALESCE(a.line_name_h, l.line_name_h), ''), NULL) AS line_name_h,\n                    COALESCE(NULLIF(COALESCE(a.line_name_r, l.line_name_r), ''), NULL) AS line_name_r,\n                    COALESCE(NULLIF(COALESCE(a.line_name_zh, l.line_name_zh), ''), NULL) AS line_name_zh,\n                    COALESCE(NULLIF(COALESCE(a.line_name_ko, l.line_name_ko), ''), NULL) AS line_name_ko,\n                    COALESCE(NULLIF(COALESCE(a.line_color_c, l.line_color_c), ''), NULL) AS line_color_c,\n                    l.line_type,\n                    l.line_symbol1,\n                    l.line_symbol2,\n                    l.line_symbol3,\n                    l.line_symbol4,\n                    l.line_symbol1_color,\n                    l.line_symbol2_color,\n                    l.line_symbol3_color,\n                    l.line_symbol4_color,\n                    l.line_symbol1_shape,\n                    l.line_symbol2_shape,\n                    l.line_symbol3_shape,\n                    l.line_symbol4_shape,\n                    COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n                    COALESCE(from_sst.line_group_cd, NULL)::int AS line_group_cd, -- has_train_types用\n                    NULL::int AS type_id,\n                    NULL::int AS sst_id,\n                    NULL::int AS type_cd,\n                    NULL::int AS pass,\n                    NULL::text AS type_name,\n                    NULL::text AS type_name_k,\n                    NULL::text AS type_name_r,\n                    NULL::text AS type_name_zh,\n                    NULL::text AS type_name_ko,\n                    NULL::text AS color,\n                    NULL::int AS direction,\n                    NULL::int AS kind,\n                s.transport_type\n                FROM stations AS s\n                    LEFT JOIN from_stations AS fs\n                        ON fs.station_cd IS NOT NULL\n                    LEFT JOIN station_station_types AS from_sst\n                        ON from_sst.station_cd = fs.station_cd\n                    LEFT JOIN station_station_types AS dst_sst\n                        ON dst_sst.station_cd = s.station_cd\n                    LEFT JOIN types AS t\n                        ON t.type_cd = dst_sst.type_cd\n                    LEFT JOIN line_aliases AS la\n                        ON la.station_cd = s.station_cd\n                    LEFT JOIN aliases AS a\n                        ON la.alias_cd = a.id\n                    JOIN lines AS l\n                        ON l.line_cd = s.line_cd\n                        AND l.e_status = 0\n                WHERE\n                    (\n                        s.station_name   LIKE $2\n                        OR s.station_name_rn LIKE $3\n                        OR s.station_name_k LIKE $4\n                        OR s.station_name_zh LIKE $5\n                        OR s.station_name_ko LIKE $6\n                    )\n                    AND s.e_status = 0\n                    AND ($8::int IS NULL OR COALESCE(s.transport_type, 0) = $8)\n                    AND (\n                        (\n                            from_sst.id IS NOT NULL\n                            AND dst_sst.id IS NOT NULL\n                            AND from_sst.line_group_cd = dst_sst.line_group_cd\n                            AND dst_sst.pass <> 1\n                        )\n                        OR\n                        (\n                            (from_sst.id IS NULL OR dst_sst.id IS NULL)\n                            AND s.line_cd = COALESCE(fs.line_cd, s.line_cd)\n                        )\n                    )\n                ORDER BY s.station_cd, s.station_g_cd, s.station_name\n            )\n            SELECT *\n            FROM filtered\n            ORDER BY station_g_cd, station_name\n            LIMIT $7",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "station_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "station_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "station_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "station_name_rn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "station_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "station_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "station_number1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_number2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "station_number3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "station_number4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "three_letter_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "pref_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "post",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "lon",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "lat",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 19,
+        "name": "open_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "close_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 30,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 31,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 32,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 33,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 34,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 35,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 36,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 37,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 38,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 39,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 40,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 41,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 42,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 43,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 44,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 45,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 46,
+        "name": "type_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 47,
+        "name": "sst_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 48,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 49,
+        "name": "pass",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 50,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 51,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 52,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 53,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 54,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 55,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 56,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 57,
+        "name": "kind",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 58,
+        "name": "transport_type",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Int8",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false
+    ]
+  },
+  "hash": "16b301ca5df4be89b803987fd71cc41b55e885ccd4bd3ca4bcae1f7336742d3f"
+}

--- a/.sqlx/query-20f83c69618f5ad0ba1a7fc15e48ac7b77b61446b7c104121ae09b2371514eb2.json
+++ b/.sqlx/query-20f83c69618f5ad0ba1a7fc15e48ac7b77b61446b7c104121ae09b2371514eb2.json
@@ -1,0 +1,196 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT \n            l.line_cd,\n            l.company_cd,\n            l.line_type,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            l.e_status,\n            l.e_sort,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            s.station_cd,\n            s.station_g_cd,\n            sst.line_group_cd,\n            sst.type_cd,\n            l.line_name,\n            l.line_name_k,\n            l.line_name_h,\n            l.line_name_r,\n            l.line_name_zh,\n            l.line_name_ko,\n            l.line_color_c,\n            l.transport_type\n        FROM lines AS l\n            JOIN station_station_types AS sst ON sst.line_group_cd = $1 AND sst.pass <> 1\n            JOIN stations AS s ON s.station_cd = sst.station_cd\n            AND s.e_status = 0\n            AND l.line_cd = s.line_cd\n            LEFT JOIN line_aliases AS la ON la.station_cd = s.station_cd\n            LEFT JOIN aliases AS a ON la.alias_cd = a.id\n        WHERE l.e_status = 0",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 17,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 19,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 20,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 21,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 23,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "transport_type",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      null,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "20f83c69618f5ad0ba1a7fc15e48ac7b77b61446b7c104121ae09b2371514eb2"
+}

--- a/.sqlx/query-2217a8a08cc485bd86fde1e2312d80eeb5957224af02af9c634ef262e5d6a0e0.json
+++ b/.sqlx/query-2217a8a08cc485bd86fde1e2312d80eeb5957224af02af9c634ef262e5d6a0e0.json
@@ -1,0 +1,370 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT s.station_cd,\n            s.station_g_cd,\n            s.station_name,\n            s.station_name_k,\n            s.station_name_r,\n            s.station_name_rn,\n            s.station_name_zh,\n            s.station_name_ko,\n            s.station_number1,\n            s.station_number2,\n            s.station_number3,\n            s.station_number4,\n            s.three_letter_code,\n            s.line_cd,\n            s.pref_cd,\n            s.post,\n            s.address,\n            s.lon,\n            s.lat,\n            s.open_ymd,\n            s.close_ymd,\n            s.e_status,\n            s.e_sort,\n            l.company_cd,\n            COALESCE(NULLIF(COALESCE(a.line_name, l.line_name), ''), NULL) AS line_name,\n            COALESCE(NULLIF(COALESCE(a.line_name_k, l.line_name_k), ''), NULL) AS line_name_k,\n            COALESCE(NULLIF(COALESCE(a.line_name_h, l.line_name_h), ''), NULL) AS line_name_h,\n            COALESCE(NULLIF(COALESCE(a.line_name_r, l.line_name_r), ''), NULL) AS line_name_r,\n            COALESCE(NULLIF(COALESCE(a.line_name_zh, l.line_name_zh), ''), NULL) AS line_name_zh,\n            COALESCE(NULLIF(COALESCE(a.line_name_ko, l.line_name_ko), ''), NULL) AS line_name_ko,\n            COALESCE(NULLIF(COALESCE(a.line_color_c, l.line_color_c), ''), NULL) AS line_color_c,\n            l.line_type,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            t.id AS type_id,\n            sst.id AS sst_id,\n            sst.type_cd,\n            sst.line_group_cd,\n            sst.pass,\n            t.type_name,\n            t.type_name_k,\n            t.type_name_r,\n            t.type_name_zh,\n            t.type_name_ko,\n            t.color,\n            t.direction,\n            t.kind,\n            s.transport_type\n          FROM stations AS s\n          JOIN lines AS l ON l.line_cd = s.line_cd\n          LEFT JOIN station_station_types AS sst ON sst.station_cd = s.station_cd\n          LEFT JOIN types AS t ON t.type_cd = sst.type_cd\n          LEFT JOIN line_aliases AS la ON la.station_cd = s.station_cd\n          LEFT JOIN aliases AS a ON a.id = la.alias_cd\n          WHERE s.station_cd = $1\n            AND s.e_status = 0\n            AND l.e_status = 0\n          LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "station_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "station_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "station_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "station_name_rn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "station_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "station_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "station_number1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_number2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "station_number3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "station_number4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "three_letter_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "pref_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "post",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "lon",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "lat",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 19,
+        "name": "open_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "close_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 30,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 31,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 32,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 33,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 34,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 35,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 36,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 37,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 38,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 39,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 40,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 41,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 42,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 43,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 44,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 45,
+        "name": "type_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 46,
+        "name": "sst_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 47,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 48,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 49,
+        "name": "pass",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 50,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 51,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 52,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 53,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 54,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 55,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 56,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 57,
+        "name": "kind",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 58,
+        "name": "transport_type",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "2217a8a08cc485bd86fde1e2312d80eeb5957224af02af9c634ef262e5d6a0e0"
+}

--- a/.sqlx/query-55bee6b45754d1da9bf555d319f015ce232f8574a41c3ef25b730d11071f8428.json
+++ b/.sqlx/query-55bee6b45754d1da9bf555d319f015ce232f8574a41c3ef25b730d11071f8428.json
@@ -1,0 +1,94 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n            t.type_name,\n            t.type_name_k,\n            t.type_name_r,\n            t.type_name_zh,\n            t.type_name_ko,\n            t.color,\n            t.direction,\n            t.kind,\n            sst.id,\n            sst.station_cd,\n            sst.type_cd,\n            sst.line_group_cd,\n            sst.pass\n            FROM types as t\n            JOIN station_station_types AS sst ON sst.line_group_cd = $1\n            WHERE \n                t.type_cd = sst.type_cd\n            ORDER BY t.kind, sst.id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "kind",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 12,
+        "name": "pass",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "55bee6b45754d1da9bf555d319f015ce232f8574a41c3ef25b730d11071f8428"
+}

--- a/.sqlx/query-5f3a17f24bd4844e46b57d4920a3261ff87dfa6557926fb1b680d96c42ed56d4.json
+++ b/.sqlx/query-5f3a17f24bd4844e46b57d4920a3261ff87dfa6557926fb1b680d96c42ed56d4.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(sst.line_group_cd)::integer AS train_types_count\n            FROM station_station_types AS sst\n                JOIN types AS t ON t.type_cd = sst.type_cd\n            WHERE sst.station_cd = $1\n                AND (\n                    t.kind IN (0, 1)\n                    OR t.priority > 0\n                )",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "train_types_count",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "5f3a17f24bd4844e46b57d4920a3261ff87dfa6557926fb1b680d96c42ed56d4"
+}

--- a/.sqlx/query-6a624360045e2278d6c1e08559918dcd026348e9304bba9584e72061034ac3db.json
+++ b/.sqlx/query-6a624360045e2278d6c1e08559918dcd026348e9304bba9584e72061034ac3db.json
@@ -1,0 +1,370 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n            s.station_cd,\n            s.station_g_cd,\n            s.station_name,\n            s.station_name_k,\n            s.station_name_r,\n            s.station_name_rn,\n            s.station_name_zh,\n            s.station_name_ko,\n            s.station_number1,\n            s.station_number2,\n            s.station_number3,\n            s.station_number4,\n            s.three_letter_code,\n            s.line_cd,\n            s.pref_cd,\n            s.post,\n            s.address,\n            s.lon,\n            s.lat,\n            s.open_ymd,\n            s.close_ymd,\n            s.e_status,\n            s.e_sort,\n            COALESCE(NULLIF(COALESCE(a.line_name, l.line_name), ''), NULL) AS line_name,\n            COALESCE(NULLIF(COALESCE(a.line_name_k, l.line_name_k), ''), NULL) AS line_name_k,\n            COALESCE(NULLIF(COALESCE(a.line_name_h, l.line_name_h), ''), NULL) AS line_name_h,\n            COALESCE(NULLIF(COALESCE(a.line_name_r, l.line_name_r), ''), NULL) AS line_name_r,\n            COALESCE(NULLIF(COALESCE(a.line_name_zh, l.line_name_zh), ''), NULL) AS line_name_zh,\n            COALESCE(NULLIF(COALESCE(a.line_name_ko, l.line_name_ko), ''), NULL) AS line_name_ko,\n            COALESCE(NULLIF(COALESCE(a.line_color_c, l.line_color_c), ''), NULL) AS line_color_c,\n            l.company_cd,\n            l.line_type,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            sst.id AS sst_id,\n            sst.type_cd,\n            sst.line_group_cd,\n            sst.pass,\n            t.id AS type_id,\n            t.type_name,\n            t.type_name_k,\n            t.type_name_r,\n            t.type_name_zh,\n            t.type_name_ko,\n            t.color,\n            t.direction,\n            t.kind,\n            s.transport_type\n          FROM stations AS s\n          JOIN lines AS l ON l.line_cd = s.line_cd AND l.e_status = 0\n          LEFT JOIN station_station_types AS sst ON sst.line_group_cd = $1\n          LEFT JOIN types AS t ON t.type_cd = sst.type_cd\n          LEFT JOIN line_aliases AS la ON la.station_cd = s.station_cd\n          LEFT JOIN aliases AS a ON a.id = la.alias_cd\n          WHERE\n            s.line_cd = l.line_cd\n            AND s.station_cd = sst.station_cd\n            AND s.e_status = 0\n          ORDER BY sst.id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "station_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "station_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "station_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "station_name_rn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "station_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "station_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "station_number1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_number2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "station_number3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "station_number4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "three_letter_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "pref_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "post",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "lon",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "lat",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 19,
+        "name": "open_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "close_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 30,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 31,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 32,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 33,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 34,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 35,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 36,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 37,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 38,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 39,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 40,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 41,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 42,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 43,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 44,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 45,
+        "name": "sst_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 46,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 47,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 48,
+        "name": "pass",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 49,
+        "name": "type_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 50,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 51,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 52,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 53,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 54,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 55,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 56,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 57,
+        "name": "kind",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 58,
+        "name": "transport_type",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "6a624360045e2278d6c1e08559918dcd026348e9304bba9584e72061034ac3db"
+}

--- a/.sqlx/query-7428cc69d3756a749121a1ad5eee1603aa5e7ee3fc30071a142f9a15502da031.json
+++ b/.sqlx/query-7428cc69d3756a749121a1ad5eee1603aa5e7ee3fc30071a142f9a15502da031.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(stations.station_cd) <> 0 AS alive FROM stations",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "alive",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "7428cc69d3756a749121a1ad5eee1603aa5e7ee3fc30071a142f9a15502da031"
+}

--- a/.sqlx/query-792ccb86508366f1a36b6d43a6f9a5dc2535b80b9df16fbd2d308221b545813b.json
+++ b/.sqlx/query-792ccb86508366f1a36b6d43a6f9a5dc2535b80b9df16fbd2d308221b545813b.json
@@ -1,0 +1,374 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH\n                from_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $1\n                ),\n                to_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $2\n                ),\n                common_lines AS (\n                    SELECT DISTINCT s1.line_cd\n                    FROM stations s1\n                    WHERE s1.station_g_cd = $3\n                        AND s1.e_status = 0\n                        AND ($5::int IS NULL OR s1.line_cd = $5)\n                        AND EXISTS (\n                        SELECT 1\n                        FROM stations s2\n                        WHERE s2.station_g_cd = $4\n                            AND s2.e_status = 0\n                            AND s2.line_cd = s1.line_cd\n                        )\n                ),\n                sst_cte_c1 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN from_cte ON sst.station_cd = from_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte_c2 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN to_cte ON sst.station_cd = to_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte AS (\n                    SELECT\n                        sst.id,\n                        sst.station_cd,\n                        sst.type_cd,\n                        sst.line_group_cd,\n                        sst.pass\n                    FROM\n                        station_station_types AS sst\n                        JOIN sst_cte_c1 ON sst.line_group_cd = sst_cte_c1.line_group_cd\n                        JOIN sst_cte_c2 ON sst.line_group_cd = sst_cte_c2.line_group_cd\n                )\n            SELECT\n            sta.station_cd,\n            sta.station_g_cd,\n            sta.station_name,\n            sta.station_name_k,\n            sta.station_name_r,\n            sta.station_name_rn,\n            sta.station_name_zh,\n            sta.station_name_ko,\n            sta.station_number1,\n            sta.station_number2,\n            sta.station_number3,\n            sta.station_number4,\n            sta.three_letter_code,\n            sta.line_cd,\n            sta.pref_cd,\n            sta.post,\n            sta.address,\n            sta.lon,\n            sta.lat,\n            sta.open_ymd,\n            sta.close_ymd,\n            sta.e_status,\n            sta.e_sort,\n            lin.company_cd,\n            COALESCE(NULLIF(COALESCE(a.line_name, lin.line_name), ''), NULL) AS line_name,\n            COALESCE(NULLIF(COALESCE(a.line_name_k, lin.line_name_k), ''), NULL) AS line_name_k,\n            COALESCE(NULLIF(COALESCE(a.line_name_h, lin.line_name_h), ''), NULL) AS line_name_h,\n            COALESCE(NULLIF(COALESCE(a.line_name_r, lin.line_name_r), ''), NULL) AS line_name_r,\n            COALESCE(NULLIF(COALESCE(a.line_name_zh, lin.line_name_zh), ''), NULL) AS line_name_zh,\n            COALESCE(NULLIF(COALESCE(a.line_name_ko, lin.line_name_ko), ''), NULL) AS line_name_ko,\n            COALESCE(NULLIF(COALESCE(a.line_color_c, lin.line_color_c), ''), NULL) AS line_color_c,\n            lin.line_type,\n            lin.line_symbol1,\n            lin.line_symbol2,\n            lin.line_symbol3,\n            lin.line_symbol4,\n            lin.line_symbol1_color,\n            lin.line_symbol2_color,\n            lin.line_symbol3_color,\n            lin.line_symbol4_color,\n            lin.line_symbol1_shape,\n            lin.line_symbol2_shape,\n            lin.line_symbol3_shape,\n            lin.line_symbol4_shape,\n            COALESCE(lin.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            COALESCE(sst.line_group_cd, NULL)::int AS line_group_cd, -- has_train_types用\n            NULL::int AS type_id,\n            NULL::int AS sst_id,\n            NULL::int AS type_cd,\n            NULL::int AS pass,\n            NULL::text AS type_name,\n            NULL::text AS type_name_k,\n            NULL::text AS type_name_r,\n            NULL::text AS type_name_zh,\n            NULL::text AS type_name_ko,\n            NULL::text AS color,\n            NULL::int AS direction,\n            NULL::int AS kind,\n            sta.transport_type\n            FROM\n                stations AS sta\n\t\t\t\tJOIN common_lines AS cl ON sta.line_cd = cl.line_cd\n\t\t\t\tJOIN lines AS lin ON lin.line_cd = cl.line_cd\n                LEFT JOIN sst_cte AS sst ON sst.station_cd = sta.station_cd\n                LEFT JOIN types AS tt ON tt.type_cd = sst.type_cd\n                LEFT JOIN line_aliases AS la ON la.station_cd = sta.station_cd\n                LEFT JOIN aliases AS a ON a.id = la.alias_cd\n            WHERE\n                sst.line_group_cd IS NULL\n                AND lin.e_status = 0\n                AND sta.e_status = 0\n                ORDER BY sta.e_sort, sta.station_cd",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "station_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "station_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "station_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "station_name_rn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "station_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "station_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "station_number1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_number2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "station_number3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "station_number4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "three_letter_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "pref_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "post",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "lon",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "lat",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 19,
+        "name": "open_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "close_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 30,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 31,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 32,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 33,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 34,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 35,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 36,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 37,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 38,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 39,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 40,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 41,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 42,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 43,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 44,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 45,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 46,
+        "name": "type_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 47,
+        "name": "sst_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 48,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 49,
+        "name": "pass",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 50,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 51,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 52,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 53,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 54,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 55,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 56,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 57,
+        "name": "kind",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 58,
+        "name": "transport_type",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false
+    ]
+  },
+  "hash": "792ccb86508366f1a36b6d43a6f9a5dc2535b80b9df16fbd2d308221b545813b"
+}

--- a/.sqlx/query-7bc61cc6e96fcdaf7e9a05c8f76582a0470a8b5f5e61ffcd0609ce4c45300afb.json
+++ b/.sqlx/query-7bc61cc6e96fcdaf7e9a05c8f76582a0470a8b5f5e61ffcd0609ce4c45300afb.json
@@ -1,0 +1,201 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT \n            l.line_cd,\n            l.company_cd,\n            l.line_type,\n            l.line_name,\n            l.line_name_k,\n            l.line_name_h,\n            l.line_name_r,\n            l.line_name_zh,\n            l.line_name_ko,\n            l.line_color_c,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            l.e_status,\n            l.e_sort,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            CAST(NULL AS INTEGER) AS line_group_cd,\n            CAST(NULL AS INTEGER) AS station_cd,\n            CAST(NULL AS INTEGER) AS station_g_cd,\n            CAST(NULL AS INTEGER) AS type_cd,\n            l.transport_type\n            FROM lines AS l\n            WHERE (\n                    l.line_name LIKE $1\n                    OR l.line_name_rn LIKE $2\n                    OR l.line_name_k LIKE $3\n                    OR l.line_name_zh LIKE $4\n                    OR l.line_name_ko LIKE $5\n                )\n                AND l.e_status = 0\n            LIMIT $6",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 18,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 19,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 26,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 27,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 28,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 29,
+        "name": "transport_type",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false
+    ]
+  },
+  "hash": "7bc61cc6e96fcdaf7e9a05c8f76582a0470a8b5f5e61ffcd0609ce4c45300afb"
+}

--- a/.sqlx/query-8fd35acd42a42b730854a2f1b9ffa0fd2f8384b457e7945d4070d976ecd9594f.json
+++ b/.sqlx/query-8fd35acd42a42b730854a2f1b9ffa0fd2f8384b457e7945d4070d976ecd9594f.json
@@ -1,0 +1,94 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n            t.type_name,\n            t.type_name_k,\n            t.type_name_r,\n            t.type_name_zh,\n            t.type_name_ko,\n            t.color,\n            t.direction,\n            t.kind,\n            sst.id,\n            sst.station_cd,\n            sst.type_cd,\n            sst.line_group_cd,\n            sst.pass\n            FROM  types AS t\n            JOIN stations AS s ON s.station_cd = $1 AND s.e_status = 0\n            JOIN station_station_types AS sst ON sst.station_cd = s.station_cd AND sst.type_cd = t.type_cd AND sst.pass <> 1\n            ORDER BY sst.id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "kind",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 12,
+        "name": "pass",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "8fd35acd42a42b730854a2f1b9ffa0fd2f8384b457e7945d4070d976ecd9594f"
+}

--- a/.sqlx/query-90906c9a7d97f432f66f1722a6a51731194922c4cb16f8809ae1e2e711d5a0da.json
+++ b/.sqlx/query-90906c9a7d97f432f66f1722a6a51731194922c4cb16f8809ae1e2e711d5a0da.json
@@ -1,0 +1,370 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT s.station_cd,\n            s.station_g_cd,\n            s.station_name,\n            s.station_name_k,\n            s.station_name_r,\n            s.station_name_rn,\n            s.station_name_zh,\n            s.station_name_ko,\n            s.station_number1,\n            s.station_number2,\n            s.station_number3,\n            s.station_number4,\n            s.three_letter_code,\n            s.line_cd,\n            s.pref_cd,\n            s.post,\n            s.address,\n            s.lon,\n            s.lat,\n            s.open_ymd,\n            s.close_ymd,\n            s.e_status,\n            s.e_sort,\n            l.company_cd,\n            l.line_type,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            COALESCE(NULLIF(COALESCE(a.line_name, l.line_name), ''), NULL) AS line_name,\n            COALESCE(NULLIF(COALESCE(a.line_name_k, l.line_name_k), ''), NULL) AS line_name_k,\n            COALESCE(NULLIF(COALESCE(a.line_name_h, l.line_name_h), ''), NULL) AS line_name_h,\n            COALESCE(NULLIF(COALESCE(a.line_name_r, l.line_name_r), ''), NULL) AS line_name_r,\n            COALESCE(NULLIF(COALESCE(a.line_name_zh, l.line_name_zh), ''), NULL) AS line_name_zh,\n            COALESCE(NULLIF(COALESCE(a.line_name_ko, l.line_name_ko), ''), NULL) AS line_name_ko,\n            COALESCE(NULLIF(COALESCE(a.line_color_c, l.line_color_c), ''), NULL) AS line_color_c,\n            sst.id AS sst_id,\n            sst.type_cd,\n            sst.line_group_cd,\n            sst.pass,\n            t.id AS type_id,\n            t.type_name,\n            t.type_name_k,\n            t.type_name_r,\n            t.type_name_zh,\n            t.type_name_ko,\n            t.color,\n            t.direction,\n            t.kind,\n            s.transport_type\n          FROM\n            stations AS s\n            JOIN lines AS l ON l.line_cd = s.line_cd\n            LEFT JOIN station_station_types AS sst ON sst.station_cd = s.station_cd\n            LEFT JOIN types AS t ON t.type_cd = sst.type_cd\n            LEFT JOIN line_aliases AS la ON la.station_cd = s.station_cd\n            LEFT JOIN aliases AS a ON a.id = la.alias_cd\n          WHERE\n            s.station_g_cd = $1\n            AND s.line_cd = l.line_cd\n            AND s.e_status = 0\n            AND l.e_status = 0",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "station_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "station_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "station_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "station_name_rn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "station_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "station_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "station_number1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_number2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "station_number3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "station_number4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "three_letter_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "pref_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "post",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "lon",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "lat",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 19,
+        "name": "open_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "close_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 30,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 31,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 32,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 33,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 34,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 35,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 36,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 37,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 38,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 39,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 40,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 41,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 42,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 43,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 44,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 45,
+        "name": "sst_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 46,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 47,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 48,
+        "name": "pass",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 49,
+        "name": "type_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 50,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 51,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 52,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 53,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 54,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 55,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 56,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 57,
+        "name": "kind",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 58,
+        "name": "transport_type",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "90906c9a7d97f432f66f1722a6a51731194922c4cb16f8809ae1e2e711d5a0da"
+}

--- a/.sqlx/query-9c6aff223f1912290cdda35d4cd8c9f3d26fc0efece17de6390f06ea9935241f.json
+++ b/.sqlx/query-9c6aff223f1912290cdda35d4cd8c9f3d26fc0efece17de6390f06ea9935241f.json
@@ -1,0 +1,372 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH\n                from_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $1\n                        AND s.e_status = 0\n                ),\n                to_cte AS (\n                    SELECT\n                        s.station_cd,\n                        s.line_cd\n                    FROM\n                        stations AS s\n                    WHERE\n                        s.station_g_cd = $2\n                        AND s.e_status = 0\n                ),\n                sst_cte_c1 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN from_cte ON sst.station_cd = from_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte_c2 AS (\n                    SELECT\n                        sst.line_group_cd\n                    FROM\n                        station_station_types AS sst\n                        JOIN to_cte ON sst.station_cd = to_cte.station_cd\n                    WHERE\n                        sst.pass <> 1\n                ),\n                sst_cte AS (\n                    SELECT\n                        sst.id,\n                        sst.station_cd,\n                        sst.type_cd,\n                        sst.line_group_cd,\n                        sst.pass\n                    FROM\n                        station_station_types AS sst\n                        JOIN sst_cte_c1 ON sst.line_group_cd = sst_cte_c1.line_group_cd\n                        JOIN sst_cte_c2 ON sst.line_group_cd = sst_cte_c2.line_group_cd\n                )\n            SELECT\n                sta.station_cd,\n                sta.station_g_cd,\n                sta.station_name,\n                sta.station_name_k,\n                sta.station_name_r,\n                sta.station_name_rn,\n                sta.station_name_zh,\n                sta.station_name_ko,\n                sta.station_number1,\n                sta.station_number2,\n                sta.station_number3,\n                sta.station_number4,\n                sta.three_letter_code,\n                sta.line_cd,\n                sta.pref_cd,\n                sta.post,\n                sta.address,\n                sta.lon,\n                sta.lat,\n                sta.open_ymd,\n                sta.close_ymd,\n                sta.e_status,\n                sta.e_sort,\n                lin.company_cd,\n                COALESCE(NULLIF(COALESCE(a.line_name, lin.line_name), ''), NULL) AS line_name,\n                COALESCE(NULLIF(COALESCE(a.line_name_k, lin.line_name_k), ''), NULL) AS line_name_k,\n                COALESCE(NULLIF(COALESCE(a.line_name_h, lin.line_name_h), ''), NULL) AS line_name_h,\n                COALESCE(NULLIF(COALESCE(a.line_name_r, lin.line_name_r), ''), NULL) AS line_name_r,\n                COALESCE(NULLIF(COALESCE(a.line_name_zh, lin.line_name_zh), ''), NULL) AS line_name_zh,\n                COALESCE(NULLIF(COALESCE(a.line_name_ko, lin.line_name_ko), ''), NULL) AS line_name_ko,\n                COALESCE(NULLIF(COALESCE(a.line_color_c, lin.line_color_c), ''), NULL) AS line_color_c,\n                lin.line_type,\n                lin.line_symbol1,\n                lin.line_symbol2,\n                lin.line_symbol3,\n                lin.line_symbol4,\n                lin.line_symbol1_color,\n                lin.line_symbol2_color,\n                lin.line_symbol3_color,\n                lin.line_symbol4_color,\n                lin.line_symbol1_shape,\n                lin.line_symbol2_shape,\n                lin.line_symbol3_shape,\n                lin.line_symbol4_shape,\n                COALESCE(lin.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n                tt.id AS type_id,\n                sst.id AS sst_id,\n                sst.type_cd,\n                sst.line_group_cd,\n                sst.pass,\n                tt.type_name,\n                tt.type_name_k,\n                tt.type_name_r,\n                tt.type_name_zh,\n                tt.type_name_ko,\n                tt.color,\n                tt.direction,\n                tt.kind,\n                sta.transport_type\n            FROM\n                stations AS sta\n                LEFT JOIN sst_cte AS sst ON sst.station_cd = sta.station_cd\n                JOIN types AS tt ON tt.type_cd = sst.type_cd\n                JOIN lines AS lin ON lin.line_cd = sta.line_cd AND lin.e_status = 0\n                LEFT JOIN line_aliases AS la ON la.station_cd = sta.station_cd\n                LEFT JOIN aliases AS a ON a.id = la.alias_cd\n            WHERE\n                sta.e_status = 0\n                AND ($3::int IS NULL OR sta.line_cd = $3)\n            ORDER BY sst.id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "station_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "station_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "station_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "station_name_rn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "station_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "station_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "station_number1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "station_number2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "station_number3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "station_number4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "three_letter_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "pref_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "post",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "lon",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "lat",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 19,
+        "name": "open_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "close_ymd",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 30,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 31,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 32,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 33,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 34,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 35,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 36,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 37,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 38,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 39,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 40,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 41,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 42,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 43,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 44,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 45,
+        "name": "type_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 46,
+        "name": "sst_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 47,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 48,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 49,
+        "name": "pass",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 50,
+        "name": "type_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 51,
+        "name": "type_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 52,
+        "name": "type_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 53,
+        "name": "type_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 54,
+        "name": "type_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 55,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 56,
+        "name": "direction",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 57,
+        "name": "kind",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 58,
+        "name": "transport_type",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "9c6aff223f1912290cdda35d4cd8c9f3d26fc0efece17de6390f06ea9935241f"
+}

--- a/.sqlx/query-c08e746f79517801e8a235b4cbc4377f9addfa50f0a0b9ac5e2dacad55fb9a97.json
+++ b/.sqlx/query-c08e746f79517801e8a235b4cbc4377f9addfa50f0a0b9ac5e2dacad55fb9a97.json
@@ -1,0 +1,196 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT DISTINCT ON (sst.id, l.line_cd)\n                l.line_cd,\n                l.company_cd,\n                l.line_type,\n                l.line_name,\n                l.line_name_k,\n                l.line_name_h,\n                l.line_name_r,\n                l.line_name_zh,\n                l.line_name_ko,\n                l.line_color_c,\n                l.line_symbol1,\n                l.line_symbol2,\n                l.line_symbol3,\n                l.line_symbol4,\n                l.line_symbol1_color,\n                l.line_symbol2_color,\n                l.line_symbol3_color,\n                l.line_symbol4_color,\n                l.line_symbol1_shape,\n                l.line_symbol2_shape,\n                l.line_symbol3_shape,\n                l.line_symbol4_shape,\n                l.e_status,\n                l.e_sort,\n                COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n                sst.line_group_cd,\n                sst.type_cd,\n                s.station_cd,\n                s.station_g_cd,\n                l.transport_type\n            FROM lines AS l\n            JOIN station_station_types AS sst ON sst.line_group_cd = ANY($1) AND sst.pass <> 1\n            JOIN stations AS s ON s.station_cd = sst.station_cd AND s.e_status = 0 AND s.line_cd = l.line_cd\n            LEFT JOIN line_aliases AS la ON la.station_cd = s.station_cd\n            LEFT JOIN aliases AS a ON la.alias_cd = a.id\n            WHERE l.e_status = 0\n            ORDER BY sst.id, l.line_cd",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 18,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 19,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 22,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 26,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 27,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 28,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 29,
+        "name": "transport_type",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4Array"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      null,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c08e746f79517801e8a235b4cbc4377f9addfa50f0a0b9ac5e2dacad55fb9a97"
+}

--- a/.sqlx/query-d3f9188af86adfa1b16ea4ce538299c4e0942aeadc2497c7752b6b98fb78087f.json
+++ b/.sqlx/query-d3f9188af86adfa1b16ea4ce538299c4e0942aeadc2497c7752b6b98fb78087f.json
@@ -1,0 +1,196 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT l.line_cd,\n            l.company_cd,\n            l.line_type,\n            l.line_symbol1,\n            l.line_symbol2,\n            l.line_symbol3,\n            l.line_symbol4,\n            l.line_symbol1_color,\n            l.line_symbol2_color,\n            l.line_symbol3_color,\n            l.line_symbol4_color,\n            l.line_symbol1_shape,\n            l.line_symbol2_shape,\n            l.line_symbol3_shape,\n            l.line_symbol4_shape,\n            l.e_status,\n            l.e_sort,\n            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,\n            s.station_cd,\n            s.station_g_cd,\n            sst.line_group_cd,\n            sst.type_cd,\n            COALESCE(alias_data.line_name, l.line_name) AS line_name,\n            COALESCE(alias_data.line_name_k, l.line_name_k) AS line_name_k,\n            COALESCE(alias_data.line_name_h, l.line_name_h) AS line_name_h,\n            COALESCE(alias_data.line_name_r, l.line_name_r) AS line_name_r,\n            COALESCE(alias_data.line_name_zh, l.line_name_zh) AS line_name_zh,\n            COALESCE(alias_data.line_name_ko, l.line_name_ko) AS line_name_ko,\n            COALESCE(alias_data.line_color_c, l.line_color_c) AS line_color_c,\n            l.transport_type\n        FROM lines AS l\n            JOIN stations AS s ON s.station_cd = $1\n            LEFT JOIN station_station_types AS sst ON sst.station_cd = s.station_cd AND sst.pass <> 1\n            LEFT JOIN (\n                SELECT DISTINCT ON (la.station_cd)\n                    la.station_cd,\n                    a.line_name,\n                    a.line_name_k,\n                    a.line_name_h,\n                    a.line_name_r,\n                    a.line_name_zh,\n                    a.line_name_ko,\n                    a.line_color_c\n                FROM line_aliases AS la\n                JOIN aliases AS a ON la.alias_cd = a.id\n                WHERE la.station_cd = $1\n                LIMIT 1\n            ) AS alias_data ON alias_data.station_cd = s.station_cd\n        WHERE l.line_cd = s.line_cd",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "line_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "company_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "line_type",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "line_symbol1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "line_symbol2",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "line_symbol3",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "line_symbol4",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "line_symbol1_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "line_symbol2_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "line_symbol3_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "line_symbol4_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "line_symbol1_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "line_symbol2_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "line_symbol3_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "line_symbol4_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "e_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "e_sort",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 17,
+        "name": "average_distance",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 18,
+        "name": "station_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 19,
+        "name": "station_g_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 20,
+        "name": "line_group_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 21,
+        "name": "type_cd",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 22,
+        "name": "line_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 23,
+        "name": "line_name_k",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 24,
+        "name": "line_name_h",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 25,
+        "name": "line_name_r",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 26,
+        "name": "line_name_zh",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 27,
+        "name": "line_name_ko",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 28,
+        "name": "line_color_c",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 29,
+        "name": "transport_type",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      null,
+      false,
+      false,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false
+    ]
+  },
+  "hash": "d3f9188af86adfa1b16ea4ce538299c4e0942aeadc2497c7752b6b98fb78087f"
+}

--- a/compose.yml
+++ b/compose.yml
@@ -24,6 +24,8 @@ services:
       POSTGRES_USER: stationapi
       POSTGRES_PASSWORD: stationapi
       POSTGRES_DB: stationapi
-    restart: always 
+    restart: always
+    ports:
+      - 5432:5432
     volumes:
       - ./docker/postgres:/docker-entrypoint-initdb.d:ro

--- a/docs/nearby-bus-stops.md
+++ b/docs/nearby-bus-stops.md
@@ -1,0 +1,104 @@
+# 近傍バス停検索機能
+
+鉄道駅から半径300m以内のバス停を同一グループとして返す機能の仕様。
+
+## 概要
+
+各APIで`transport_type`パラメータを使用して、鉄道駅に加えて近くのバス停を含めるかどうかを制御できる。
+
+## パラメータ
+
+### TransportType
+
+```protobuf
+enum TransportType {
+  TransportTypeUnspecified = 0;  // 鉄道駅 + 近くのバス停を含める
+  Rail = 1;                       // 鉄道駅のみ
+  Bus = 2;                        // バス停のみ
+}
+```
+
+## 動作仕様
+
+| transport_type | 動作 |
+|----------------|------|
+| **未指定 / Unspecified** | 鉄道駅を取得し、最初の鉄道駅から半径300m以内のバス停も追加して返す |
+| **Rail** | 鉄道駅のみを返す |
+| **Bus** | 最初の鉄道駅から半径300m以内のバス停のみを返す |
+
+## 対象API
+
+| API | 近傍バス停対応 | 備考 |
+|-----|---------------|------|
+| `GetStationById` | ✅ | |
+| `GetStationByIdList` | ✅ | |
+| `GetStationsByGroupId` | ✅ | |
+| `GetStationsByLineId` | ❌ | 路線の停車駅のみ返す（`transport_type`は無視） |
+| `GetStationsByLineGroupId` | ❌ | 路線の停車駅のみ返す（`transport_type`は無視） |
+| `GetStationsByCoordinates` | ✅ | |
+| `GetStationsByName` | ✅ | |
+
+**注**: 路線系API（`GetStationsByLineId`、`GetStationsByLineGroupId`）は、路線の停車駅一覧を返すため、近傍バス停を混在させることは意味がありません。これらのAPIでは`transport_type`パラメータは無視されます。
+
+## 距離計算
+
+- **アルゴリズム**: Haversine公式（地球の曲率を考慮）
+- **半径**: 300メートル（定数 `NEARBY_BUS_STOP_RADIUS_METERS`）
+- **基準点**: 取得した鉄道駅の最初の1件の座標
+
+## 使用例
+
+### 鉄道駅 + 近くのバス停を取得
+
+```protobuf
+// transport_type未指定で鉄道駅と近くのバス停を両方取得
+GetStationByGroupIdRequest {
+  group_id: 1130201
+}
+```
+
+### 鉄道駅のみを取得
+
+```protobuf
+GetStationByGroupIdRequest {
+  group_id: 1130201
+  transport_type: Rail
+}
+```
+
+### 近くのバス停のみを取得
+
+```protobuf
+GetStationByGroupIdRequest {
+  group_id: 1130201
+  transport_type: Bus
+}
+```
+
+## 実装詳細
+
+### 関連ファイル
+
+- `proto/stationapi.proto`: リクエスト定義
+- `src/use_case/interactor/query.rs`: ビジネスロジック
+- `src/presentation/controller/grpc.rs`: gRPCコントローラー
+
+### 定数
+
+```rust
+// src/use_case/interactor/query.rs
+const NEARBY_BUS_STOP_RADIUS_METERS: f64 = 300.0;
+```
+
+### ヘルパーメソッド
+
+```rust
+/// 指定座標から半径300m以内のバス停を取得
+async fn get_nearby_bus_stops(&self, ref_lat: f64, ref_lon: f64) -> Result<Vec<Station>, UseCaseError>
+```
+
+## 注意事項
+
+- バス停検索は最大50件の候補を取得し、その中から300m以内のものをフィルタリング
+- 鉄道駅が存在しない場合、`transport_type: Bus`は空の結果を返す
+- 複数の鉄道駅がある場合、最初の1件の座標を基準点として使用

--- a/stationapi/src/presentation/controller/grpc.rs
+++ b/stationapi/src/presentation/controller/grpc.rs
@@ -642,6 +642,7 @@ mod tests {
             &self,
             stations: Vec<Station>,
             _line_group_id: Option<u32>,
+            _transport_type: Option<TransportType>,
         ) -> Result<Vec<Station>, UseCaseError> {
             Ok(stations)
         }

--- a/stationapi/src/presentation/controller/grpc.rs
+++ b/stationapi/src/presentation/controller/grpc.rs
@@ -43,9 +43,15 @@ impl StationApi for MyApi {
         &self,
         request: tonic::Request<GetStationByIdRequest>,
     ) -> Result<tonic::Response<SingleStationResponse>, tonic::Status> {
-        let station_id = request.get_ref().id;
+        let request_ref = request.get_ref();
+        let station_id = request_ref.id;
+        let transport_type = request_ref.transport_type.and_then(convert_transport_type);
 
-        let station = match self.query_use_case.find_station_by_id(station_id).await {
+        let station = match self
+            .query_use_case
+            .find_station_by_id(station_id, transport_type)
+            .await
+        {
             Ok(Some(station)) => station,
             Ok(None) => {
                 return Err(PresentationalError::NotFound(format!(
@@ -67,11 +73,13 @@ impl StationApi for MyApi {
         &self,
         request: tonic::Request<GetStationByIdListRequest>,
     ) -> Result<tonic::Response<MultipleStationResponse>, tonic::Status> {
-        let station_ids = &request.get_ref().ids;
+        let request_ref = request.get_ref();
+        let station_ids = &request_ref.ids;
+        let transport_type = request_ref.transport_type.and_then(convert_transport_type);
 
         let stations = match self
             .query_use_case
-            .get_stations_by_id_vec(station_ids)
+            .get_stations_by_id_vec(station_ids, transport_type)
             .await
         {
             Ok(stations) => stations,
@@ -89,9 +97,15 @@ impl StationApi for MyApi {
         &self,
         request: tonic::Request<GetStationByGroupIdRequest>,
     ) -> Result<tonic::Response<MultipleStationResponse>, tonic::Status> {
-        let group_id = request.get_ref().group_id;
+        let request_ref = request.get_ref();
+        let group_id = request_ref.group_id;
+        let transport_type = request_ref.transport_type.and_then(convert_transport_type);
 
-        match self.query_use_case.get_stations_by_group_id(group_id).await {
+        match self
+            .query_use_case
+            .get_stations_by_group_id(group_id, transport_type)
+            .await
+        {
             Ok(stations) => {
                 return Ok(Response::new(MultipleStationResponse {
                     stations: stations.into_iter().map(|station| station.into()).collect(),
@@ -126,13 +140,15 @@ impl StationApi for MyApi {
         &self,
         request: tonic::Request<GetStationByLineIdRequest>,
     ) -> Result<tonic::Response<MultipleStationResponse>, tonic::Status> {
-        let line_id = request.get_ref().line_id;
-        let station_id = request.get_ref().station_id;
-        let direction_id = request.get_ref().direction_id;
+        let request_ref = request.get_ref();
+        let line_id = request_ref.line_id;
+        let station_id = request_ref.station_id;
+        let direction_id = request_ref.direction_id;
+        let transport_type = request_ref.transport_type.and_then(convert_transport_type);
 
         match self
             .query_use_case
-            .get_stations_by_line_id(line_id, station_id, direction_id)
+            .get_stations_by_line_id(line_id, station_id, direction_id, transport_type)
             .await
         {
             Ok(stations) => {
@@ -177,10 +193,11 @@ impl StationApi for MyApi {
     ) -> Result<tonic::Response<MultipleStationResponse>, tonic::Status> {
         let request_ref = request.get_ref();
         let query_line_group_id = request_ref.line_group_id;
+        let transport_type = request_ref.transport_type.and_then(convert_transport_type);
 
         match self
             .query_use_case
-            .get_stations_by_line_group_id(query_line_group_id)
+            .get_stations_by_line_group_id(query_line_group_id, transport_type)
             .await
         {
             Ok(stations) => {
@@ -532,6 +549,7 @@ mod tests {
         async fn find_station_by_id(
             &self,
             _station_id: u32,
+            _transport_type: Option<TransportType>,
         ) -> Result<Option<Station>, UseCaseError> {
             Ok(None)
         }
@@ -539,6 +557,7 @@ mod tests {
         async fn get_stations_by_id_vec(
             &self,
             _station_ids: &[u32],
+            _transport_type: Option<TransportType>,
         ) -> Result<Vec<Station>, UseCaseError> {
             Ok(vec![])
         }
@@ -546,6 +565,7 @@ mod tests {
         async fn get_stations_by_group_id(
             &self,
             _station_group_id: u32,
+            _transport_type: Option<TransportType>,
         ) -> Result<Vec<Station>, UseCaseError> {
             Ok(vec![])
         }
@@ -584,6 +604,7 @@ mod tests {
             _line_id: u32,
             _station_id: Option<u32>,
             _direction_id: Option<u32>,
+            _transport_type: Option<TransportType>,
         ) -> Result<Vec<Station>, UseCaseError> {
             Ok(vec![])
         }
@@ -689,6 +710,7 @@ mod tests {
         async fn get_stations_by_line_group_id(
             &self,
             _line_group_id: u32,
+            _transport_type: Option<TransportType>,
         ) -> Result<Vec<Station>, UseCaseError> {
             Ok(vec![])
         }

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -931,10 +931,7 @@ where
             line.line_symbols = self.get_line_symbols(line);
 
             // Find the matching bus stop for this line and embed it
-            if let Some(bus_stop) = nearby_bus_stops
-                .iter()
-                .find(|s| s.line_cd == line.line_cd)
-            {
+            if let Some(bus_stop) = nearby_bus_stops.iter().find(|s| s.line_cd == line.line_cd) {
                 let mut station_copy = bus_stop.clone();
                 station_copy.station_numbers = self.get_station_numbers(&station_copy);
                 line.station = Some(station_copy);

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -273,8 +273,8 @@ where
 
             // For rail stations, add nearby bus routes to lines array
             // Only add bus routes if transport_type is not specified or is not Bus-only
-            let should_include_bus_routes = transport_type.is_none()
-                || transport_type == Some(TransportType::Rail);
+            let should_include_bus_routes =
+                transport_type.is_none() || transport_type == Some(TransportType::Rail);
             if station.transport_type == TransportType::Rail && should_include_bus_routes {
                 let nearby_bus_lines = self.get_nearby_bus_lines(station.lat, station.lon).await?;
                 for bus_line in nearby_bus_lines {

--- a/stationapi/src/use_case/traits/query.rs
+++ b/stationapi/src/use_case/traits/query.rs
@@ -59,6 +59,7 @@ pub trait QueryUseCase: Send + Sync + 'static {
         &self,
         stations: Vec<Station>,
         line_group_id: Option<u32>,
+        transport_type: Option<TransportType>,
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_lines_by_station_group_id(
         &self,

--- a/stationapi/src/use_case/traits/query.rs
+++ b/stationapi/src/use_case/traits/query.rs
@@ -11,14 +11,20 @@ use crate::{
 
 #[async_trait]
 pub trait QueryUseCase: Send + Sync + 'static {
-    async fn find_station_by_id(&self, station_id: u32) -> Result<Option<Station>, UseCaseError>;
+    async fn find_station_by_id(
+        &self,
+        station_id: u32,
+        transport_type: Option<TransportType>,
+    ) -> Result<Option<Station>, UseCaseError>;
     async fn get_stations_by_id_vec(
         &self,
         station_ids: &[u32],
+        transport_type: Option<TransportType>,
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_stations_by_group_id(
         &self,
         station_group_id: u32,
+        transport_type: Option<TransportType>,
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_stations_by_group_id_vec(
         &self,
@@ -36,6 +42,7 @@ pub trait QueryUseCase: Send + Sync + 'static {
         line_id: u32,
         station_id: Option<u32>,
         direction_id: Option<u32>,
+        transport_type: Option<TransportType>,
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_stations_by_name(
         &self,
@@ -67,6 +74,7 @@ pub trait QueryUseCase: Send + Sync + 'static {
     async fn get_stations_by_line_group_id(
         &self,
         line_group_id: u32,
+        transport_type: Option<TransportType>,
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_train_types_by_station_id(
         &self,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 駅関連APIで transport_type を指定可能に（Unspecified/Rail/Bus）。駅検索で電車のみ／バス停のみ／両方を選択できます。
  * 指定駅の位置を基準に半径300m以内のバス停を自動検出して結果に含める近接バス停機能を追加。

* **Documentation**
  * 近くのバス停検索の仕様、利用例、挙動（300m、候補上限など）をまとめたドキュメントを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->