### PR TITLE
Fix IPA generation for compound station names

### DIFF
--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -121,6 +121,10 @@ fn word_to_ipa(token: &str) -> Option<String> {
         return Some(String::new());
     }
 
+    if let Some(ipa) = split_compound_token_to_ipa(&normalized) {
+        return Some(ipa);
+    }
+
     if let Some(ipa) = lookup_english_word_ipa(&normalized) {
         return Some(ipa.to_string());
     }
@@ -139,6 +143,26 @@ fn word_to_ipa(token: &str) -> Option<String> {
     }
 
     romaji_to_katakana(&normalized).and_then(|katakana| katakana_to_ipa(&katakana))
+}
+
+fn split_compound_token_to_ipa(token: &str) -> Option<String> {
+    const JAPANESE_SUFFIXES: &[&str] = &["kaigan"];
+
+    for suffix in JAPANESE_SUFFIXES {
+        if token.len() <= suffix.len() || !token.ends_with(suffix) {
+            continue;
+        }
+
+        let stem = &token[..token.len() - suffix.len()];
+        let stem_ipa = word_to_ipa(stem)?;
+        let suffix_ipa = word_to_ipa(suffix)?;
+        if stem_ipa.is_empty() || suffix_ipa.is_empty() {
+            return None;
+        }
+        return Some(format!("{stem_ipa} {suffix_ipa}"));
+    }
+
+    None
 }
 
 fn is_name_token_char(c: char) -> bool {
@@ -1251,6 +1275,22 @@ mod tests {
         assert_eq!(
             station_name_to_ipa("シンバシ", Some("Shimbashi")),
             Some("ɕimbaɕi".to_string())
+        );
+    }
+
+    #[test]
+    fn test_station_name_ipa_splits_compound_kaigan_suffix() {
+        assert_eq!(
+            station_name_to_ipa("イナゲカイガン", Some("Inagekaigan")),
+            Some("inage ka.igaɴ".to_string())
+        );
+    }
+
+    #[test]
+    fn test_station_name_ipa_splits_other_compound_kaigan_suffix() {
+        assert_eq!(
+            station_name_to_ipa("オオモリカイガン", Some("Omorikaigan")),
+            Some("omoɾi ka.igaɴ".to_string())
         );
     }
 

--- a/stationapi/src/use_case/dto/station.rs
+++ b/stationapi/src/use_case/dto/station.rs
@@ -18,7 +18,8 @@ impl From<TransportType> for i32 {
 impl From<Station> for GrpcStation {
     fn from(station: Station) -> Self {
         let name_ipa = katakana_to_ipa(&station.station_name_k).filter(|ipa| !ipa.is_empty());
-        let name_roman_ipa = station_name_to_ipa("", station.station_name_r.as_deref());
+        let name_roman_ipa =
+            station_name_to_ipa(&station.station_name_k, station.station_name_r.as_deref());
         Self {
             id: station.station_cd as u32,
             group_id: station.station_g_cd as u32,
@@ -51,5 +52,102 @@ impl From<Station> for GrpcStation {
             name_ipa,
             name_roman_ipa,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        domain::entity::{gtfs::TransportType, station::Station},
+        proto::StopCondition,
+    };
+
+    fn create_test_station(name: &str, name_katakana: &str, name_roman: Option<&str>) -> Station {
+        Station::new(
+            1,
+            1,
+            name.to_string(),
+            name_katakana.to_string(),
+            name_roman.map(str::to_string),
+            None,
+            None,
+            vec![],
+            None,
+            None,
+            None,
+            None,
+            None,
+            1,
+            None,
+            vec![],
+            12,
+            String::new(),
+            String::new(),
+            0.0,
+            0.0,
+            String::new(),
+            String::new(),
+            0,
+            0,
+            StopCondition::All,
+            None,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            TransportType::Rail,
+        )
+    }
+
+    #[test]
+    fn test_station_sets_expected_roman_ipa_for_inagekaigan() {
+        let grpc_station: GrpcStation =
+            create_test_station("稲毛海岸", "イナゲカイガン", Some("Inagekaigan")).into();
+
+        assert_eq!(
+            grpc_station.name_roman_ipa,
+            Some("inage ka.igaɴ".to_string())
+        );
+    }
+
+    #[test]
+    fn test_station_name_roman_ipa_falls_back_to_katakana() {
+        let grpc_station: GrpcStation = create_test_station("渋谷", "シブヤ", Some("???")).into();
+
+        assert_eq!(grpc_station.name_roman_ipa, Some("ɕibɯja".to_string()));
     }
 }

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -836,8 +836,10 @@ where
 
                     let name_ipa = crate::domain::ipa::katakana_to_ipa(&row.station_name_k)
                         .filter(|ipa| !ipa.is_empty());
-                    let name_roman_ipa =
-                        crate::domain::ipa::station_name_to_ipa("", row.station_name_r.as_deref());
+                    let name_roman_ipa = crate::domain::ipa::station_name_to_ipa(
+                        &row.station_name_k,
+                        row.station_name_r.as_deref(),
+                    );
                     proto::StationMinimal {
                         id: row.station_cd as u32,
                         group_id: row.station_g_cd as u32,


### PR DESCRIPTION
## Summary
- split romanized compound station names ending in `kaigan` before English word lookup
- pass katakana station names into `station_name_to_ipa` so station DTOs fall back correctly when roman parsing fails
- add regression tests for `Inagekaigan` and katakana fallback behavior

## Testing
- `SQLX_OFFLINE=true cargo test --lib --package stationapi use_case::dto::station -- --nocapture`
- `SQLX_OFFLINE=true cargo test --lib --package stationapi test_station_name_ipa_splits_compound_kaigan_suffix -- --nocapture`
- `cargo fmt --package stationapi`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 複合駅名（例：イナゲカイガン）のローマ字化に対応しました。

* **改善**
  * 駅名のローマ字表記精度を向上させました。

* **テスト**
  * ローマ字化処理の検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->