### PR TITLE
Refactor PR labeler configuration and upgrade to v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,20 +1,24 @@
 ci/cd:
-  - ".github/workflows/*"
-  - ".github/*.yml"
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/*"
+          - ".github/*.yml"
 rust:
-  - "src/*"
-  - "src/**/*"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/*"
+          - "src/**/*"
 protobuf:
-  - "proto/*"
-  - "proto/**/*"
-deploy-prod:
-  - "master"
-deploy-staging:
-  - "staging"
-deploy-dev:
-  - "dev"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "proto/*"
+          - "proto/**/*"
 documentation:
-  - ".github/ISSUE_TEMPLATE/*"
-  - "pull_request_template.md"
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/ISSUE_TEMPLATE/*"
+          - "pull_request_template.md"
 data:
-  - "*.csv"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "*.csv"

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,3 +1,11 @@
+# Head branch (source) patterns
 feature: feature/*
 fix: fix/*
 chore: chore/*
+data: data/*
+release: release/*
+
+# Base branch (target) patterns
+deploy:production: master
+deploy:dev: dev
+deploy:staging: staging

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -3,12 +3,25 @@ on:
   - pull_request_target
 
 jobs:
-  triage:
+  label-by-files:
+    name: Label by changed files
     permissions:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  label-by-branch:
+    name: Label by branch
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/pr-labeler.yml


### PR DESCRIPTION
## Summary
Updated the PR labeler workflow to use the latest version of the labeler action and restructured the labeling configuration to separate file-based and branch-based labeling strategies. #1377

## Key Changes
- **Upgraded `actions/labeler` from v4 to v5** in the PR labeler workflow
- **Refactored `.github/labeler.yml`** to use the new `changed-files` syntax with `any-glob-to-any-file` matchers, which is required by labeler v5
- **Removed branch-based labels** (`deploy-prod`, `deploy-staging`, `deploy-dev`) from the file-based labeler configuration
- **Added new workflow job `label-by-branch`** using `TimonVS/pr-labeler-action@v5` to handle branch-based labeling separately
- **Created `.github/pr-labeler.yml`** with:
  - Head branch (source) patterns for feature, fix, chore, data, and release branches
  - Base branch (target) patterns for deployment labels (production, dev, staging)

## Implementation Details
The labeling logic is now split into two independent jobs:
1. **`label-by-files`**: Uses the official GitHub labeler action to apply labels based on changed files
2. **`label-by-branch`**: Uses a community action to apply labels based on branch naming conventions

This separation provides better maintainability and allows for independent scaling of each labeling strategy.

https://claude.ai/code/session_011JibAfjh65ao3VdZFJhXka

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * プルリクエストの自動ラベリングシステムを改善しました。新しいブランチパターン（data/*、release/*、chore/*）に対応し、デプロイメント対象ブランチ（production、dev、staging）に基づくラベル付けが可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->