### PR TITLE
ci: fix PR number resolution in comment workflows

### DIFF
--- a/.github/workflows/verify_data_integrity_comment.yml
+++ b/.github/workflows/verify_data_integrity_comment.yml
@@ -27,7 +27,17 @@ jobs:
       - name: Read metadata
         id: meta
         run: |
-          echo "pr_number=${{ github.event.workflow_run.pull_requests[0].number }}" >> "$GITHUB_OUTPUT"
+          PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+          if [ -z "$PR_NUMBER" ] && [ -s /tmp/validation-artifacts/pr_number ]; then
+            PR_NUMBER=$(cat /tmp/validation-artifacts/pr_number)
+            echo "::warning::pull_requests context empty, using artifact fallback"
+          fi
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::Could not determine PR number"
+            exit 1
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
           if [ -s /tmp/validation-artifacts/result ]; then
             echo "result=$(cat /tmp/validation-artifacts/result)" >> "$GITHUB_OUTPUT"
           else
@@ -39,7 +49,7 @@ jobs:
         uses: peter-evans/find-comment@v3
         id: find_comment
         with:
-          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue-number: ${{ steps.meta.outputs.pr_number }}
           comment-author: "github-actions[bot]"
           body-includes: "<!-- data-validator -->"
 
@@ -47,7 +57,7 @@ jobs:
         if: steps.meta.outputs.result == 'failure'
         uses: peter-evans/create-or-update-comment@v4
         with:
-          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue-number: ${{ steps.meta.outputs.pr_number }}
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           body-path: /tmp/validation-artifacts/validation_report.md
           edit-mode: replace

--- a/.github/workflows/visualize_stopping_patterns_comment.yml
+++ b/.github/workflows/visualize_stopping_patterns_comment.yml
@@ -29,7 +29,17 @@ jobs:
       - name: Read metadata
         id: meta
         run: |
-          echo "pr_number=${{ github.event.workflow_run.pull_requests[0].number }}" >> "$GITHUB_OUTPUT"
+          PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+          if [ -z "$PR_NUMBER" ] && [ -s /tmp/visualize-artifacts/pr_number ]; then
+            PR_NUMBER=$(cat /tmp/visualize-artifacts/pr_number)
+            echo "::warning::pull_requests context empty, using artifact fallback"
+          fi
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::Could not determine PR number"
+            exit 1
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
           if [ -s /tmp/visualize-artifacts/has_changes ]; then
             echo "has_changes=$(cat /tmp/visualize-artifacts/has_changes)" >> "$GITHUB_OUTPUT"
           else
@@ -41,7 +51,7 @@ jobs:
         uses: peter-evans/find-comment@v3
         id: find_comment
         with:
-          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue-number: ${{ steps.meta.outputs.pr_number }}
           comment-author: "github-actions[bot]"
           body-includes: "<!-- station-visualizer -->"
 
@@ -49,7 +59,7 @@ jobs:
         if: steps.meta.outputs.has_changes == 'true'
         uses: peter-evans/create-or-update-comment@v4
         with:
-          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue-number: ${{ steps.meta.outputs.pr_number }}
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           body-path: /tmp/visualize-artifacts/visualization_comment.md
           edit-mode: replace


### PR DESCRIPTION
## Summary
- Comment workflow で `github.event.workflow_run.pull_requests[0].number` が空の場合にアーティファクトの `pr_number` にフォールバックするよう修正
- PR #1405 で head/base ブランチが同名のため `pull_requests` 配列が空になり、コメント投稿が失敗していた問題を解消
- 全ダウンストリームステップを `steps.meta.outputs.pr_number` に統一

## Test plan
- [ ] PR #1405 のように head/base が同名の PR で comment workflow が正しく動作することを確認
- [ ] 通常の PR でもイベントコンテキストからPR番号が取得され正常にコメントが投稿されることを確認

https://claude.ai/code/session_01Lr3k5y8UYcH26a8hndo8ek

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * プルリクエスト番号の取得ロジックを強化し、複数のフォールバック機構を追加しました。これにより、ワークフロー処理の信頼性が向上し、エラーハンドリングが改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->