### PR TITLE
バス経路に時刻表ベースのstop_conditionフィルタリングを追加

### DIFF
--- a/data/create_table.sql
+++ b/data/create_table.sql
@@ -605,6 +605,22 @@ END $$;
 CREATE INDEX IF NOT EXISTS idx_stations_transport_type ON public.stations USING btree (transport_type);
 CREATE INDEX IF NOT EXISTS idx_lines_transport_type ON public.lines USING btree (transport_type);
 
+--
+-- Add gtfs_stop_id to stations table for bus timetable filtering
+--
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'stations' AND column_name = 'gtfs_stop_id'
+    ) THEN
+        ALTER TABLE public.stations ADD COLUMN gtfs_stop_id TEXT;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_stations_gtfs_stop_id ON public.stations USING btree (gtfs_stop_id);
+
 -- ============================================================
 -- GTFS Tables
 -- ============================================================

--- a/stationapi/src/domain/repository/station_repository.rs
+++ b/stationapi/src/domain/repository/station_repository.rs
@@ -434,6 +434,7 @@ mod tests {
             None,
             None,
             None,
+            None, // kind
             TransportType::Bus,
         )
     }
@@ -526,7 +527,7 @@ mod tests {
     async fn test_get_by_line_group_id() {
         let repo = MockStationRepository::new();
         let result = repo.get_by_line_group_id(1000).await.unwrap();
-        assert_eq!(result.len(), 4); // すべての駅がline_group_cd = 1000に設定されている
+        assert_eq!(result.len(), 6); // すべての駅・バス停がline_group_cd = 1000に設定されている
     }
 
     #[tokio::test]

--- a/stationapi/src/domain/repository/station_repository.rs
+++ b/stationapi/src/domain/repository/station_repository.rs
@@ -88,8 +88,10 @@ mod tests {
             stations.insert(4, station4);
 
             // Add bus stops for testing
-            let bus_stop1 = create_test_bus_stop(100, "新宿駅前バス停", 2001, 35.690500, 139.700100);
-            let bus_stop2 = create_test_bus_stop(101, "渋谷駅前バス停", 2001, 35.659200, 139.700200);
+            let bus_stop1 =
+                create_test_bus_stop(100, "新宿駅前バス停", 2001, 35.690500, 139.700100);
+            let bus_stop2 =
+                create_test_bus_stop(101, "渋谷駅前バス停", 2001, 35.659200, 139.700200);
             stations.insert(100, bus_stop1);
             stations.insert(101, bus_stop2);
 

--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -1906,10 +1906,10 @@ async fn integrate_gtfs_stops_to_stations(
                     station_cd, station_g_cd, station_name, station_name_k,
                     station_name_r, station_name_zh, station_name_ko,
                     line_cd, pref_cd, post, address, lon, lat,
-                    open_ymd, close_ymd, e_status, e_sort, transport_type
+                    open_ymd, close_ymd, e_status, e_sort, transport_type, gtfs_stop_id
                 ) VALUES (
                     $1, $2, $3, $4, $5, $6, $7, $8, 13, '', '', $9, $10,
-                    '', '', 0, $11, 1
+                    '', '', 0, $11, 1, $12
                 )
                 ON CONFLICT (station_cd) DO NOTHING"#,
             )
@@ -1929,6 +1929,7 @@ async fn integrate_gtfs_stops_to_stations(
             .bind(stop.stop_lon)
             .bind(stop.stop_lat)
             .bind(stop_sequence)
+            .bind(&stop.stop_id)
             .execute(&mut *conn)
             .await?;
 

--- a/stationapi/src/infrastructure/station_repository.rs
+++ b/stationapi/src/infrastructure/station_repository.rs
@@ -1638,6 +1638,14 @@ impl InternalStationRepository {
             station_cd: Option<i32>,
         }
 
+        tracing::debug!(
+            "get_active_bus_stop_station_cds: date={}, start_time={}, end_time={}, station_cds_count={}",
+            current_date_jst,
+            start_time,
+            end_time,
+            station_cds.len()
+        );
+
         let rows: Vec<StationCdRow> = sqlx::query_as(&query)
             .bind(date)
             .bind(&start_time)
@@ -1645,6 +1653,11 @@ impl InternalStationRepository {
             .bind(station_cds)
             .fetch_all(conn)
             .await?;
+
+        tracing::debug!(
+            "get_active_bus_stop_station_cds: found {} active bus stops",
+            rows.len()
+        );
 
         let result: std::collections::HashSet<i32> =
             rows.into_iter().filter_map(|r| r.station_cd).collect();

--- a/stationapi/src/infrastructure/station_repository.rs
+++ b/stationapi/src/infrastructure/station_repository.rs
@@ -1571,32 +1571,16 @@ impl InternalStationRepository {
 
         // Calculate time window (±30 minutes)
         let time_parts: Vec<&str> = current_time_jst.split(':').collect();
-        let hours: i32 = time_parts
-            .first()
-            .unwrap_or(&"0")
-            .parse()
-            .unwrap_or(0);
-        let minutes: i32 = time_parts
-            .get(1)
-            .unwrap_or(&"0")
-            .parse()
-            .unwrap_or(0);
+        let hours: i32 = time_parts.first().unwrap_or(&"0").parse().unwrap_or(0);
+        let minutes: i32 = time_parts.get(1).unwrap_or(&"0").parse().unwrap_or(0);
 
         // Calculate start and end times for the 30-minute window
         let total_minutes = hours * 60 + minutes;
         let start_minutes = (total_minutes - 30).max(0);
         let end_minutes = total_minutes + 30;
 
-        let start_time = format!(
-            "{:02}:{:02}:00",
-            start_minutes / 60,
-            start_minutes % 60
-        );
-        let end_time = format!(
-            "{:02}:{:02}:00",
-            end_minutes / 60,
-            end_minutes % 60
-        );
+        let start_time = format!("{:02}:{:02}:00", start_minutes / 60, start_minutes % 60);
+        let end_time = format!("{:02}:{:02}:00", end_minutes / 60, end_minutes % 60);
 
         // Query to find active bus stops:
         // 1. Find service_ids that are active today based on gtfs_calendar and gtfs_calendar_dates
@@ -1655,10 +1639,8 @@ impl InternalStationRepository {
             .fetch_all(conn)
             .await?;
 
-        let result: std::collections::HashSet<i32> = rows
-            .into_iter()
-            .filter_map(|r| r.station_cd)
-            .collect();
+        let result: std::collections::HashSet<i32> =
+            rows.into_iter().filter_map(|r| r.station_cd).collect();
 
         Ok(result)
     }

--- a/stationapi/src/infrastructure/station_repository.rs
+++ b/stationapi/src/infrastructure/station_repository.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use chrono::Datelike;
 use sqlx::{PgConnection, Pool, Postgres};
 use std::sync::Arc;
 

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -6,8 +6,8 @@ const NEARBY_BUS_STOP_RADIUS_METERS: f64 = 300.0;
 /// Get current JST (Japan Standard Time) as date and time strings.
 /// Returns (date_string in YYYYMMDD format, time_string in HH:MM:SS format)
 fn get_current_jst() -> (String, String) {
-    use chrono::{Duration, Utc};
-    let jst_now = Utc::now() + Duration::hours(9);
+    use chrono::{TimeDelta, Utc};
+    let jst_now = Utc::now() + TimeDelta::hours(9);
     let date_str = jst_now.format("%Y%m%d").to_string();
     let time_str = jst_now.format("%H:%M:%S").to_string();
     (date_str, time_str)

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -318,12 +318,24 @@ where
         // Get active bus stops based on current JST time
         let active_bus_stops = if !bus_station_cds.is_empty() {
             let (current_date, current_time) = get_current_jst();
+            tracing::debug!(
+                "update_station_vec_with_attributes: bus_station_cds.len()={}, date={}, time={}",
+                bus_station_cds.len(),
+                current_date,
+                current_time
+            );
             match self
                 .station_repository
                 .get_active_bus_stop_station_cds(&bus_station_cds, &current_time, &current_date)
                 .await
             {
-                Ok(stops) => stops,
+                Ok(stops) => {
+                    tracing::debug!(
+                        "update_station_vec_with_attributes: active_bus_stops.len()={}",
+                        stops.len()
+                    );
+                    stops
+                }
                 Err(e) => {
                     tracing::warn!(
                         "Failed to get active bus stop station_cds: {}. Using empty set as fallback.",

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -407,6 +407,12 @@ where
                     {
                         station_copy.train_type = Some(tt);
                     };
+                    // Apply bus timetable filtering to nested station copy
+                    if station_copy.transport_type == TransportType::Bus
+                        && !active_bus_stops.contains(&station_copy.station_cd)
+                    {
+                        station_copy.stop_condition = crate::proto::StopCondition::Not;
+                    }
                     line.station = Some(station_copy);
                 }
             }

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -354,6 +354,22 @@ where
             HashSet::new()
         };
 
+        // Debug: log sample station_cds for comparison
+        if !active_bus_stops.is_empty() {
+            let sample_active: Vec<_> = active_bus_stops.iter().take(5).collect();
+            let sample_stations: Vec<_> = stations
+                .iter()
+                .filter(|s| s.transport_type == TransportType::Bus)
+                .take(5)
+                .map(|s| s.station_cd)
+                .collect();
+            tracing::info!(
+                "active_bus_stops sample: {:?}, stations sample: {:?}",
+                sample_active,
+                sample_stations
+            );
+        }
+
         for station in stations.iter_mut() {
             // Apply bus timetable filtering: set stop_condition to Not for inactive bus stops
             // Only apply if there are active bus stops (i.e., buses are running)

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -716,51 +716,51 @@ where
                 .map(|row| {
                     let extracted_line = self.extract_line_from_station(row);
 
-                    let mut proto_station: proto::Station =
-                        if let Some(tt_line) = tt_line_map.get(&row.line_cd).copied() {
-                            let train_type = match row.type_id.is_some() {
-                                true => {
-                                    // Filter lines to only include those with matching line_group_cd
-                                    // and remove duplicates by line_cd
-                                    let mut seen_line_cds = std::collections::HashSet::new();
-                                    let filtered_lines: Vec<Line> = tt_lines
-                                        .iter()
-                                        .filter(|line| {
-                                            row.line_group_cd.is_some()
-                                                && line.line_group_cd == row.line_group_cd
-                                                && seen_line_cds.insert(line.line_cd)
-                                        })
-                                        .cloned()
-                                        .collect();
+                    let mut proto_station: proto::Station = if let Some(tt_line) =
+                        tt_line_map.get(&row.line_cd).copied()
+                    {
+                        let train_type = match row.type_id.is_some() {
+                            true => {
+                                // Filter lines to only include those with matching line_group_cd
+                                // and remove duplicates by line_cd
+                                let mut seen_line_cds = std::collections::HashSet::new();
+                                let filtered_lines: Vec<Line> = tt_lines
+                                    .iter()
+                                    .filter(|line| {
+                                        row.line_group_cd.is_some()
+                                            && line.line_group_cd == row.line_group_cd
+                                            && seen_line_cds.insert(line.line_cd)
+                                    })
+                                    .cloned()
+                                    .collect();
 
-                                    Some(Box::new(TrainType {
-                                        id: row.type_id,
-                                        station_cd: Some(row.station_cd),
-                                        type_cd: row.type_cd,
-                                        line_group_cd: row.line_group_cd,
-                                        pass: row.pass,
-                                        type_name: row.type_name.clone().unwrap_or_default(),
-                                        type_name_k: row.type_name_k.clone().unwrap_or_default(),
-                                        type_name_r: row.type_name_r.clone(),
-                                        type_name_zh: row.type_name_zh.clone(),
-                                        type_name_ko: row.type_name_ko.clone(),
-                                        color: row.color.clone().unwrap_or_default(),
-                                        direction: row.direction,
-                                        kind: row.kind,
-                                        line: Some(Box::new(tt_line.clone())),
-                                        lines: filtered_lines,
-                                    }))
-                                }
-                                false => None,
-                            };
-
-                            let stop =
-                                self.build_station_from_row(row, &extracted_line, train_type);
-                            stop.into()
-                        } else {
-                            let stop = self.build_station_from_row(row, &extracted_line, None);
-                            stop.into()
+                                Some(Box::new(TrainType {
+                                    id: row.type_id,
+                                    station_cd: Some(row.station_cd),
+                                    type_cd: row.type_cd,
+                                    line_group_cd: row.line_group_cd,
+                                    pass: row.pass,
+                                    type_name: row.type_name.clone().unwrap_or_default(),
+                                    type_name_k: row.type_name_k.clone().unwrap_or_default(),
+                                    type_name_r: row.type_name_r.clone(),
+                                    type_name_zh: row.type_name_zh.clone(),
+                                    type_name_ko: row.type_name_ko.clone(),
+                                    color: row.color.clone().unwrap_or_default(),
+                                    direction: row.direction,
+                                    kind: row.kind,
+                                    line: Some(Box::new(tt_line.clone())),
+                                    lines: filtered_lines,
+                                }))
+                            }
+                            false => None,
                         };
+
+                        let stop = self.build_station_from_row(row, &extracted_line, train_type);
+                        stop.into()
+                    } else {
+                        let stop = self.build_station_from_row(row, &extracted_line, None);
+                        stop.into()
+                    };
 
                     // Apply bus timetable filtering: set stop_condition to Not for inactive bus stops
                     if row.transport_type == TransportType::Bus

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -6,8 +6,9 @@ const NEARBY_BUS_STOP_RADIUS_METERS: f64 = 300.0;
 /// Get current JST (Japan Standard Time) as date and time strings.
 /// Returns (date_string in YYYYMMDD format, time_string in HH:MM:SS format)
 fn get_current_jst() -> (String, String) {
-    use chrono::{TimeDelta, Utc};
-    let jst_now = Utc::now() + TimeDelta::hours(9);
+    use chrono::{FixedOffset, Utc};
+    let jst_offset = FixedOffset::east_opt(9 * 3600).expect("JST offset is valid");
+    let jst_now = Utc::now().with_timezone(&jst_offset);
     let date_str = jst_now.format("%Y%m%d").to_string();
     let time_str = jst_now.format("%H:%M:%S").to_string();
     (date_str, time_str)

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -338,7 +338,9 @@ where
 
         for station in stations.iter_mut() {
             // Apply bus timetable filtering: set stop_condition to Not for inactive bus stops
-            if station.transport_type == TransportType::Bus
+            // Only apply if there are active bus stops (i.e., buses are running)
+            if !active_bus_stops.is_empty()
+                && station.transport_type == TransportType::Bus
                 && !active_bus_stops.contains(&station.station_cd)
             {
                 station.stop_condition = crate::proto::StopCondition::Not;
@@ -379,9 +381,12 @@ where
                     for mut bus_line in nearby_bus_lines {
                         if seen_line_cds.insert(bus_line.line_cd) {
                             // Apply bus timetable filtering to nearby bus stops
-                            if let Some(ref mut bus_stop) = bus_line.station {
-                                if !active_bus_stops.contains(&bus_stop.station_cd) {
-                                    bus_stop.stop_condition = crate::proto::StopCondition::Not;
+                            // Only apply if there are active bus stops (i.e., buses are running)
+                            if !active_bus_stops.is_empty() {
+                                if let Some(ref mut bus_stop) = bus_line.station {
+                                    if !active_bus_stops.contains(&bus_stop.station_cd) {
+                                        bus_stop.stop_condition = crate::proto::StopCondition::Not;
+                                    }
                                 }
                             }
                             lines.push(bus_line);
@@ -408,7 +413,9 @@ where
                         station_copy.train_type = Some(tt);
                     };
                     // Apply bus timetable filtering to nested station copy
-                    if station_copy.transport_type == TransportType::Bus
+                    // Only apply if there are active bus stops (i.e., buses are running)
+                    if !active_bus_stops.is_empty()
+                        && station_copy.transport_type == TransportType::Bus
                         && !active_bus_stops.contains(&station_copy.station_cd)
                     {
                         station_copy.stop_condition = crate::proto::StopCondition::Not;
@@ -790,7 +797,9 @@ where
                     };
 
                     // Apply bus timetable filtering: set stop_condition to Not for inactive bus stops
-                    if row.transport_type == TransportType::Bus
+                    // Only apply if there are active bus stops (i.e., buses are running)
+                    if !active_bus_stops.is_empty()
+                        && row.transport_type == TransportType::Bus
                         && !active_bus_stops.contains(&row.station_cd)
                     {
                         proto_station.stop_condition = proto::StopCondition::Not.into();
@@ -912,7 +921,9 @@ where
                         .collect();
 
                     // Determine stop_condition: for inactive bus stops, set to Not (1)
-                    let stop_condition: i32 = if row.transport_type == TransportType::Bus
+                    // Only apply if there are active bus stops (i.e., buses are running)
+                    let stop_condition: i32 = if !active_bus_stops.is_empty()
+                        && row.transport_type == TransportType::Bus
                         && !active_bus_stops.contains(&row.station_cd)
                     {
                         proto::StopCondition::Not.into()

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -316,11 +316,16 @@ where
         }
 
         // Get active bus stops based on current JST time
+        tracing::info!(
+            "update_station_vec_with_attributes: stations.len()={}, bus_station_cds.len()={}, transport_type={:?}",
+            stations.len(),
+            bus_station_cds.len(),
+            transport_type
+        );
         let active_bus_stops = if !bus_station_cds.is_empty() {
             let (current_date, current_time) = get_current_jst();
-            tracing::debug!(
-                "update_station_vec_with_attributes: bus_station_cds.len()={}, date={}, time={}",
-                bus_station_cds.len(),
+            tracing::info!(
+                "update_station_vec_with_attributes: calling get_active_bus_stop_station_cds with date={}, time={}",
                 current_date,
                 current_time
             );
@@ -330,7 +335,7 @@ where
                 .await
             {
                 Ok(stops) => {
-                    tracing::debug!(
+                    tracing::info!(
                         "update_station_vec_with_attributes: active_bus_stops.len()={}",
                         stops.len()
                     );
@@ -345,6 +350,7 @@ where
                 }
             }
         } else {
+            tracing::info!("update_station_vec_with_attributes: bus_station_cds is empty, skipping filtering");
             HashSet::new()
         };
 

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -317,10 +317,20 @@ where
         // Get active bus stops based on current JST time
         let active_bus_stops = if !bus_station_cds.is_empty() {
             let (current_date, current_time) = get_current_jst();
-            self.station_repository
+            match self
+                .station_repository
                 .get_active_bus_stop_station_cds(&bus_station_cds, &current_time, &current_date)
                 .await
-                .unwrap_or_default()
+            {
+                Ok(stops) => stops,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to get active bus stop station_cds: {}. Using empty set as fallback.",
+                        e
+                    );
+                    HashSet::new()
+                }
+            }
         } else {
             HashSet::new()
         };
@@ -681,10 +691,20 @@ where
         // Get active bus stops based on current JST time
         let active_bus_stops = if !bus_station_cds.is_empty() {
             let (current_date, current_time) = get_current_jst();
-            self.station_repository
+            match self
+                .station_repository
                 .get_active_bus_stop_station_cds(&bus_station_cds, &current_time, &current_date)
                 .await
-                .unwrap_or_default()
+            {
+                Ok(stops) => stops,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to get active bus stop station_cds: {}. Using empty set as fallback.",
+                        e
+                    );
+                    HashSet::new()
+                }
+            }
         } else {
             HashSet::new()
         };
@@ -812,10 +832,20 @@ where
         // Get active bus stops based on current JST time
         let active_bus_stops = if !bus_station_cds.is_empty() {
             let (current_date, current_time) = get_current_jst();
-            self.station_repository
+            match self
+                .station_repository
                 .get_active_bus_stop_station_cds(&bus_station_cds, &current_time, &current_date)
                 .await
-                .unwrap_or_default()
+            {
+                Ok(stops) => stops,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to get active bus stop station_cds: {}. Using empty set as fallback.",
+                        e
+                    );
+                    HashSet::new()
+                }
+            }
         } else {
             HashSet::new()
         };
@@ -875,12 +905,12 @@ where
                         .collect();
 
                     // Determine stop_condition: for inactive bus stops, set to Not (1)
-                    let stop_condition = if row.transport_type == TransportType::Bus
+                    let stop_condition: i32 = if row.transport_type == TransportType::Bus
                         && !active_bus_stops.contains(&row.station_cd)
                     {
-                        proto::StopCondition::Not as i32
+                        proto::StopCondition::Not.into()
                     } else {
-                        row.pass.unwrap_or(0)
+                        row.stop_condition.into()
                     };
 
                     proto::StationMinimal {


### PR DESCRIPTION
- get_routes/get_routes_minimalにバス時刻表フィルタリングを実装
- 現在のJST時刻で±30分以内に発車予定がないバス停は
  stop_condition=Notを返すように変更
- StationRepositoryにget_active_bus_stop_station_cdsメソッドを追加
- gtfs_calendar/gtfs_calendar_datesを使用して曜日別の
  サービス運行状況を考慮
- ユニットテストを追加（get_current_jst、バス停判定など）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * JST現在日時を用いて、指定した駅コード群から稼働中のバス停を判定・抽出するフィルタを追加（時刻窓±30分・曜日・カレンダー考慮）。駅情報更新・鉄道＋バス集約・経路生成で非稼働バス停を自動除外・状態反映。
  * GTFSの停留所IDを駅データに保存する仕組みと索引を追加し、取り込み処理で停留所IDを格納。

* **テスト**
  * 新フィルタ向けの単体・統合テストとモックを追加。時刻・曜日処理、混在入力、空入力、鉄道除外、関連処理への反映を検証。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->