### PR TITLE
fix: 路線名IPAから共通接尾辞(線/本線/支線)を除去

### DIFF
--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -638,29 +638,44 @@ mod tests {
 
     #[test]
     fn test_strip_sen() {
-        assert_eq!(strip_line_name_suffix("セイブイケブクロセン"), "セイブイケブクロ");
+        assert_eq!(
+            strip_line_name_suffix("セイブイケブクロセン"),
+            "セイブイケブクロ"
+        );
     }
 
     #[test]
     fn test_strip_honsen() {
-        assert_eq!(strip_line_name_suffix("トウカイドウホンセン"), "トウカイドウ");
+        assert_eq!(
+            strip_line_name_suffix("トウカイドウホンセン"),
+            "トウカイドウ"
+        );
     }
 
     #[test]
     fn test_strip_shinkansen_preserved() {
         // 新幹線(Shinkansen)は英語でもそのまま使われるので除去しない
-        assert_eq!(strip_line_name_suffix("トウホクシンカンセン"), "トウホクシンカンセン");
+        assert_eq!(
+            strip_line_name_suffix("トウホクシンカンセン"),
+            "トウホクシンカンセン"
+        );
     }
 
     #[test]
     fn test_strip_shisen() {
-        assert_eq!(strip_line_name_suffix("ナガノハラクサツグチシセン"), "ナガノハラクサツグチ");
+        assert_eq!(
+            strip_line_name_suffix("ナガノハラクサツグチシセン"),
+            "ナガノハラクサツグチ"
+        );
     }
 
     #[test]
     fn test_strip_no_suffix() {
         // ライン等セン以外の末尾はそのまま返す
-        assert_eq!(strip_line_name_suffix("ショウナンシンジュクライン"), "ショウナンシンジュクライン");
+        assert_eq!(
+            strip_line_name_suffix("ショウナンシンジュクライン"),
+            "ショウナンシンジュクライン"
+        );
     }
 
     #[test]

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -3,7 +3,8 @@ const LINE_NAME_SUFFIXES: &[&str] = &["ホンセン", "シセン", "セン"];
 /// Suffixes that should NOT be stripped even though they end with セン.
 const LINE_NAME_SUFFIX_EXCEPTIONS: &[&str] = &["シンカンセン"];
 
-/// Strip a common line-name suffix (線/本線/支線/新幹線) from a katakana string.
+/// Strip a common line-name suffix (線/本線/支線) from a katakana string.
+/// 新幹線 (Shinkansen) is preserved as it is used as-is in English.
 /// Returns the stem (without the suffix). If no known suffix is found, returns the input unchanged.
 pub fn strip_line_name_suffix(input: &str) -> &str {
     for exception in LINE_NAME_SUFFIX_EXCEPTIONS {

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -1,3 +1,26 @@
+/// Common katakana suffixes for line names, ordered longest-first for greedy matching.
+const LINE_NAME_SUFFIXES: &[&str] = &["ホンセン", "シセン", "セン"];
+/// Suffixes that should NOT be stripped even though they end with セン.
+const LINE_NAME_SUFFIX_EXCEPTIONS: &[&str] = &["シンカンセン"];
+
+/// Strip a common line-name suffix (線/本線/支線/新幹線) from a katakana string.
+/// Returns the stem (without the suffix). If no known suffix is found, returns the input unchanged.
+pub fn strip_line_name_suffix(input: &str) -> &str {
+    for exception in LINE_NAME_SUFFIX_EXCEPTIONS {
+        if input.ends_with(exception) {
+            return input;
+        }
+    }
+    for suffix in LINE_NAME_SUFFIXES {
+        if let Some(stem) = input.strip_suffix(suffix) {
+            if !stem.is_empty() {
+                return stem;
+            }
+        }
+    }
+    input
+}
+
 /// Convert a katakana string to its IPA transcription.
 /// Returns `None` if the input contains characters that cannot be converted.
 pub fn katakana_to_ipa(input: &str) -> Option<String> {
@@ -607,5 +630,42 @@ mod tests {
             ipa("ドッキョウダイガクマエ ソウカマツバラ"),
             "dokkʲoːdaiɡakɯmae soːkamat͡sɯbaɾa"
         );
+    }
+
+    // ============================================
+    // strip_line_name_suffix tests
+    // ============================================
+
+    #[test]
+    fn test_strip_sen() {
+        assert_eq!(strip_line_name_suffix("セイブイケブクロセン"), "セイブイケブクロ");
+    }
+
+    #[test]
+    fn test_strip_honsen() {
+        assert_eq!(strip_line_name_suffix("トウカイドウホンセン"), "トウカイドウ");
+    }
+
+    #[test]
+    fn test_strip_shinkansen_preserved() {
+        // 新幹線(Shinkansen)は英語でもそのまま使われるので除去しない
+        assert_eq!(strip_line_name_suffix("トウホクシンカンセン"), "トウホクシンカンセン");
+    }
+
+    #[test]
+    fn test_strip_shisen() {
+        assert_eq!(strip_line_name_suffix("ナガノハラクサツグチシセン"), "ナガノハラクサツグチ");
+    }
+
+    #[test]
+    fn test_strip_no_suffix() {
+        // ライン等セン以外の末尾はそのまま返す
+        assert_eq!(strip_line_name_suffix("ショウナンシンジュクライン"), "ショウナンシンジュクライン");
+    }
+
+    #[test]
+    fn test_strip_bare_sen_returns_unchanged() {
+        // "セン" だけの場合、stemが空になるので除去しない
+        assert_eq!(strip_line_name_suffix("セン"), "セン");
     }
 }

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -8,8 +8,8 @@ use crate::{
 
 impl From<Line> for GrpcLine {
     fn from(line: Line) -> Self {
-        let name_ipa =
-            katakana_to_ipa(strip_line_name_suffix(&line.line_name_k)).filter(|ipa| !ipa.is_empty());
+        let name_ipa = katakana_to_ipa(strip_line_name_suffix(&line.line_name_k))
+            .filter(|ipa| !ipa.is_empty());
         // バス路線の場合は line_type を OtherLineType (0) に強制
         // (鉄道用の line_type が誤って設定されている可能性があるため)
         let line_type = if line.transport_type == TransportType::Bus {

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -1,14 +1,15 @@
 use crate::{
     domain::{
         entity::{gtfs::TransportType, line::Line},
-        ipa::katakana_to_ipa,
+        ipa::{katakana_to_ipa, strip_line_name_suffix},
     },
     proto::{Line as GrpcLine, TransportType as GrpcTransportType},
 };
 
 impl From<Line> for GrpcLine {
     fn from(line: Line) -> Self {
-        let name_ipa = katakana_to_ipa(&line.line_name_k).filter(|ipa| !ipa.is_empty());
+        let name_ipa =
+            katakana_to_ipa(strip_line_name_suffix(&line.line_name_k)).filter(|ipa| !ipa.is_empty());
         // バス路線の場合は line_type を OtherLineType (0) に強制
         // (鉄道用の line_type が誤って設定されている可能性があるため)
         let line_type = if line.transport_type == TransportType::Bus {


### PR DESCRIPTION
## Summary
- 路線名カタカナ（例: セイブイケブクロセン）をIPA変換する際、英語TTSでは "Line" と読まれるべき接尾辞（セン/ホンセン/シセン）を事前に除去するようにした
- シンカンセン（Shinkansen）は英語でもそのまま使われるため例外として保護
- `strip_line_name_suffix()` 関数を `ipa.rs` に追加し、`line.rs` のDTO変換で適用

## Test plan
- [x] `strip_line_name_suffix` のユニットテスト追加（セン/ホンセン/シセン除去、シンカンセン保護、ライン等の非対象、空stemの保護）
- [x] 既存のIPA変換テスト49件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 路線名の末尾にある既知の片仮名接尾辞を自動で除去する処理を追加しました。特定語（例：新幹線など）は除去対象から保護されます。
* **改善**
  * 除去処理を経てからIPA変換を行う前処理を導入し、路線名のIPA変換精度を向上させました。
* **テスト**
  * 末尾除去の振る舞いや境界ケースを検証する単体テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->