### PR TITLE
fix: handle full-width space in katakana-to-IPA conversion

### DIFF
--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -176,6 +176,8 @@ fn lookup_single(c: char) -> Option<Phoneme> {
         'ン' => return Some(Phoneme::MoraicNasal),
         'ッ' => return Some(Phoneme::Geminate),
         'ー' => return Some(Phoneme::LongVowel),
+        // 空白（全角・半角）はそのまま透過
+        '　' | ' ' => return Some(Phoneme::Regular(" ")),
         _ => return None,
     };
     Some(Phoneme::Regular(ipa))
@@ -587,5 +589,14 @@ mod tests {
     fn test_geminate_palatalized() {
         // ッキョ → kkʲo (only the base consonant 'k' is geminated, not 'kʲ')
         assert_eq!(ipa("ニッキョウ"), "ɲikkʲoː");
+    }
+
+    #[test]
+    fn test_dokkyo_daigakumae_soka_matsubara() {
+        // Full-width space between words should be preserved
+        assert_eq!(
+            ipa("ドッキョウダイガクマエ　ソウカマツバラ"),
+            "dokkʲoːdaiɡakɯmae soːkamat͡sɯbaɾa"
+        );
     }
 }

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -599,4 +599,13 @@ mod tests {
             "dokkʲoːdaiɡakɯmae soːkamat͡sɯbaɾa"
         );
     }
+
+    #[test]
+    fn test_dokkyo_daigakumae_soka_matsubara_halfwidth() {
+        // Half-width (ASCII) space between words should also be accepted
+        assert_eq!(
+            ipa("ドッキョウダイガクマエ ソウカマツバラ"),
+            "dokkʲoːdaiɡakɯmae soːkamat͡sɯbaɾa"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- 駅名に含まれる全角スペース（U+3000）が `lookup_single` で未定義だったため、`katakana_to_ipa` が `None` を返し `nameIpa` が null になっていた問題を修正
- `lookup_single` に全角スペース `　` と半角スペース ` ` のマッピングを追加（IPA出力では半角スペースとして透過）
- 「ドッキョウダイガクマエ　ソウカマツバラ」のテストケースを追加

## Test plan
- [x] `SQLX_OFFLINE=true cargo test --lib domain::ipa` — 42テスト全パス

https://claude.ai/code/session_01Pjo9E2fzdLZEkvNqxXAPeQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * IPA出力で全角スペースと半角スペースが正しく保持されるようになりました（テキスト内のスペースが意図した通り出力されます）。
* **テスト**
  * 全角・半角スペースが単語間で維持されることを確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->