### PR TITLE
インポートが全て終わった後にANALYZEを実行するように修正

### DIFF
--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -324,8 +324,6 @@ pub async fn import_gtfs() -> Result<(), Box<dyn std::error::Error>> {
     // Import feed_info
     import_gtfs_feed_info(&mut tx, gtfs_path).await?;
 
-    sqlx::query("ANALYZE;").execute(&mut *tx).await?;
-
     // Commit transaction - all changes are now permanent
     tx.commit().await?;
 

--- a/stationapi/src/main.rs
+++ b/stationapi/src/main.rs
@@ -91,6 +91,21 @@ async fn run() -> std::result::Result<(), anyhow::Error> {
             return;
         }
 
+        // Run ANALYZE after all GTFS imports are complete
+        let db_url = fetch_database_url();
+        match sqlx::PgConnection::connect(&db_url).await {
+            Ok(mut conn) => {
+                if let Err(e) = sqlx::query("ANALYZE;").execute(&mut conn).await {
+                    warn!("Failed to run ANALYZE: {}", e);
+                } else {
+                    info!("ANALYZE completed after GTFS import.");
+                }
+            }
+            Err(e) => {
+                warn!("Failed to connect for ANALYZE: {}", e);
+            }
+        }
+
         info!("GTFS import completed in background.");
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * GTFS インポート後のデータベース統計更新をインポート処理の外で別途実行するように変更しました。インポート完了後に最適化が行われ、クエリ性能の安定化が期待できます。
* **Tests**
  * 翻訳処理、日付/時刻解析、文字変換、ハッシュ、SQL エスケープ等を含むテストを大幅に拡充しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->