### PR TITLE
Add katakana to IPA conversion for SSML phoneme tags

### DIFF
--- a/stationapi/src/domain.rs
+++ b/stationapi/src/domain.rs
@@ -1,4 +1,5 @@
 pub mod entity;
 pub mod error;
+pub mod ipa;
 pub mod normalize;
 pub mod repository;

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -1,8 +1,3 @@
-/// Katakana to IPA (International Phonetic Alphabet) conversion module.
-///
-/// Converts Japanese katakana text to IPA transcription for use in
-/// SSML `<phoneme>` tags for text-to-speech pronunciation.
-
 /// Convert a katakana string to its IPA transcription.
 pub fn katakana_to_ipa(input: &str) -> String {
     let chars: Vec<char> = input.chars().collect();
@@ -188,8 +183,8 @@ fn lookup_single(c: char) -> Option<Phoneme> {
 #[derive(Debug, Clone)]
 enum Phoneme {
     Regular(&'static str),
-    MoraicNasal,  // ン - assimilates to following consonant
-    Geminate,     // ッ - doubles following consonant
+    MoraicNasal, // ン - assimilates to following consonant
+    Geminate,    // ッ - doubles following consonant
     LongVowel,   // ー - lengthens preceding vowel
 }
 
@@ -224,10 +219,7 @@ fn last_vowel(ipa: &str) -> Option<&'static str> {
 /// Classify the place of articulation of the following phoneme for ン assimilation.
 fn nasal_for_following(next_ipa: &str) -> &'static str {
     // Check first meaningful character(s) of the following phoneme
-    if next_ipa.starts_with('b')
-        || next_ipa.starts_with('p')
-        || next_ipa.starts_with('m')
-    {
+    if next_ipa.starts_with('b') || next_ipa.starts_with('p') || next_ipa.starts_with('m') {
         "m" // bilabial assimilation
     } else if next_ipa.starts_with('ɲ')
         || next_ipa.starts_with("dʑ")
@@ -237,9 +229,7 @@ fn nasal_for_following(next_ipa: &str) -> &'static str {
         || next_ipa.starts_with("kʲ")
     {
         "ɲ" // palatal assimilation
-    } else if next_ipa.starts_with('k')
-        || next_ipa.starts_with('ɡ')
-        || next_ipa.starts_with('ŋ')
+    } else if next_ipa.starts_with('k') || next_ipa.starts_with('ɡ') || next_ipa.starts_with('ŋ')
     {
         "ŋ" // velar assimilation
     } else if next_ipa.starts_with('n')
@@ -272,7 +262,7 @@ fn apply_phonological_rules(phonemes: &[Phoneme]) -> String {
                 if let Some(next_ipa) = find_next_regular(&phonemes[i + 1..]) {
                     output.push_str(nasal_for_following(next_ipa));
                 } else {
-                    output.push_str("ɴ"); // word-final
+                    output.push('ɴ'); // word-final
                 }
                 i += 1;
             }
@@ -280,7 +270,10 @@ fn apply_phonological_rules(phonemes: &[Phoneme]) -> String {
                 // Double the onset of the following consonant.
                 // For affricates (t͡ɕ, t͡s), only the stop portion (t) is geminated.
                 if let Some(next_ipa) = find_next_regular(&phonemes[i + 1..]) {
-                    if next_ipa.starts_with("t͡ɕ") || next_ipa.starts_with("t͡s") || next_ipa.starts_with("d͡") {
+                    if next_ipa.starts_with("t͡ɕ")
+                        || next_ipa.starts_with("t͡s")
+                        || next_ipa.starts_with("d͡")
+                    {
                         output.push('t');
                     } else {
                         let (onset, _) = split_onset(next_ipa);

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -68,7 +68,7 @@ fn lookup_digraph(c1: char, c2: char) -> Option<Phoneme> {
         // ザ行拗音 (ジ is voiced postalveolar affricate)
         ('ジ', 'ャ') => "dʑa",
         ('ジ', 'ュ') => "dʑɯ",
-        ('ジ', 'ョ') => "ʤo",
+        ('ジ', 'ョ') => "dʑo",
         // バ行拗音
         ('ビ', 'ャ') => "bʲa",
         ('ビ', 'ュ') => "bʲɯ",

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -1,5 +1,10 @@
 /// Convert a katakana string to its IPA transcription.
-pub fn katakana_to_ipa(input: &str) -> String {
+/// Returns `None` if the input contains characters that cannot be converted.
+pub fn katakana_to_ipa(input: &str) -> Option<String> {
+    if input.is_empty() {
+        return Some(String::new());
+    }
+
     let chars: Vec<char> = input.chars().collect();
     let len = chars.len();
     let mut result = Vec::new();
@@ -15,16 +20,13 @@ pub fn katakana_to_ipa(input: &str) -> String {
             }
         }
 
-        // Single character lookup
-        if let Some(ipa) = lookup_single(chars[i]) {
-            result.push(ipa);
-        }
-        // Skip unknown characters silently
+        // Single character lookup — return None on unknown characters
+        result.push(lookup_single(chars[i])?);
 
         i += 1;
     }
 
-    apply_phonological_rules(&result)
+    Some(apply_phonological_rules(&result))
 }
 
 /// Look up a two-character (digraph) combination.
@@ -200,6 +202,12 @@ fn split_onset(ipa: &str) -> (&str, &str) {
     ipa.split_at(vowel_start)
 }
 
+/// Strip secondary articulation markers (e.g., palatalization ʲ) from an onset,
+/// returning only the base consonant(s).
+fn strip_secondary_articulation(onset: &str) -> String {
+    onset.replace('ʲ', "")
+}
+
 /// Get the last vowel character from an IPA string for long vowel extension.
 fn last_vowel(ipa: &str) -> Option<&'static str> {
     for c in ipa.chars().rev() {
@@ -271,6 +279,7 @@ fn apply_phonological_rules(phonemes: &[Phoneme]) -> String {
             Phoneme::Geminate => {
                 // Double the onset of the following consonant.
                 // For affricates (t͡ɕ, t͡s), only the stop portion (t) is geminated.
+                // For palatalized onsets (kʲ, ɡʲ, etc.), only the base consonant is geminated.
                 if let Some(next_ipa) = find_next_regular(&phonemes[i + 1..]) {
                     if next_ipa.starts_with("t͡ɕ") || next_ipa.starts_with("t͡s") {
                         output.push('t');
@@ -279,7 +288,8 @@ fn apply_phonological_rules(phonemes: &[Phoneme]) -> String {
                     } else {
                         let (onset, _) = split_onset(next_ipa);
                         if !onset.is_empty() {
-                            output.push_str(onset);
+                            let base = strip_secondary_articulation(onset);
+                            output.push_str(&base);
                         }
                     }
                 }
@@ -346,217 +356,234 @@ fn apply_vowel_length(input: &str) -> String {
 mod tests {
     use super::*;
 
+    /// Helper: unwrap the Option for concise test assertions.
+    fn ipa(input: &str) -> String {
+        katakana_to_ipa(input).expect("expected valid katakana input")
+    }
+
     // Tests based on the hardcoded IPA mappings from Cloud Functions tts.ts
 
     #[test]
     fn test_shibuya() {
-        assert_eq!(katakana_to_ipa("シブヤ"), "ɕibɯja");
+        assert_eq!(ipa("シブヤ"), "ɕibɯja");
     }
 
     #[test]
     fn test_shinagawa() {
-        assert_eq!(katakana_to_ipa("シナガワ"), "ɕinaɡawa");
+        assert_eq!(ipa("シナガワ"), "ɕinaɡawa");
     }
 
     #[test]
     fn test_ueno() {
-        assert_eq!(katakana_to_ipa("ウエノ"), "ɯeno");
+        assert_eq!(ipa("ウエノ"), "ɯeno");
     }
 
     #[test]
     fn test_ikebukuro() {
-        assert_eq!(katakana_to_ipa("イケブクロ"), "ikebɯkɯɾo");
+        assert_eq!(ipa("イケブクロ"), "ikebɯkɯɾo");
     }
 
     #[test]
     fn test_shinjuku() {
         // ン before ジュ → ɲ, ジュ → dʑɯ
-        assert_eq!(katakana_to_ipa("シンジュク"), "ɕiɲdʑɯkɯ");
+        assert_eq!(ipa("シンジュク"), "ɕiɲdʑɯkɯ");
     }
 
     #[test]
     fn test_osaka() {
         // オオ → oː
-        assert_eq!(katakana_to_ipa("オオサカ"), "oːsaka");
+        assert_eq!(ipa("オオサカ"), "oːsaka");
     }
 
     #[test]
     fn test_kyoto() {
         // キョウ → kʲoː (via kʲo + ウ → oɯ → oː)
-        assert_eq!(katakana_to_ipa("キョウト"), "kʲoːto");
+        assert_eq!(ipa("キョウト"), "kʲoːto");
     }
 
     #[test]
     fn test_yokohama() {
-        assert_eq!(katakana_to_ipa("ヨコハマ"), "jokohama");
+        assert_eq!(ipa("ヨコハマ"), "jokohama");
     }
 
     #[test]
     fn test_chiba() {
-        assert_eq!(katakana_to_ipa("チバ"), "t͡ɕiba");
+        assert_eq!(ipa("チバ"), "t͡ɕiba");
     }
 
     #[test]
     fn test_kawasaki() {
-        assert_eq!(katakana_to_ipa("カワサキ"), "kawasakʲi");
+        assert_eq!(ipa("カワサキ"), "kawasakʲi");
     }
 
     #[test]
     fn test_tsurumi() {
-        assert_eq!(katakana_to_ipa("ツルミ"), "t͡sɯɾɯmi");
+        assert_eq!(ipa("ツルミ"), "t͡sɯɾɯmi");
     }
 
     #[test]
     fn test_ryogoku() {
         // リョウ → ɾʲoː (via ɾʲo + ウ → oɯ → oː)
-        assert_eq!(katakana_to_ipa("リョウゴク"), "ɾʲoːɡokɯ");
+        assert_eq!(ipa("リョウゴク"), "ɾʲoːɡokɯ");
     }
 
     #[test]
     fn test_shimbashi() {
         // ン before バ → m
-        assert_eq!(katakana_to_ipa("シンバシ"), "ɕimbaɕi");
+        assert_eq!(ipa("シンバシ"), "ɕimbaɕi");
     }
 
     #[test]
     fn test_keisei() {
-        assert_eq!(katakana_to_ipa("ケイセイ"), "keisei");
+        assert_eq!(ipa("ケイセイ"), "keisei");
     }
 
     #[test]
     fn test_oshiage() {
-        assert_eq!(katakana_to_ipa("オシアゲ"), "oɕiaɡe");
+        assert_eq!(ipa("オシアゲ"), "oɕiaɡe");
     }
 
     #[test]
     fn test_meitetsu() {
         // ツ is consistently t͡sɯ (affricate with tie bar)
-        assert_eq!(katakana_to_ipa("メイテツ"), "meitet͡sɯ");
+        assert_eq!(ipa("メイテツ"), "meitet͡sɯ");
     }
 
     #[test]
     fn test_seibu() {
-        assert_eq!(katakana_to_ipa("セイブ"), "seibɯ");
+        assert_eq!(ipa("セイブ"), "seibɯ");
     }
 
     #[test]
     fn test_toride() {
-        assert_eq!(katakana_to_ipa("トリデ"), "toɾide");
+        assert_eq!(ipa("トリデ"), "toɾide");
     }
 
     #[test]
     fn test_fukiage() {
-        assert_eq!(katakana_to_ipa("フキアゲ"), "ɸɯkʲiaɡe");
+        assert_eq!(ipa("フキアゲ"), "ɸɯkʲiaɡe");
     }
 
     #[test]
     fn test_fuse() {
-        assert_eq!(katakana_to_ipa("フセ"), "ɸɯse");
+        assert_eq!(ipa("フセ"), "ɸɯse");
     }
 
     #[test]
     fn test_inagekaigan() {
         // ン at word end → ɴ
-        assert_eq!(katakana_to_ipa("イナゲカイガン"), "inaɡekaiɡaɴ");
+        assert_eq!(ipa("イナゲカイガン"), "inaɡekaiɡaɴ");
     }
 
     #[test]
     fn test_inage() {
-        assert_eq!(katakana_to_ipa("イナゲ"), "inaɡe");
+        assert_eq!(ipa("イナゲ"), "inaɡe");
     }
 
     #[test]
     fn test_kire_uriwari() {
-        assert_eq!(katakana_to_ipa("キレウリワリ"), "kʲiɾeɯɾiwaɾi");
+        assert_eq!(ipa("キレウリワリ"), "kʲiɾeɯɾiwaɾi");
     }
 
     #[test]
     fn test_yao() {
-        assert_eq!(katakana_to_ipa("ヤオ"), "jao");
+        assert_eq!(ipa("ヤオ"), "jao");
     }
 
     #[test]
     fn test_mejiro() {
-        assert_eq!(katakana_to_ipa("メジロ"), "meʤiɾo");
+        assert_eq!(ipa("メジロ"), "meʤiɾo");
     }
 
     #[test]
     fn test_isesaki() {
-        assert_eq!(katakana_to_ipa("イセサキ"), "isesakʲi");
+        assert_eq!(ipa("イセサキ"), "isesakʲi");
     }
 
     #[test]
     fn test_ube() {
-        assert_eq!(katakana_to_ipa("ウベ"), "ɯbe");
+        assert_eq!(ipa("ウベ"), "ɯbe");
     }
 
     #[test]
     fn test_itchome() {
         // ッチョウ → tt͡ɕoː
-        assert_eq!(katakana_to_ipa("イッチョウメ"), "itt͡ɕoːme");
+        assert_eq!(ipa("イッチョウメ"), "itt͡ɕoːme");
     }
 
     #[test]
     fn test_sanchome() {
-        assert_eq!(katakana_to_ipa("サンチョウメ"), "sant͡ɕoːme");
+        assert_eq!(ipa("サンチョウメ"), "sant͡ɕoːme");
     }
 
     #[test]
     fn test_koen() {
         // コウエン: コ=ko, ウ→長音化でoː, エン=eɴ → koːeɴ
         // Note: the original hardcoded value was "koeɴ" but phonologically "koːeɴ" is correct
-        assert_eq!(katakana_to_ipa("コウエン"), "koːeɴ");
+        assert_eq!(ipa("コウエン"), "koːeɴ");
     }
 
     #[test]
     fn test_long_vowel_mark() {
         // ー explicitly lengthens
-        assert_eq!(katakana_to_ipa("ラーメン"), "ɾaːmeɴ");
+        assert_eq!(ipa("ラーメン"), "ɾaːmeɴ");
     }
 
     #[test]
     fn test_tokyo() {
         // トウキョウ: ト=to, ウ→oː, キョ=kʲo, ウ→oː
-        assert_eq!(katakana_to_ipa("トウキョウ"), "toːkʲoː");
+        assert_eq!(ipa("トウキョウ"), "toːkʲoː");
     }
 
     #[test]
     fn test_nagoya() {
-        assert_eq!(katakana_to_ipa("ナゴヤ"), "naɡoja");
+        assert_eq!(ipa("ナゴヤ"), "naɡoja");
     }
 
     #[test]
     fn test_sapporo() {
         // ッポ → ppo
-        assert_eq!(katakana_to_ipa("サッポロ"), "sappoɾo");
+        assert_eq!(ipa("サッポロ"), "sappoɾo");
     }
 
     #[test]
     fn test_namba() {
         // ン before バ → m
-        assert_eq!(katakana_to_ipa("ナンバ"), "namba");
+        assert_eq!(ipa("ナンバ"), "namba");
     }
 
     #[test]
     fn test_shin_yokohama() {
         // ン before ヨ(j) → ɲ (palatal assimilation)
-        assert_eq!(katakana_to_ipa("シンヨコハマ"), "ɕiɲjokohama");
+        assert_eq!(ipa("シンヨコハマ"), "ɕiɲjokohama");
     }
 
     #[test]
     fn test_geminate_ji() {
         // ッジ → dʤi (voiced affricate gemination emits 'd')
-        assert_eq!(katakana_to_ipa("カッジ"), "kadʤi");
+        assert_eq!(ipa("カッジ"), "kadʤi");
     }
 
     #[test]
     fn test_geminate_ju() {
         // ッジュ → ddʑɯ (voiced affricate gemination with digraph)
-        assert_eq!(katakana_to_ipa("カッジュ"), "kaddʑɯ");
+        assert_eq!(ipa("カッジュ"), "kaddʑɯ");
     }
 
     #[test]
     fn test_empty() {
-        assert_eq!(katakana_to_ipa(""), "");
+        assert_eq!(katakana_to_ipa(""), Some(String::new()));
+    }
+
+    #[test]
+    fn test_unknown_characters_returns_none() {
+        assert_eq!(katakana_to_ipa("ABC"), None);
+        assert_eq!(katakana_to_ipa("シブヤX"), None);
+    }
+
+    #[test]
+    fn test_geminate_palatalized() {
+        // ッキョ → kkʲo (only the base consonant 'k' is geminated, not 'kʲ')
+        assert_eq!(ipa("ニッキョウ"), "ɲikkʲoː");
     }
 }

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -544,6 +544,18 @@ mod tests {
     }
 
     #[test]
+    fn test_geminate_ji() {
+        // ッジ → dʤi (voiced affricate gemination emits 'd')
+        assert_eq!(katakana_to_ipa("カッジ"), "kadʤi");
+    }
+
+    #[test]
+    fn test_geminate_ju() {
+        // ッジュ → ddʑɯ (voiced affricate gemination with digraph)
+        assert_eq!(katakana_to_ipa("カッジュ"), "kaddʑɯ");
+    }
+
+    #[test]
     fn test_empty() {
         assert_eq!(katakana_to_ipa(""), "");
     }

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -1,0 +1,550 @@
+/// Katakana to IPA (International Phonetic Alphabet) conversion module.
+///
+/// Converts Japanese katakana text to IPA transcription for use in
+/// SSML `<phoneme>` tags for text-to-speech pronunciation.
+
+/// Convert a katakana string to its IPA transcription.
+pub fn katakana_to_ipa(input: &str) -> String {
+    let chars: Vec<char> = input.chars().collect();
+    let len = chars.len();
+    let mut result = Vec::new();
+    let mut i = 0;
+
+    while i < len {
+        // Try two-character combinations first (palatalized sounds: キョ, シャ, etc.)
+        if i + 1 < len {
+            if let Some(ipa) = lookup_digraph(chars[i], chars[i + 1]) {
+                result.push(ipa);
+                i += 2;
+                continue;
+            }
+        }
+
+        // Single character lookup
+        if let Some(ipa) = lookup_single(chars[i]) {
+            result.push(ipa);
+        }
+        // Skip unknown characters silently
+
+        i += 1;
+    }
+
+    apply_phonological_rules(&result)
+}
+
+/// Look up a two-character (digraph) combination.
+/// Handles palatalized sounds (拗音): キャ, シュ, チョ, etc.
+fn lookup_digraph(c1: char, c2: char) -> Option<Phoneme> {
+    let ipa = match (c1, c2) {
+        // カ行拗音
+        ('キ', 'ャ') => "kʲa",
+        ('キ', 'ュ') => "kʲɯ",
+        ('キ', 'ョ') => "kʲo",
+        // サ行拗音 (シ is already palatal)
+        ('シ', 'ャ') => "ɕa",
+        ('シ', 'ュ') => "ɕɯ",
+        ('シ', 'ョ') => "ɕo",
+        // タ行拗音
+        ('チ', 'ャ') => "t͡ɕa",
+        ('チ', 'ュ') => "t͡ɕɯ",
+        ('チ', 'ョ') => "t͡ɕo",
+        // ナ行拗音
+        ('ニ', 'ャ') => "ɲa",
+        ('ニ', 'ュ') => "ɲɯ",
+        ('ニ', 'ョ') => "ɲo",
+        // ハ行拗音
+        ('ヒ', 'ャ') => "ça",
+        ('ヒ', 'ュ') => "çɯ",
+        ('ヒ', 'ョ') => "ço",
+        // マ行拗音
+        ('ミ', 'ャ') => "mʲa",
+        ('ミ', 'ュ') => "mʲɯ",
+        ('ミ', 'ョ') => "mʲo",
+        // ラ行拗音
+        ('リ', 'ャ') => "ɾʲa",
+        ('リ', 'ュ') => "ɾʲɯ",
+        ('リ', 'ョ') => "ɾʲo",
+        // ガ行拗音
+        ('ギ', 'ャ') => "ɡʲa",
+        ('ギ', 'ュ') => "ɡʲɯ",
+        ('ギ', 'ョ') => "ɡʲo",
+        // ザ行拗音 (ジ is voiced postalveolar affricate)
+        ('ジ', 'ャ') => "dʑa",
+        ('ジ', 'ュ') => "dʑɯ",
+        ('ジ', 'ョ') => "ʤo",
+        // バ行拗音
+        ('ビ', 'ャ') => "bʲa",
+        ('ビ', 'ュ') => "bʲɯ",
+        ('ビ', 'ョ') => "bʲo",
+        // ピ行拗音
+        ('ピ', 'ャ') => "pʲa",
+        ('ピ', 'ュ') => "pʲɯ",
+        ('ピ', 'ョ') => "pʲo",
+        _ => return None,
+    };
+    Some(Phoneme::Regular(ipa))
+}
+
+/// Look up a single katakana character.
+fn lookup_single(c: char) -> Option<Phoneme> {
+    let ipa = match c {
+        // 母音
+        'ア' | 'ァ' => return Some(Phoneme::Regular("a")),
+        'イ' | 'ィ' => return Some(Phoneme::Regular("i")),
+        'ウ' | 'ゥ' => return Some(Phoneme::Regular("ɯ")),
+        'エ' | 'ェ' => return Some(Phoneme::Regular("e")),
+        'オ' | 'ォ' => return Some(Phoneme::Regular("o")),
+        // カ行
+        'カ' => "ka",
+        'キ' => "kʲi",
+        'ク' => "kɯ",
+        'ケ' => "ke",
+        'コ' => "ko",
+        // サ行
+        'サ' => "sa",
+        'シ' => "ɕi",
+        'ス' => "sɯ",
+        'セ' => "se",
+        'ソ' => "so",
+        // タ行
+        'タ' => "ta",
+        'チ' => "t͡ɕi",
+        'ツ' => "t͡sɯ",
+        'テ' => "te",
+        'ト' => "to",
+        // ナ行
+        'ナ' => "na",
+        'ニ' => "ɲi",
+        'ヌ' => "nɯ",
+        'ネ' => "ne",
+        'ノ' => "no",
+        // ハ行
+        'ハ' => "ha",
+        'ヒ' => "çi",
+        'フ' => "ɸɯ",
+        'ヘ' => "he",
+        'ホ' => "ho",
+        // マ行
+        'マ' => "ma",
+        'ミ' => "mi",
+        'ム' => "mɯ",
+        'メ' => "me",
+        'モ' => "mo",
+        // ヤ行
+        'ヤ' | 'ャ' => "ja",
+        'ユ' | 'ュ' => "jɯ",
+        'ヨ' | 'ョ' => "jo",
+        // ラ行
+        'ラ' => "ɾa",
+        'リ' => "ɾi",
+        'ル' => "ɾɯ",
+        'レ' => "ɾe",
+        'ロ' => "ɾo",
+        // ワ行
+        'ワ' => "wa",
+        'ヰ' => "i",
+        'ヱ' => "e",
+        'ヲ' => "o",
+        // ガ行
+        'ガ' => "ɡa",
+        'ギ' => "ɡi",
+        'グ' => "ɡɯ",
+        'ゲ' => "ɡe",
+        'ゴ' => "ɡo",
+        // ザ行
+        'ザ' => "za",
+        'ジ' => "ʤi",
+        'ズ' => "zɯ",
+        'ゼ' => "ze",
+        'ゾ' => "zo",
+        // ダ行
+        'ダ' => "da",
+        'ヂ' => "dʑi",
+        'ヅ' => "dzɯ",
+        'デ' => "de",
+        'ド' => "do",
+        // バ行
+        'バ' => "ba",
+        'ビ' => "bi",
+        'ブ' => "bɯ",
+        'ベ' => "be",
+        'ボ' => "bo",
+        // パ行
+        'パ' => "pa",
+        'ピ' => "pi",
+        'プ' => "pɯ",
+        'ペ' => "pe",
+        'ポ' => "po",
+        // 特殊
+        'ン' => return Some(Phoneme::MoraicNasal),
+        'ッ' => return Some(Phoneme::Geminate),
+        'ー' => return Some(Phoneme::LongVowel),
+        _ => return None,
+    };
+    Some(Phoneme::Regular(ipa))
+}
+
+/// Intermediate phoneme representation before phonological rules are applied.
+#[derive(Debug, Clone)]
+enum Phoneme {
+    Regular(&'static str),
+    MoraicNasal,  // ン - assimilates to following consonant
+    Geminate,     // ッ - doubles following consonant
+    LongVowel,   // ー - lengthens preceding vowel
+}
+
+/// Extract the leading consonant cluster from an IPA string.
+/// Returns (consonant_cluster, remainder) or None if starts with a vowel.
+fn split_onset(ipa: &str) -> (&str, &str) {
+    // Find where the first vowel-like character starts
+    let vowel_start = ipa
+        .char_indices()
+        .find(|(_, c)| "aiɯeouəɐ".contains(*c))
+        .map(|(i, _)| i)
+        .unwrap_or(ipa.len());
+    ipa.split_at(vowel_start)
+}
+
+/// Get the last vowel character from an IPA string for long vowel extension.
+fn last_vowel(ipa: &str) -> Option<&'static str> {
+    for c in ipa.chars().rev() {
+        match c {
+            'a' => return Some("a"),
+            'i' => return Some("i"),
+            'ɯ' => return Some("ɯ"),
+            'e' => return Some("e"),
+            'o' => return Some("o"),
+            'u' => return Some("u"),
+            _ => continue,
+        }
+    }
+    None
+}
+
+/// Classify the place of articulation of the following phoneme for ン assimilation.
+fn nasal_for_following(next_ipa: &str) -> &'static str {
+    // Check first meaningful character(s) of the following phoneme
+    if next_ipa.starts_with('b')
+        || next_ipa.starts_with('p')
+        || next_ipa.starts_with('m')
+    {
+        "m" // bilabial assimilation
+    } else if next_ipa.starts_with('ɲ')
+        || next_ipa.starts_with("dʑ")
+        || next_ipa.starts_with('ʤ')
+        || next_ipa.starts_with('ɕ')
+        || next_ipa.starts_with("ɡʲ")
+        || next_ipa.starts_with("kʲ")
+    {
+        "ɲ" // palatal assimilation
+    } else if next_ipa.starts_with('k')
+        || next_ipa.starts_with('ɡ')
+        || next_ipa.starts_with('ŋ')
+    {
+        "ŋ" // velar assimilation
+    } else if next_ipa.starts_with('n')
+        || next_ipa.starts_with('t')
+        || next_ipa.starts_with('d')
+        || next_ipa.starts_with('s')
+        || next_ipa.starts_with('z')
+        || next_ipa.starts_with('ɾ')
+    {
+        "n" // alveolar assimilation (includes t͡ɕ, t͡s which start with t)
+    } else {
+        "ɴ" // default: uvular nasal (word-final or before vowels)
+    }
+}
+
+/// Apply phonological rules: ン assimilation, ッ gemination, long vowels.
+fn apply_phonological_rules(phonemes: &[Phoneme]) -> String {
+    let mut output = String::new();
+    let len = phonemes.len();
+    let mut i = 0;
+
+    while i < len {
+        match &phonemes[i] {
+            Phoneme::Regular(ipa) => {
+                output.push_str(ipa);
+                i += 1;
+            }
+            Phoneme::MoraicNasal => {
+                // Look ahead for assimilation
+                if let Some(next_ipa) = find_next_regular(&phonemes[i + 1..]) {
+                    output.push_str(nasal_for_following(next_ipa));
+                } else {
+                    output.push_str("ɴ"); // word-final
+                }
+                i += 1;
+            }
+            Phoneme::Geminate => {
+                // Double the onset of the following consonant.
+                // For affricates (t͡ɕ, t͡s), only the stop portion (t) is geminated.
+                if let Some(next_ipa) = find_next_regular(&phonemes[i + 1..]) {
+                    if next_ipa.starts_with("t͡ɕ") || next_ipa.starts_with("t͡s") || next_ipa.starts_with("d͡") {
+                        output.push('t');
+                    } else {
+                        let (onset, _) = split_onset(next_ipa);
+                        if !onset.is_empty() {
+                            output.push_str(onset);
+                        }
+                    }
+                }
+                i += 1;
+            }
+            Phoneme::LongVowel => {
+                // Lengthen the preceding vowel
+                if last_vowel(&output).is_some() {
+                    // Check if already has ː
+                    if !output.ends_with('ː') {
+                        output.push('ː');
+                    }
+                } else {
+                    output.push('ː');
+                }
+                i += 1;
+            }
+        }
+    }
+
+    // Apply long vowel contractions: オウ → oː pattern
+    apply_vowel_length(&output)
+}
+
+/// Find the IPA string of the next Regular phoneme in the slice.
+fn find_next_regular(phonemes: &[Phoneme]) -> Option<&'static str> {
+    phonemes.iter().find_map(|p| match p {
+        Phoneme::Regular(ipa) => Some(*ipa),
+        _ => None,
+    })
+}
+
+/// Apply vowel length rules for common Japanese patterns.
+/// オウ → oː (after consonant+o), ョウ/ョオ patterns are handled by digraph + this.
+fn apply_vowel_length(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let chars: Vec<char> = input.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        if i + 1 < len && chars[i] == 'o' && chars[i + 1] == 'ɯ' {
+            // oɯ → oː (おう/こう pattern)
+            result.push('o');
+            result.push('ː');
+            i += 2;
+            continue;
+        }
+        if i + 1 < len && chars[i] == 'o' && chars[i + 1] == 'o' {
+            // oo → oː (おお pattern)
+            result.push('o');
+            result.push('ː');
+            i += 2;
+            continue;
+        }
+        result.push(chars[i]);
+        i += 1;
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tests based on the hardcoded IPA mappings from Cloud Functions tts.ts
+
+    #[test]
+    fn test_shibuya() {
+        assert_eq!(katakana_to_ipa("シブヤ"), "ɕibɯja");
+    }
+
+    #[test]
+    fn test_shinagawa() {
+        assert_eq!(katakana_to_ipa("シナガワ"), "ɕinaɡawa");
+    }
+
+    #[test]
+    fn test_ueno() {
+        assert_eq!(katakana_to_ipa("ウエノ"), "ɯeno");
+    }
+
+    #[test]
+    fn test_ikebukuro() {
+        assert_eq!(katakana_to_ipa("イケブクロ"), "ikebɯkɯɾo");
+    }
+
+    #[test]
+    fn test_shinjuku() {
+        // ン before ジュ → ɲ, ジュ → dʑɯ
+        assert_eq!(katakana_to_ipa("シンジュク"), "ɕiɲdʑɯkɯ");
+    }
+
+    #[test]
+    fn test_osaka() {
+        // オオ → oː
+        assert_eq!(katakana_to_ipa("オオサカ"), "oːsaka");
+    }
+
+    #[test]
+    fn test_kyoto() {
+        // キョウ → kʲoː (via kʲo + ウ → oɯ → oː)
+        assert_eq!(katakana_to_ipa("キョウト"), "kʲoːto");
+    }
+
+    #[test]
+    fn test_yokohama() {
+        assert_eq!(katakana_to_ipa("ヨコハマ"), "jokohama");
+    }
+
+    #[test]
+    fn test_chiba() {
+        assert_eq!(katakana_to_ipa("チバ"), "t͡ɕiba");
+    }
+
+    #[test]
+    fn test_kawasaki() {
+        assert_eq!(katakana_to_ipa("カワサキ"), "kawasakʲi");
+    }
+
+    #[test]
+    fn test_tsurumi() {
+        assert_eq!(katakana_to_ipa("ツルミ"), "t͡sɯɾɯmi");
+    }
+
+    #[test]
+    fn test_ryogoku() {
+        // リョウ → ɾʲoː (via ɾʲo + ウ → oɯ → oː)
+        assert_eq!(katakana_to_ipa("リョウゴク"), "ɾʲoːɡokɯ");
+    }
+
+    #[test]
+    fn test_shimbashi() {
+        // ン before バ → m
+        assert_eq!(katakana_to_ipa("シンバシ"), "ɕimbaɕi");
+    }
+
+    #[test]
+    fn test_keisei() {
+        assert_eq!(katakana_to_ipa("ケイセイ"), "keisei");
+    }
+
+    #[test]
+    fn test_oshiage() {
+        assert_eq!(katakana_to_ipa("オシアゲ"), "oɕiaɡe");
+    }
+
+    #[test]
+    fn test_meitetsu() {
+        // ツ is consistently t͡sɯ (affricate with tie bar)
+        assert_eq!(katakana_to_ipa("メイテツ"), "meitet͡sɯ");
+    }
+
+    #[test]
+    fn test_seibu() {
+        assert_eq!(katakana_to_ipa("セイブ"), "seibɯ");
+    }
+
+    #[test]
+    fn test_toride() {
+        assert_eq!(katakana_to_ipa("トリデ"), "toɾide");
+    }
+
+    #[test]
+    fn test_fukiage() {
+        assert_eq!(katakana_to_ipa("フキアゲ"), "ɸɯkʲiaɡe");
+    }
+
+    #[test]
+    fn test_fuse() {
+        assert_eq!(katakana_to_ipa("フセ"), "ɸɯse");
+    }
+
+    #[test]
+    fn test_inagekaigan() {
+        // ン at word end → ɴ
+        assert_eq!(katakana_to_ipa("イナゲカイガン"), "inaɡekaiɡaɴ");
+    }
+
+    #[test]
+    fn test_inage() {
+        assert_eq!(katakana_to_ipa("イナゲ"), "inaɡe");
+    }
+
+    #[test]
+    fn test_kire_uriwari() {
+        assert_eq!(katakana_to_ipa("キレウリワリ"), "kʲiɾeɯɾiwaɾi");
+    }
+
+    #[test]
+    fn test_yao() {
+        assert_eq!(katakana_to_ipa("ヤオ"), "jao");
+    }
+
+    #[test]
+    fn test_mejiro() {
+        assert_eq!(katakana_to_ipa("メジロ"), "meʤiɾo");
+    }
+
+    #[test]
+    fn test_isesaki() {
+        assert_eq!(katakana_to_ipa("イセサキ"), "isesakʲi");
+    }
+
+    #[test]
+    fn test_ube() {
+        assert_eq!(katakana_to_ipa("ウベ"), "ɯbe");
+    }
+
+    #[test]
+    fn test_itchome() {
+        // ッチョウ → tt͡ɕoː
+        assert_eq!(katakana_to_ipa("イッチョウメ"), "itt͡ɕoːme");
+    }
+
+    #[test]
+    fn test_sanchome() {
+        assert_eq!(katakana_to_ipa("サンチョウメ"), "sant͡ɕoːme");
+    }
+
+    #[test]
+    fn test_koen() {
+        // コウエン: コ=ko, ウ→長音化でoː, エン=eɴ → koːeɴ
+        // Note: the original hardcoded value was "koeɴ" but phonologically "koːeɴ" is correct
+        assert_eq!(katakana_to_ipa("コウエン"), "koːeɴ");
+    }
+
+    #[test]
+    fn test_long_vowel_mark() {
+        // ー explicitly lengthens
+        assert_eq!(katakana_to_ipa("ラーメン"), "ɾaːmeɴ");
+    }
+
+    #[test]
+    fn test_tokyo() {
+        // トウキョウ: ト=to, ウ→oː, キョ=kʲo, ウ→oː
+        assert_eq!(katakana_to_ipa("トウキョウ"), "toːkʲoː");
+    }
+
+    #[test]
+    fn test_nagoya() {
+        assert_eq!(katakana_to_ipa("ナゴヤ"), "naɡoja");
+    }
+
+    #[test]
+    fn test_sapporo() {
+        // ッポ → ppo
+        assert_eq!(katakana_to_ipa("サッポロ"), "sappoɾo");
+    }
+
+    #[test]
+    fn test_namba() {
+        // ン before バ → m
+        assert_eq!(katakana_to_ipa("ナンバ"), "namba");
+    }
+
+    #[test]
+    fn test_empty() {
+        assert_eq!(katakana_to_ipa(""), "");
+    }
+}

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -191,7 +191,7 @@ enum Phoneme {
 }
 
 /// Extract the leading consonant cluster from an IPA string.
-/// Returns (consonant_cluster, remainder) or None if starts with a vowel.
+/// Returns (onset, remainder). If the string starts with a vowel, onset is "".
 fn split_onset(ipa: &str) -> (&str, &str) {
     // Find where the first vowel-like character starts
     let vowel_start = ipa

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -227,6 +227,8 @@ fn nasal_for_following(next_ipa: &str) -> &'static str {
         || next_ipa.starts_with('ɕ')
         || next_ipa.starts_with("ɡʲ")
         || next_ipa.starts_with("kʲ")
+        || next_ipa.starts_with('j')
+        || next_ipa.starts_with('ç')
     {
         "ɲ" // palatal assimilation
     } else if next_ipa.starts_with('k') || next_ipa.starts_with('ɡ') || next_ipa.starts_with('ŋ')
@@ -270,11 +272,10 @@ fn apply_phonological_rules(phonemes: &[Phoneme]) -> String {
                 // Double the onset of the following consonant.
                 // For affricates (t͡ɕ, t͡s), only the stop portion (t) is geminated.
                 if let Some(next_ipa) = find_next_regular(&phonemes[i + 1..]) {
-                    if next_ipa.starts_with("t͡ɕ")
-                        || next_ipa.starts_with("t͡s")
-                        || next_ipa.starts_with("d͡")
-                    {
+                    if next_ipa.starts_with("t͡ɕ") || next_ipa.starts_with("t͡s") {
                         output.push('t');
+                    } else if next_ipa.starts_with("dʑ") || next_ipa.starts_with("ʤ") {
+                        output.push('d');
                     } else {
                         let (onset, _) = split_onset(next_ipa);
                         if !onset.is_empty() {
@@ -534,6 +535,12 @@ mod tests {
     fn test_namba() {
         // ン before バ → m
         assert_eq!(katakana_to_ipa("ナンバ"), "namba");
+    }
+
+    #[test]
+    fn test_shin_yokohama() {
+        // ン before ヨ(j) → ɲ (palatal assimilation)
+        assert_eq!(katakana_to_ipa("シンヨコハマ"), "ɕiɲjokohama");
     }
 
     #[test]

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -289,7 +289,9 @@ fn apply_phonological_rules(phonemes: &[Phoneme]) -> String {
                         let (onset, _) = split_onset(next_ipa);
                         if !onset.is_empty() {
                             let base = strip_secondary_articulation(onset);
-                            output.push_str(&base);
+                            if let Some(c) = base.chars().next() {
+                                output.push(c);
+                            }
                         }
                     }
                 }

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -1,10 +1,17 @@
 use crate::{
-    domain::entity::{gtfs::TransportType, line::Line},
+    domain::{
+        entity::{gtfs::TransportType, line::Line},
+        ipa::katakana_to_ipa,
+    },
     proto::{Line as GrpcLine, TransportType as GrpcTransportType},
 };
 
 impl From<Line> for GrpcLine {
     fn from(line: Line) -> Self {
+        let name_ipa = {
+            let ipa = katakana_to_ipa(&line.line_name_k);
+            if ipa.is_empty() { None } else { Some(ipa) }
+        };
         // バス路線の場合は line_type を OtherLineType (0) に強制
         // (鉄道用の line_type が誤って設定されている可能性があるため)
         let line_type = if line.transport_type == TransportType::Bus {
@@ -32,6 +39,7 @@ impl From<Line> for GrpcLine {
                 .map(|train_type| Box::new(train_type.into())),
             average_distance: line.average_distance.unwrap_or(0.0),
             transport_type: convert_transport_type(line.transport_type),
+            name_ipa,
         }
     }
 }

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -10,7 +10,11 @@ impl From<Line> for GrpcLine {
     fn from(line: Line) -> Self {
         let name_ipa = {
             let ipa = katakana_to_ipa(&line.line_name_k);
-            if ipa.is_empty() { None } else { Some(ipa) }
+            if ipa.is_empty() {
+                None
+            } else {
+                Some(ipa)
+            }
         };
         // バス路線の場合は line_type を OtherLineType (0) に強制
         // (鉄道用の line_type が誤って設定されている可能性があるため)

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -8,8 +8,7 @@ use crate::{
 
 impl From<Line> for GrpcLine {
     fn from(line: Line) -> Self {
-        let name_ipa =
-            katakana_to_ipa(&line.line_name_k).filter(|ipa| !ipa.is_empty());
+        let name_ipa = katakana_to_ipa(&line.line_name_k).filter(|ipa| !ipa.is_empty());
         // バス路線の場合は line_type を OtherLineType (0) に強制
         // (鉄道用の line_type が誤って設定されている可能性があるため)
         let line_type = if line.transport_type == TransportType::Bus {

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -8,14 +8,8 @@ use crate::{
 
 impl From<Line> for GrpcLine {
     fn from(line: Line) -> Self {
-        let name_ipa = {
-            let ipa = katakana_to_ipa(&line.line_name_k);
-            if ipa.is_empty() {
-                None
-            } else {
-                Some(ipa)
-            }
-        };
+        let name_ipa =
+            katakana_to_ipa(&line.line_name_k).filter(|ipa| !ipa.is_empty());
         // バス路線の場合は line_type を OtherLineType (0) に強制
         // (鉄道用の line_type が誤って設定されている可能性があるため)
         let line_type = if line.transport_type == TransportType::Bus {

--- a/stationapi/src/use_case/dto/station.rs
+++ b/stationapi/src/use_case/dto/station.rs
@@ -1,5 +1,8 @@
 use crate::{
-    domain::entity::{gtfs::TransportType, station::Station},
+    domain::{
+        entity::{gtfs::TransportType, station::Station},
+        ipa::katakana_to_ipa,
+    },
     proto::{Station as GrpcStation, TransportType as GrpcTransportType},
 };
 
@@ -14,6 +17,10 @@ impl From<TransportType> for i32 {
 
 impl From<Station> for GrpcStation {
     fn from(station: Station) -> Self {
+        let name_ipa = {
+            let ipa = katakana_to_ipa(&station.station_name_k);
+            if ipa.is_empty() { None } else { Some(ipa) }
+        };
         Self {
             id: station.station_cd as u32,
             group_id: station.station_g_cd as u32,
@@ -43,6 +50,7 @@ impl From<Station> for GrpcStation {
             has_train_types: Some(station.has_train_types),
             train_type: station.train_type.map(|tt| Box::new((*tt).into())),
             transport_type: station.transport_type.into(),
+            name_ipa,
         }
     }
 }

--- a/stationapi/src/use_case/dto/station.rs
+++ b/stationapi/src/use_case/dto/station.rs
@@ -19,7 +19,11 @@ impl From<Station> for GrpcStation {
     fn from(station: Station) -> Self {
         let name_ipa = {
             let ipa = katakana_to_ipa(&station.station_name_k);
-            if ipa.is_empty() { None } else { Some(ipa) }
+            if ipa.is_empty() {
+                None
+            } else {
+                Some(ipa)
+            }
         };
         Self {
             id: station.station_cd as u32,

--- a/stationapi/src/use_case/dto/station.rs
+++ b/stationapi/src/use_case/dto/station.rs
@@ -17,14 +17,8 @@ impl From<TransportType> for i32 {
 
 impl From<Station> for GrpcStation {
     fn from(station: Station) -> Self {
-        let name_ipa = {
-            let ipa = katakana_to_ipa(&station.station_name_k);
-            if ipa.is_empty() {
-                None
-            } else {
-                Some(ipa)
-            }
-        };
+        let name_ipa =
+            katakana_to_ipa(&station.station_name_k).filter(|ipa| !ipa.is_empty());
         Self {
             id: station.station_cd as u32,
             group_id: station.station_g_cd as u32,

--- a/stationapi/src/use_case/dto/station.rs
+++ b/stationapi/src/use_case/dto/station.rs
@@ -17,8 +17,7 @@ impl From<TransportType> for i32 {
 
 impl From<Station> for GrpcStation {
     fn from(station: Station) -> Self {
-        let name_ipa =
-            katakana_to_ipa(&station.station_name_k).filter(|ipa| !ipa.is_empty());
+        let name_ipa = katakana_to_ipa(&station.station_name_k).filter(|ipa| !ipa.is_empty());
         Self {
             id: station.station_cd as u32,
             group_id: station.station_g_cd as u32,

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -834,6 +834,10 @@ where
                         })
                         .collect();
 
+                    let name_ipa = {
+                        let ipa = crate::domain::ipa::katakana_to_ipa(&row.station_name_k);
+                        if ipa.is_empty() { None } else { Some(ipa) }
+                    };
                     proto::StationMinimal {
                         id: row.station_cd as u32,
                         group_id: row.station_g_cd as u32,
@@ -845,6 +849,7 @@ where
                         stop_condition: row.pass.unwrap_or(0),
                         has_train_types: Some(row.type_id.is_some()),
                         train_type_id: row.type_id.map(|id| id as u32),
+                        name_ipa,
                     }
                 })
                 .collect::<Vec<proto::StationMinimal>>();

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -834,14 +834,8 @@ where
                         })
                         .collect();
 
-                    let name_ipa = {
-                        let ipa = crate::domain::ipa::katakana_to_ipa(&row.station_name_k);
-                        if ipa.is_empty() {
-                            None
-                        } else {
-                            Some(ipa)
-                        }
-                    };
+                    let name_ipa = crate::domain::ipa::katakana_to_ipa(&row.station_name_k)
+                        .filter(|ipa| !ipa.is_empty());
                     proto::StationMinimal {
                         id: row.station_cd as u32,
                         group_id: row.station_g_cd as u32,

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -836,7 +836,11 @@ where
 
                     let name_ipa = {
                         let ipa = crate::domain::ipa::katakana_to_ipa(&row.station_name_k);
-                        if ipa.is_empty() { None } else { Some(ipa) }
+                        if ipa.is_empty() {
+                            None
+                        } else {
+                            Some(ipa)
+                        }
                     };
                     proto::StationMinimal {
                         id: row.station_cd as u32,


### PR DESCRIPTION
## Summary
This PR adds a new katakana-to-IPA (International Phonetic Alphabet) conversion module to support generating phonetic transcriptions for Japanese station and line names. These IPA strings are used in SSML `<phoneme>` tags for text-to-speech pronunciation.

## Key Changes
- **New IPA conversion module** (`stationapi/src/domain/ipa.rs`):
  - Implements `katakana_to_ipa()` function that converts Japanese katakana text to IPA transcription
  - Handles single characters (basic hiragana/katakana) and two-character combinations (palatalized sounds like キャ, シュ, チョ)
  - Applies phonological rules for:
    - ン (moraic nasal) assimilation based on following consonant place of articulation
    - ッ (geminate) consonant doubling
    - ー (long vowel mark) and オウ/オオ patterns for vowel lengthening
  - Includes comprehensive test suite with 30+ test cases covering major Japanese station names

- **Integration with DTOs**:
  - Updated `station.rs` to generate IPA transcription for `station_name_k` (katakana station name)
  - Updated `line.rs` to generate IPA transcription for `line_name_k` (katakana line name)
  - Updated `query.rs` interactor to include IPA for `StationMinimal` responses
  - IPA field is optional (None if conversion produces empty string)

- **Proto updates**: Updated proto submodule to include new IPA fields in gRPC message definitions

## Implementation Details
- Uses a two-pass approach: first tries two-character digraph lookups for palatalized sounds, then falls back to single-character lookups
- Phoneme enum distinguishes between regular IPA strings, moraic nasals, geminates, and long vowel markers
- Nasal assimilation logic classifies following consonants by place of articulation (bilabial, palatal, velar, alveolar, uvular)
- Vowel length rules handle common Japanese patterns (e.g., コウ → koː, オオ → oː)
- All conversions use standard IPA symbols with proper diacritics (e.g., ɕ for palatal fricative, t͡ɕ for affricate)

https://claude.ai/code/session_01Pjo9E2fzdLZEkvNqxXAPeQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * カタカナ表記を自動で国際音声記号（IPA）に変換する機能を追加しました。
  * 駅・路線・StationMinimal 出力に任意の IPA 表記フィールドを追加し、利用可能な場合は API 応答で返却します（未対応時は空）。

* **テスト**
  * 多数のカタカナパターンを検証する網羅的なテストを追加しました。

* **雑務**
  * 内部参照のサブモジュール参照を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->