### PR TITLE
RailAndBusが指定された場合はSQLレベルでRailを先頭にソート

### DIFF
--- a/stationapi/src/infrastructure/station_repository.rs
+++ b/stationapi/src/infrastructure/station_repository.rs
@@ -984,7 +984,9 @@ impl InternalStationRepository {
                 ON a.id = la.alias_cd
                 WHERE s.e_status = 0
                 AND ($4::int IS NULL OR COALESCE(s.transport_type, 0) = $4)
-                ORDER BY point(s.lat, s.lon) <-> point($1, $2)
+                ORDER BY
+                    CASE WHEN $4 IS NULL THEN COALESCE(s.transport_type, 0) ELSE 0 END,
+                    point(s.lat, s.lon) <-> point($1, $2)
                 LIMIT $3"#,
         )
         .bind(latitude)

--- a/stationapi/src/presentation/controller/grpc.rs
+++ b/stationapi/src/presentation/controller/grpc.rs
@@ -1,5 +1,5 @@
 use crate::{
-    domain::entity::gtfs::{TransportType, TransportTypeFilter},
+    domain::entity::gtfs::TransportTypeFilter,
     infrastructure::{
         company_repository::MyCompanyRepository, line_repository::MyLineRepository,
         station_repository::MyStationRepository, train_type_repository::MyTrainTypeRepository,
@@ -123,7 +123,7 @@ impl StationApi for MyApi {
         let longitude = request_ref.longitude;
         let limit = request_ref.limit;
         let transport_type = convert_transport_type(request_ref.transport_type);
-        let mut stations = match self
+        let stations = match self
             .query_use_case
             .get_stations_by_coordinates(latitude, longitude, limit, transport_type)
             .await
@@ -131,15 +131,6 @@ impl StationApi for MyApi {
             Ok(stations) => stations,
             Err(err) => return Err(PresentationalError::from(err).into()),
         };
-
-        // RailAndBusが指定された場合は、Railを先頭にソート（stable sortで距離順を維持）
-        if transport_type == TransportTypeFilter::RailAndBus {
-            stations.sort_by(|a, b| match (a.transport_type, b.transport_type) {
-                (TransportType::Rail, TransportType::Bus) => std::cmp::Ordering::Less,
-                (TransportType::Bus, TransportType::Rail) => std::cmp::Ordering::Greater,
-                _ => std::cmp::Ordering::Equal,
-            });
-        }
 
         Ok(tonic::Response::new(MultipleStationResponse {
             stations: stations.into_iter().map(|station| station.into()).collect(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 座標検索による駅検索結果の表示順序ロジックを最適化しました。
  * 交通機関タイプに基づくフィルタリング処理の動作を改善し、より正確な検索結果の並び替えを実現しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->