### PR TITLE
test: Line DTO変換のname_ipaユニットテスト追加

### DIFF
--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -372,4 +372,38 @@ mod tests {
 
         assert_eq!(grpc_line.id, 12345);
     }
+
+    // ============================================
+    // name_ipa 変換テスト
+    // ============================================
+
+    #[test]
+    fn test_name_ipa_sen_suffix_replaced_with_line() {
+        // 〜セン → IPA + " laɪn"
+        let mut line = create_test_line(TransportType::Rail, None);
+        line.line_name_k = "セイブイケブクロセン".to_string();
+        let grpc_line: GrpcLine = line.into();
+
+        assert_eq!(grpc_line.name_ipa, Some("sɛibɯikɛbɯkɯɾo laɪn".to_string()));
+    }
+
+    #[test]
+    fn test_name_ipa_honsen_suffix_replaced_with_main_line() {
+        // 〜ホンセン → IPA + " meɪn laɪn"
+        let mut line = create_test_line(TransportType::Rail, None);
+        line.line_name_k = "トウカイドウホンセン".to_string();
+        let grpc_line: GrpcLine = line.into();
+
+        assert_eq!(grpc_line.name_ipa, Some("toːkaidoː meɪn laɪn".to_string()));
+    }
+
+    #[test]
+    fn test_name_ipa_shinkansen_preserved() {
+        // 〜シンカンセン は英語でもそのまま使われるため置換しない
+        let mut line = create_test_line(TransportType::Rail, None);
+        line.line_name_k = "トウホクシンカンセン".to_string();
+        let grpc_line: GrpcLine = line.into();
+
+        assert_eq!(grpc_line.name_ipa, Some("toːhokɯɕiŋkansɛɴ".to_string()));
+    }
 }


### PR DESCRIPTION
## Summary
- Line DTO変換層で `name_ipa` が正しく生成されることを検証するユニットテストを追加
  - セン → `" laɪn"` に置換されること
  - ホンセン → `" meɪn laɪn"` に置換されること
  - シンカンセン → 置換されず保護されること

## Test plan
- [x] 新規テスト3件を含む全28件のline DTOテストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 線名の音声記号変換機能に関する包括的なテストケースを追加し、各パターンに対する正確な動作検証を実施しました。品質保証の向上に貢献します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->