### PR TITLE
ci: use pull_request_target to fix token permissions

### DIFF
--- a/.github/workflows/verify_data_Integrity.yml
+++ b/.github/workflows/verify_data_Integrity.yml
@@ -1,6 +1,6 @@
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     paths:
       - "data/*.csv"
   push:
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Run data validator
         id: validate
@@ -31,7 +33,7 @@ jobs:
           fi
 
       - name: Find existing comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: peter-evans/find-comment@v3
         id: find_comment
         with:
@@ -40,7 +42,7 @@ jobs:
           body-includes: "<!-- data-validator -->"
 
       - name: Post or update validation failure comment
-        if: github.event_name == 'pull_request' && steps.validate.outputs.result == 'failure'
+        if: github.event_name == 'pull_request_target' && steps.validate.outputs.result == 'failure'
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -49,7 +51,7 @@ jobs:
           edit-mode: replace
 
       - name: Delete comment if validation passed
-        if: github.event_name == 'pull_request' && steps.validate.outputs.result == 'success' && steps.find_comment.outputs.comment-id != ''
+        if: github.event_name == 'pull_request_target' && steps.validate.outputs.result == 'success' && steps.find_comment.outputs.comment-id != ''
         run: gh api repos/${{ github.repository }}/issues/comments/${{ steps.find_comment.outputs.comment-id }} -X DELETE
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/verify_data_Integrity.yml
+++ b/.github/workflows/verify_data_Integrity.yml
@@ -1,6 +1,6 @@
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     paths:
       - "data/*.csv"
   push:
@@ -11,8 +11,6 @@ name: Verify station data integrity
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   verify_migration_data:
@@ -20,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Run data validator
         id: validate
@@ -32,29 +28,22 @@ jobs:
             echo "result=failure" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Find existing comment
-        if: github.event_name == 'pull_request_target'
-        uses: peter-evans/find-comment@v3
-        id: find_comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: "<!-- data-validator -->"
+      - name: Save metadata for comment workflow
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          mkdir -p /tmp/validation-artifacts
+          echo "${{ github.event.pull_request.number }}" > /tmp/validation-artifacts/pr_number
+          echo "${{ steps.validate.outputs.result }}" > /tmp/validation-artifacts/result
+          if [ -f /tmp/validation_report.md ]; then
+            cp /tmp/validation_report.md /tmp/validation-artifacts/
+          fi
 
-      - name: Post or update validation failure comment
-        if: github.event_name == 'pull_request_target' && steps.validate.outputs.result == 'failure'
-        uses: peter-evans/create-or-update-comment@v4
+      - name: Upload validation artifacts
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-id: ${{ steps.find_comment.outputs.comment-id }}
-          body-path: /tmp/validation_report.md
-          edit-mode: replace
-
-      - name: Delete comment if validation passed
-        if: github.event_name == 'pull_request_target' && steps.validate.outputs.result == 'success' && steps.find_comment.outputs.comment-id != ''
-        run: gh api repos/${{ github.repository }}/issues/comments/${{ steps.find_comment.outputs.comment-id }} -X DELETE
-        env:
-          GH_TOKEN: ${{ github.token }}
+          name: validation-result
+          path: /tmp/validation-artifacts/
 
       - name: Fail job if validation failed
         if: steps.validate.outputs.result == 'failure'

--- a/.github/workflows/verify_data_integrity_comment.yml
+++ b/.github/workflows/verify_data_integrity_comment.yml
@@ -27,14 +27,19 @@ jobs:
       - name: Read metadata
         id: meta
         run: |
-          echo "pr_number=$(cat /tmp/validation-artifacts/pr_number)" >> "$GITHUB_OUTPUT"
-          echo "result=$(cat /tmp/validation-artifacts/result)" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${{ github.event.workflow_run.pull_requests[0].number }}" >> "$GITHUB_OUTPUT"
+          if [ -s /tmp/validation-artifacts/result ]; then
+            echo "result=$(cat /tmp/validation-artifacts/result)" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Missing or empty result metadata"
+            exit 1
+          fi
 
       - name: Find existing comment
         uses: peter-evans/find-comment@v3
         id: find_comment
         with:
