### PR TITLE
GetStationsByLineGroupIdList RPC追加

### DIFF
--- a/stationapi/src/domain/repository/station_repository.rs
+++ b/stationapi/src/domain/repository/station_repository.rs
@@ -39,6 +39,10 @@ pub trait StationRepository: Send + Sync + 'static {
         transport_type: Option<TransportType>,
     ) -> Result<Vec<Station>, DomainError>;
     async fn get_by_line_group_id(&self, line_group_id: u32) -> Result<Vec<Station>, DomainError>;
+    async fn get_by_line_group_id_vec(
+        &self,
+        line_group_ids: &[u32],
+    ) -> Result<Vec<Station>, DomainError>;
     async fn get_route_stops(
         &self,
         from_station_id: u32,
@@ -214,6 +218,21 @@ mod tests {
                 .stations
                 .values()
                 .filter(|station| station.line_group_cd == Some(line_group_id as i32))
+                .cloned()
+                .collect();
+            Ok(result)
+        }
+
+        async fn get_by_line_group_id_vec(
+            &self,
+            line_group_ids: &[u32],
+        ) -> Result<Vec<Station>, DomainError> {
+            let result: Vec<Station> = self
+                .stations
+                .values()
+                .filter(|station| {
+                    line_group_ids.contains(&(station.line_group_cd.unwrap_or(0) as u32))
+                })
                 .cloned()
                 .collect();
             Ok(result)

--- a/stationapi/src/domain/repository/station_repository.rs
+++ b/stationapi/src/domain/repository/station_repository.rs
@@ -231,7 +231,10 @@ mod tests {
                 .stations
                 .values()
                 .filter(|station| {
-                    line_group_ids.contains(&(station.line_group_cd.unwrap_or(0) as u32))
+                    station
+                        .line_group_cd
+                        .map(|v| line_group_ids.contains(&(v as u32)))
+                        .unwrap_or(false)
                 })
                 .cloned()
                 .collect();

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -389,6 +389,27 @@ where
 
         Ok(stations)
     }
+    async fn get_stations_by_line_group_id_vec(
+        &self,
+        line_group_ids: &[u32],
+        transport_type: TransportTypeFilter,
+    ) -> Result<Vec<Station>, UseCaseError> {
+        let stations = self
+            .station_repository
+            .get_by_line_group_id_vec(line_group_ids)
+            .await?;
+
+        let stations: Vec<Station> = stations
+            .into_iter()
+            .filter(|s| matches_transport_filter(s.transport_type, transport_type))
+            .collect();
+
+        let stations = self
+            .update_station_vec_with_attributes(stations, None, transport_type)
+            .await?;
+
+        Ok(stations)
+    }
     fn get_station_numbers(&self, station: &Station) -> Vec<StationNumber> {
         let line_symbols_raw = [
             &station.line_symbol1,
@@ -1370,6 +1391,12 @@ mod tests {
             async fn get_by_line_group_id(&self, _: u32) -> Result<Vec<Station>, DomainError> {
                 Ok(vec![])
             }
+            async fn get_by_line_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
             async fn get_route_stops(
                 &self,
                 _: u32,
@@ -1760,6 +1787,12 @@ mod tests {
                 Ok(vec![])
             }
             async fn get_by_line_group_id(&self, _: u32) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
                 Ok(vec![])
             }
             async fn get_route_stops(

--- a/stationapi/src/use_case/traits/query.rs
+++ b/stationapi/src/use_case/traits/query.rs
@@ -82,6 +82,11 @@ pub trait QueryUseCase: Send + Sync + 'static {
         line_group_id: u32,
         transport_type: TransportTypeFilter,
     ) -> Result<Vec<Station>, UseCaseError>;
+    async fn get_stations_by_line_group_id_vec(
+        &self,
+        line_group_ids: &[u32],
+        transport_type: TransportTypeFilter,
+    ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_train_types_by_station_id(
         &self,
         station_id: u32,


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 複数の路線グループIDをまとめて指定し、一度に複数の駅情報を取得できる機能を追加しました。
  * 複数ID向けのAPIエンドポイント（一覧リクエスト）を追加し、一覧取得が可能になりました。
  * 一括取得に伴う属性付与やフィルタ処理を拡張し、既存のフィルタやレスポンス形式との整合性を維持します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->