### PR TITLE
fix: 路線名IPAの接尾辞を英語IPAに置換

### DIFF
--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -1,25 +1,32 @@
-/// Common katakana suffixes for line names, ordered longest-first for greedy matching.
-const LINE_NAME_SUFFIXES: &[&str] = &["ホンセン", "シセン", "セン"];
-/// Suffixes that should NOT be stripped even though they end with セン.
+/// Katakana line-name suffixes paired with their English IPA replacements.
+/// Ordered longest-first for greedy matching.
+const LINE_NAME_SUFFIX_MAP: &[(&str, &str)] = &[
+    ("ホンセン", " meɪn laɪn"),
+    ("シセン", " laɪn"),
+    ("セン", " laɪn"),
+];
+/// Suffixes that should NOT be replaced even though they end with セン.
 const LINE_NAME_SUFFIX_EXCEPTIONS: &[&str] = &["シンカンセン"];
 
-/// Strip a common line-name suffix (線/本線/支線) from a katakana string.
+/// Replace a common line-name suffix (線/本線/支線) in a katakana string
+/// with its English IPA equivalent (Line / Main Line).
 /// 新幹線 (Shinkansen) is preserved as it is used as-is in English.
-/// Returns the stem (without the suffix). If no known suffix is found, returns the input unchanged.
-pub fn strip_line_name_suffix(input: &str) -> &str {
+/// Returns the stem and the English IPA suffix to append.
+/// If no known suffix is found, returns the full input with an empty suffix.
+pub fn replace_line_name_suffix(input: &str) -> (&str, &str) {
     for exception in LINE_NAME_SUFFIX_EXCEPTIONS {
         if input.ends_with(exception) {
-            return input;
+            return (input, "");
         }
     }
-    for suffix in LINE_NAME_SUFFIXES {
+    for (suffix, replacement) in LINE_NAME_SUFFIX_MAP {
         if let Some(stem) = input.strip_suffix(suffix) {
             if !stem.is_empty() {
-                return stem;
+                return (stem, replacement);
             }
         }
     }
-    input
+    (input, "")
 }
 
 /// Convert a katakana string to its IPA transcription.
@@ -634,54 +641,54 @@ mod tests {
     }
 
     // ============================================
-    // strip_line_name_suffix tests
+    // replace_line_name_suffix tests
     // ============================================
 
     #[test]
-    fn test_strip_sen() {
+    fn test_replace_sen() {
         assert_eq!(
-            strip_line_name_suffix("セイブイケブクロセン"),
-            "セイブイケブクロ"
+            replace_line_name_suffix("セイブイケブクロセン"),
+            ("セイブイケブクロ", " laɪn")
         );
     }
 
     #[test]
-    fn test_strip_honsen() {
+    fn test_replace_honsen() {
         assert_eq!(
-            strip_line_name_suffix("トウカイドウホンセン"),
-            "トウカイドウ"
+            replace_line_name_suffix("トウカイドウホンセン"),
+            ("トウカイドウ", " meɪn laɪn")
         );
     }
 
     #[test]
-    fn test_strip_shinkansen_preserved() {
+    fn test_replace_shinkansen_preserved() {
         // 新幹線(Shinkansen)は英語でもそのまま使われるので除去しない
         assert_eq!(
-            strip_line_name_suffix("トウホクシンカンセン"),
-            "トウホクシンカンセン"
+            replace_line_name_suffix("トウホクシンカンセン"),
+            ("トウホクシンカンセン", "")
         );
     }
 
     #[test]
-    fn test_strip_shisen() {
+    fn test_replace_shisen() {
         assert_eq!(
-            strip_line_name_suffix("ナガノハラクサツグチシセン"),
-            "ナガノハラクサツグチ"
+            replace_line_name_suffix("ナガノハラクサツグチシセン"),
+            ("ナガノハラクサツグチ", " laɪn")
         );
     }
 
     #[test]
-    fn test_strip_no_suffix() {
+    fn test_replace_no_suffix() {
         // ライン等セン以外の末尾はそのまま返す
         assert_eq!(
-            strip_line_name_suffix("ショウナンシンジュクライン"),
-            "ショウナンシンジュクライン"
+            replace_line_name_suffix("ショウナンシンジュクライン"),
+            ("ショウナンシンジュクライン", "")
         );
     }
 
     #[test]
-    fn test_strip_bare_sen_returns_unchanged() {
+    fn test_replace_bare_sen_returns_unchanged() {
         // "セン" だけの場合、stemが空になるので除去しない
-        assert_eq!(strip_line_name_suffix("セン"), "セン");
+        assert_eq!(replace_line_name_suffix("セン"), ("セン", ""));
     }
 }

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -1,15 +1,18 @@
 use crate::{
     domain::{
         entity::{gtfs::TransportType, line::Line},
-        ipa::{katakana_to_ipa, strip_line_name_suffix},
+        ipa::{katakana_to_ipa, replace_line_name_suffix},
     },
     proto::{Line as GrpcLine, TransportType as GrpcTransportType},
 };
 
 impl From<Line> for GrpcLine {
     fn from(line: Line) -> Self {
-        let name_ipa = katakana_to_ipa(strip_line_name_suffix(&line.line_name_k))
-            .filter(|ipa| !ipa.is_empty());
+        let name_ipa = {
+            let (stem, suffix_ipa) = replace_line_name_suffix(&line.line_name_k);
+            katakana_to_ipa(stem).map(|ipa| format!("{ipa}{suffix_ipa}"))
+        }
+        .filter(|ipa| !ipa.is_empty());
         // バス路線の場合は line_type を OtherLineType (0) に強制
         // (鉄道用の line_type が誤って設定されている可能性があるため)
         let line_type = if line.transport_type == TransportType::Bus {


### PR DESCRIPTION
## Summary
- 路線名カタカナのIPA変換時、接尾辞（セン/ホンセン/シセン）を単に除去するのではなく、英語IPA（laɪn / meɪn laɪn）に置換するように変更
- 例: セイブイケブクロセン → `seibɯikebɯkɯɾo laɪn`
- シンカンセン（Shinkansen）は英語でもそのまま使われるため例外として保護

## Test plan
- [x] `replace_line_name_suffix` のユニットテスト（セン→laɪn、ホンセン→meɪn laɪn、シセン→laɪn、シンカンセン保護、ライン等の非対象、空stem保護）
- [x] 既存IPA変換テスト49件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 駅名の発音表記（IPA）処理を改良しました。駅名の接尾辞をより正確な英語の発音マッピングに置換するようになり、駅名の読み方表示がより適切になります。
  * 特定の接尾辞については例外処理を追加し、正しく処理されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->