-          issue-number: ${{ steps.meta.outputs.pr_number }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           comment-author: "github-actions[bot]"
           body-includes: "<!-- data-validator -->"
 
@@ -42,7 +47,7 @@ jobs:
         if: steps.meta.outputs.result == 'failure'
         uses: peter-evans/create-or-update-comment@v4
         with:
-          issue-number: ${{ steps.meta.outputs.pr_number }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           body-path: /tmp/validation-artifacts/validation_report.md
           edit-mode: replace

--- a/.github/workflows/verify_data_integrity_comment.yml
+++ b/.github/workflows/verify_data_integrity_comment.yml
@@ -1,0 +1,53 @@
+name: Post data validation comment
+
+on:
+  workflow_run:
+    workflows: ["Verify station data integrity"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  comment:
+    name: Post validation result comment
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: validation-result
+          path: /tmp/validation-artifacts
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Read metadata
+        id: meta
+        run: |
+          echo "pr_number=$(cat /tmp/validation-artifacts/pr_number)" >> "$GITHUB_OUTPUT"
+          echo "result=$(cat /tmp/validation-artifacts/result)" >> "$GITHUB_OUTPUT"
+
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v3
+        id: find_comment
+        with:
+          issue-number: ${{ steps.meta.outputs.pr_number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "<!-- data-validator -->"
+
+      - name: Post or update validation failure comment
+        if: steps.meta.outputs.result == 'failure'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ steps.meta.outputs.pr_number }}
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          body-path: /tmp/validation-artifacts/validation_report.md
+          edit-mode: replace
+
+      - name: Delete comment if validation passed
+        if: steps.meta.outputs.result == 'success' && steps.find_comment.outputs.comment-id != ''
+        run: gh api repos/${{ github.repository }}/issues/comments/${{ steps.find_comment.outputs.comment-id }} -X DELETE
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/verify_data_integrity_comment.yml
+++ b/.github/workflows/verify_data_integrity_comment.yml
@@ -6,6 +6,7 @@ on:
     types: [completed]
 
 permissions:
+  actions: read
   pull-requests: write
   issues: write
 

--- a/.github/workflows/visualize_stopping_patterns.yml
+++ b/.github/workflows/visualize_stopping_patterns.yml
@@ -1,15 +1,13 @@
 name: Visualize Stopping Patterns
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - "data/*.csv"
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   visualize:
@@ -18,7 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Fetch base branch
@@ -35,26 +32,19 @@ jobs:
           BASE_REF="origin/${{ github.event.pull_request.base.ref }}" \
             python3 .github/scripts/visualize_stopping_patterns.py
 
-      - name: Find existing comment
+      - name: Save metadata for comment workflow
         if: always()
-        uses: peter-evans/find-comment@v3
-        id: find_comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: "<!-- station-visualizer -->"
+        run: |
+          mkdir -p /tmp/visualize-artifacts
+          echo "${{ github.event.pull_request.number }}" > /tmp/visualize-artifacts/pr_number
+          echo "${{ steps.visualize.outputs.has_changes }}" > /tmp/visualize-artifacts/has_changes
+          if [ -f /tmp/visualization_comment.md ]; then
+            cp /tmp/visualization_comment.md /tmp/visualize-artifacts/
+          fi
 
-      - name: Post or update comment
-        if: steps.visualize.outputs.has_changes == 'true'
-        uses: peter-evans/create-or-update-comment@v4
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-id: ${{ steps.find_comment.outputs.comment-id }}
-          body-path: /tmp/visualization_comment.md
-          edit-mode: replace
-
-      - name: Delete comment if no changes
-        if: steps.visualize.outputs.has_changes == 'false' && steps.find_comment.outputs.comment-id != ''
-        run: gh api repos/${{ github.repository }}/issues/comments/${{ steps.find_comment.outputs.comment-id }} -X DELETE
-        env:
-          GH_TOKEN: ${{ github.token }}
+          name: visualization-result
+          path: /tmp/visualize-artifacts/

--- a/.github/workflows/visualize_stopping_patterns.yml
+++ b/.github/workflows/visualize_stopping_patterns.yml
@@ -1,7 +1,7 @@
 name: Visualize Stopping Patterns
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     paths:
       - "data/*.csv"
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Fetch base branch

--- a/.github/workflows/visualize_stopping_patterns_comment.yml
+++ b/.github/workflows/visualize_stopping_patterns_comment.yml
@@ -1,0 +1,53 @@
+name: Post stopping pattern visualization comment
+
+on:
+  workflow_run:
+    workflows: ["Visualize Stopping Patterns"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  comment:
+    name: Post visualization comment
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: visualization-result
+          path: /tmp/visualize-artifacts
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Read metadata
+        id: meta
+        run: |
+          echo "pr_number=$(cat /tmp/visualize-artifacts/pr_number)" >> "$GITHUB_OUTPUT"
+          echo "has_changes=$(cat /tmp/visualize-artifacts/has_changes)" >> "$GITHUB_OUTPUT"
+
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v3
+        id: find_comment
+        with:
+          issue-number: ${{ steps.meta.outputs.pr_number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "<!-- station-visualizer -->"
+
+      - name: Post or update comment
+        if: steps.meta.outputs.has_changes == 'true'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ steps.meta.outputs.pr_number }}
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          body-path: /tmp/visualize-artifacts/visualization_comment.md
+          edit-mode: replace
+
+      - name: Delete comment if no changes
+        if: steps.meta.outputs.has_changes == 'false' && steps.find_comment.outputs.comment-id != ''
+        run: gh api repos/${{ github.repository }}/issues/comments/${{ steps.find_comment.outputs.comment-id }} -X DELETE
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/visualize_stopping_patterns_comment.yml
+++ b/.github/workflows/visualize_stopping_patterns_comment.yml
@@ -6,6 +6,7 @@ on:
     types: [completed]
 
 permissions:
+  actions: read
   pull-requests: write
   issues: write
 

--- a/.github/workflows/visualize_stopping_patterns_comment.yml
+++ b/.github/workflows/visualize_stopping_patterns_comment.yml
@@ -14,7 +14,9 @@ jobs:
   comment:
     name: Post visualization comment
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request'
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -27,14 +29,19 @@ jobs:
       - name: Read metadata
         id: meta
         run: |
-          echo "pr_number=$(cat /tmp/visualize-artifacts/pr_number)" >> "$GITHUB_OUTPUT"
-          echo "has_changes=$(cat /tmp/visualize-artifacts/has_changes)" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${{ github.event.workflow_run.pull_requests[0].number }}" >> "$GITHUB_OUTPUT"
+          if [ -s /tmp/visualize-artifacts/has_changes ]; then
+            echo "has_changes=$(cat /tmp/visualize-artifacts/has_changes)" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::has_changes metadata missing or empty, defaulting to false"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Find existing comment
         uses: peter-evans/find-comment@v3
         id: find_comment
         with:
-          issue-number: ${{ steps.meta.outputs.pr_number }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           comment-author: "github-actions[bot]"
           body-includes: "<!-- station-visualizer -->"
 
@@ -42,7 +49,7 @@ jobs:
         if: steps.meta.outputs.has_changes == 'true'
         uses: peter-evans/create-or-update-comment@v4
         with:
-          issue-number: ${{ steps.meta.outputs.pr_number }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           body-path: /tmp/visualize-artifacts/visualization_comment.md
           edit-mode: replace


### PR DESCRIPTION
## Summary
- `verify_data_Integrity.yml` と `visualize_stopping_patterns.yml` のトリガーを `pull_request` → `pull_request_target` に変更
- PRヘッドのSHAを明示的にcheckoutするよう `ref` パラメータを追加
- `if` 条件の `event_name` チェックを `pull_request_target` に更新

## 背景
`pull_request` トリガーでは `GITHUB_TOKEN` が読み取り専用になるケースがあり、`peter-evans/create-or-update-comment` や `gh api DELETE` で `RequestError [HttpError]: Resource not accessible by integration` エラーが発生していました。

`pull_request_target` はベースリポジトリの権限で実行されるため、PRコメントへの書き込みが可能になります。

## Test plan
- [ ] CSVファイルを変更するPRを作成し、`Verify station data integrity` ワークフローがPRコメントを投稿できることを確認
- [ ] `Visualize Stopping Patterns` ワークフローが正常にコメントを投稿/削除できることを確認
- [ ] `Resource not accessible by integration` エラーが発生しないことを確認

https://claude.ai/code/session_01Lr3k5y8UYcH26a8hndo8ek

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ワークフローの権限を制限し、pull request と issue の書き込み権限を削減しました。
* **New Features**
  * 検証と可視化の結果はアーティファクト経由で保存され、メインワークフローはコメントを直接操作しなくなりました。
  * コメントの投稿・更新・削除は、アーティファクトを読み取って動作する別ワークフローとして新規に導入しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->