### PR TITLE
direction_idがNULLのトリップに存在するバス停も正しく取り込むよう修正

### DIFF
--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -1636,7 +1636,6 @@ async fn build_stop_route_mapping(
                )
            ),
            -- Find variant-only stops (not on main trip) with their neighbor info
-           -- Exclude stops that ONLY appear on NULL direction_id trips (loop routes)
            variant_only_with_neighbors AS (
                SELECT DISTINCT ON (vts.parent_stop_id, vts.route_id)
                    vts.parent_stop_id,
@@ -1649,15 +1648,6 @@ async fn build_stop_route_mapping(
                    SELECT 1 FROM main_trip_stops mts
                    WHERE mts.parent_stop_id = vts.parent_stop_id
                      AND mts.route_id = vts.route_id
-               )
-               -- Only include stops that appear on at least one non-NULL direction_id trip
-               AND EXISTS (
-                   SELECT 1 FROM gtfs_trips gt2
-                   JOIN gtfs_stop_times gst2 ON gt2.trip_id = gst2.trip_id
-                   JOIN gtfs_stops gs2 ON gst2.stop_id = gs2.stop_id
-                   WHERE gt2.route_id = vts.route_id
-                     AND COALESCE(gs2.parent_station, gs2.stop_id) = vts.parent_stop_id
-                     AND gt2.direction_id IS NOT NULL
                )
                ORDER BY vts.parent_stop_id, vts.route_id, vts.stop_sequence
            ),

--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -1636,6 +1636,7 @@ async fn build_stop_route_mapping(
                )
            ),
            -- Find variant-only stops (not on main trip) with their neighbor info
+           -- Prioritize records where neighbors exist on main trip for better position estimation
            variant_only_with_neighbors AS (
                SELECT DISTINCT ON (vts.parent_stop_id, vts.route_id)
                    vts.parent_stop_id,
@@ -1644,12 +1645,25 @@ async fn build_stop_route_mapping(
                    vts.prev_stop_id,
                    vts.next_stop_id
                FROM variant_trip_stops_with_neighbors vts
+               LEFT JOIN main_trip_stops mts_prev
+                   ON vts.prev_stop_id = mts_prev.parent_stop_id
+                   AND vts.route_id = mts_prev.route_id
+               LEFT JOIN main_trip_stops mts_next
+                   ON vts.next_stop_id = mts_next.parent_stop_id
+                   AND vts.route_id = mts_next.route_id
                WHERE NOT EXISTS (
                    SELECT 1 FROM main_trip_stops mts
                    WHERE mts.parent_stop_id = vts.parent_stop_id
                      AND mts.route_id = vts.route_id
                )
-               ORDER BY vts.parent_stop_id, vts.route_id, vts.stop_sequence
+               ORDER BY vts.parent_stop_id, vts.route_id,
+                        -- Prioritize records where neighbors exist on main trip
+                        CASE
+                            WHEN mts_prev.parent_stop_id IS NOT NULL AND mts_next.parent_stop_id IS NOT NULL THEN 0
+                            WHEN mts_prev.parent_stop_id IS NOT NULL OR mts_next.parent_stop_id IS NOT NULL THEN 1
+                            ELSE 2
+                        END,
+                        vts.stop_sequence
            ),
            -- Recursive CTE to find the nearest main-trip stop by following prev chain
            prev_chain AS (


### PR DESCRIPTION
GTFSの仕様ではdirection_idはオプショナルであり、NULLの場合でも
バス停は有効な停留所として扱うべきである。

これまではvariant_only_with_neighbors CTEで「direction_id IS NOT NULL」
のトリップにのみ存在するバス停をフィルタリングしていたため、
早81の原宿駅前や渋谷駅東口などのバス停がレスポンスから除外されていた。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ルート変種に属する停留所の取扱いを改善しました。これまではある方向IDに紐づかない停留所が除外されるケースがありましたが、今回の修正でそうした停留所も適切に考慮され、隣接する停留所情報がある場合は優先的に配置されるようになり、ルート表現の一貫性と完全性が向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->