### PR TITLE
transport_typeの不具合修正

### DIFF
--- a/stationapi/src/domain/entity/gtfs.rs
+++ b/stationapi/src/domain/entity/gtfs.rs
@@ -437,7 +437,7 @@ impl GtfsFeedInfo {
     }
 }
 
-/// Transport type enum for distinguishing rail and bus
+/// Transport type enum for distinguishing rail and bus (stored in database)
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[repr(i32)]
 pub enum TransportType {
@@ -453,6 +453,15 @@ impl From<i32> for TransportType {
             _ => TransportType::Rail,
         }
     }
+}
+
+/// Transport type filter for API requests
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum TransportTypeFilter {
+    #[default]
+    Rail,
+    Bus,
+    RailAndBus,
 }
 
 #[cfg(test)]

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -366,11 +366,7 @@ where
             .await?;
 
         let stations = self
-            .update_station_vec_with_attributes(
-                stations,
-                Some(line_group_id),
-                transport_type,
-            )
+            .update_station_vec_with_attributes(stations, Some(line_group_id), transport_type)
             .await?;
 
         Ok(stations)

--- a/stationapi/src/use_case/traits/query.rs
+++ b/stationapi/src/use_case/traits/query.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use crate::{
     domain::entity::{
-        company::Company, gtfs::TransportType, line::Line, line_symbol::LineSymbol,
+        company::Company, gtfs::TransportTypeFilter, line::Line, line_symbol::LineSymbol,
         station::Station, station_number::StationNumber, train_type::TrainType,
     },
     proto::{Route, RouteMinimalResponse},
@@ -14,17 +14,17 @@ pub trait QueryUseCase: Send + Sync + 'static {
     async fn find_station_by_id(
         &self,
         station_id: u32,
-        transport_type: Option<TransportType>,
+        transport_type: TransportTypeFilter,
     ) -> Result<Option<Station>, UseCaseError>;
     async fn get_stations_by_id_vec(
         &self,
         station_ids: &[u32],
-        transport_type: Option<TransportType>,
+        transport_type: TransportTypeFilter,
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_stations_by_group_id(
         &self,
         station_group_id: u32,
-        transport_type: Option<TransportType>,
+        transport_type: TransportTypeFilter,
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_stations_by_group_id_vec(
         &self,
@@ -35,21 +35,21 @@ pub trait QueryUseCase: Send + Sync + 'static {
         latitude: f64,
         longitude: f64,
         limit: Option<u32>,
-        transport_type: Option<TransportType>,
+        transport_type: TransportTypeFilter,
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_stations_by_line_id(
         &self,
         line_id: u32,
         station_id: Option<u32>,
         direction_id: Option<u32>,
-        transport_type: Option<TransportType>,
+        transport_type: TransportTypeFilter,
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_stations_by_name(
         &self,
         station_name: String,
         limit: Option<u32>,
         from_station_group_id: Option<u32>,
-        transport_type: Option<TransportType>,
+        transport_type: TransportTypeFilter,
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn find_company_by_id_vec(
         &self,
@@ -59,7 +59,7 @@ pub trait QueryUseCase: Send + Sync + 'static {
         &self,
         stations: Vec<Station>,
         line_group_id: Option<u32>,
-        transport_type: Option<TransportType>,
+        transport_type: TransportTypeFilter,
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_lines_by_station_group_id(
         &self,
@@ -75,7 +75,7 @@ pub trait QueryUseCase: Send + Sync + 'static {
     async fn get_stations_by_line_group_id(
         &self,
         line_group_id: u32,
-        transport_type: Option<TransportType>,
+        transport_type: TransportTypeFilter,
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_train_types_by_station_id(
         &self,


### PR DESCRIPTION
transport_typeを指定しなくても勝手にバスの乗換情報が返されていた

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 運行形態フィルタリング機能を新しい専用フィルタータイプ（鉄道、バス、鉄道とバス）に統一化し、APIリクエストでのフィルタリング処理を標準化しました。デフォルトは鉄道に設定されます。

* **Tests**
  * 新しいフィルタリング動作を網羅するテストカバレッジを拡張しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->