### PR TITLE
Fix IPA handling for Meitetsu station names

### DIFF
--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -69,6 +69,7 @@ pub fn station_name_to_ipa(name_katakana: &str, name_roman: Option<&str>) -> Opt
             .map(str::trim)
             .filter(|name| !name.is_empty())
             .and_then(romanized_name_to_ipa)
+            .filter(|ipa| !ipa.is_empty())
             .or_else(|| katakana_to_ipa(name_katakana)),
     )
 }

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -64,27 +64,41 @@ pub fn katakana_to_ipa(input: &str) -> Option<String> {
 /// Prefers the official romanized/English name when present so mixed names like
 /// "Kasai-Rinkai Park" use English pronunciation for translated segments.
 pub fn station_name_to_ipa(name_katakana: &str, name_roman: Option<&str>) -> Option<String> {
-    name_roman
-        .map(str::trim)
-        .filter(|name| !name.is_empty())
-        .and_then(romanized_name_to_ipa)
-        .filter(|ipa| !ipa.is_empty())
-        .or_else(|| katakana_to_ipa(name_katakana))
-        .filter(|ipa| !ipa.is_empty())
+    non_empty_ipa(
+        name_roman
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .and_then(romanized_name_to_ipa)
+            .or_else(|| katakana_to_ipa(name_katakana)),
+    )
+}
+
+pub fn katakana_name_to_ipa(input: &str) -> Option<String> {
+    non_empty_ipa(katakana_to_ipa(input))
+}
+
+pub fn non_empty_ipa(ipa: Option<String>) -> Option<String> {
+    ipa.filter(|ipa| !ipa.is_empty())
 }
 
 fn romanized_name_to_ipa(input: &str) -> Option<String> {
     let mut output = String::new();
     let mut token = String::new();
     let mut emitted_word = false;
+    let mut prev_token_char: Option<char> = None;
 
     for c in input.chars() {
         if is_name_token_char(c) {
+            if should_split_camel_case_token(prev_token_char, c) {
+                flush_name_token(&mut output, &mut token, &mut emitted_word)?;
+            }
             token.push(c);
+            prev_token_char = Some(c);
             continue;
         }
 
         flush_name_token(&mut output, &mut token, &mut emitted_word)?;
+        prev_token_char = None;
 
         if is_separator_like(c) && emitted_word && !output.ends_with(' ') {
             output.push(' ');
@@ -94,6 +108,10 @@ fn romanized_name_to_ipa(input: &str) -> Option<String> {
     flush_name_token(&mut output, &mut token, &mut emitted_word)?;
 
     Some(output.trim().to_string())
+}
+
+fn should_split_camel_case_token(prev: Option<char>, current: char) -> bool {
+    matches!(prev, Some(prev) if prev.is_ascii_lowercase() && current.is_ascii_uppercase())
 }
 
 fn flush_name_token(
@@ -1308,6 +1326,35 @@ mod tests {
             station_name_to_ipa("カイソク", Some("Commuter Rapid")),
             Some("kəmjuːtɚ ɹæpɪd".to_string())
         );
+    }
+
+    #[test]
+    fn test_station_name_ipa_supports_spaced_romanized_names_from_csv() {
+        assert_eq!(
+            station_name_to_ipa("メイテツイチノミヤ", Some("Meitetsu Ichinomiya")),
+            Some("me.itet͡sɯ it͡ɕinomija".to_string())
+        );
+    }
+
+    #[test]
+    fn test_station_name_ipa_supports_meitetsu_prefixed_station_names_from_csv() {
+        let cases = [
+            ("メイテツナゴヤ", "Meitetsu Nagoya", "me.itet͡sɯ nagoja"),
+            (
+                "メイテツイチノミヤ",
+                "Meitetsu Ichinomiya",
+                "me.itet͡sɯ it͡ɕinomija",
+            ),
+            ("メイテツギフ", "Meitetsu Gifu", "me.itet͡sɯ giɸɯ"),
+        ];
+
+        for (katakana, roman, expected) in cases {
+            assert_eq!(
+                station_name_to_ipa(katakana, Some(roman)),
+                Some(expected.to_string()),
+                "failed for {roman}"
+            );
+        }
     }
 
     #[test]

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -1,7 +1,7 @@
 use crate::{
     domain::{
         entity::{gtfs::TransportType, line::Line},
-        ipa::{katakana_to_ipa, replace_line_name_suffix, station_name_to_ipa},
+        ipa::{katakana_name_to_ipa, non_empty_ipa, replace_line_name_suffix, station_name_to_ipa},
     },
     proto::{Line as GrpcLine, TransportType as GrpcTransportType},
 };
@@ -10,11 +10,9 @@ impl From<Line> for GrpcLine {
     fn from(line: Line) -> Self {
         let name_ipa = {
             let (stem, suffix_ipa) = replace_line_name_suffix(&line.line_name_k);
-            katakana_to_ipa(stem).map(|ipa| format!("{ipa}{suffix_ipa}"))
-        }
-        .filter(|ipa| !ipa.is_empty());
-        let name_roman_ipa =
-            station_name_to_ipa("", line.line_name_r.as_deref()).filter(|ipa| !ipa.is_empty());
+            non_empty_ipa(katakana_name_to_ipa(stem).map(|ipa| format!("{ipa}{suffix_ipa}")))
+        };
+        let name_roman_ipa = station_name_to_ipa("", line.line_name_r.as_deref());
         // バス路線の場合は line_type を OtherLineType (0) に強制
         // (鉄道用の line_type が誤って設定されている可能性があるため)
         let line_type = if line.transport_type == TransportType::Bus {

--- a/stationapi/src/use_case/dto/station.rs
+++ b/stationapi/src/use_case/dto/station.rs
@@ -1,7 +1,7 @@
 use crate::{
     domain::{
         entity::{gtfs::TransportType, station::Station},
-        ipa::{katakana_to_ipa, station_name_to_ipa},
+        ipa::{katakana_name_to_ipa, station_name_to_ipa},
     },
     proto::{Station as GrpcStation, TransportType as GrpcTransportType},
 };
@@ -17,7 +17,7 @@ impl From<TransportType> for i32 {
 
 impl From<Station> for GrpcStation {
     fn from(station: Station) -> Self {
-        let name_ipa = katakana_to_ipa(&station.station_name_k).filter(|ipa| !ipa.is_empty());
+        let name_ipa = katakana_name_to_ipa(&station.station_name_k);
         let name_roman_ipa =
             station_name_to_ipa(&station.station_name_k, station.station_name_r.as_deref());
         Self {
@@ -149,5 +149,20 @@ mod tests {
         let grpc_station: GrpcStation = create_test_station("渋谷", "シブヤ", Some("???")).into();
 
         assert_eq!(grpc_station.name_roman_ipa, Some("ɕibɯja".to_string()));
+    }
+
+    #[test]
+    fn test_station_name_roman_ipa_uses_meitetsu_station_data() {
+        let grpc_station: GrpcStation = create_test_station(
+            "名鉄一宮",
+            "メイテツイチノミヤ",
+            Some("Meitetsu Ichinomiya"),
+        )
+        .into();
+
+        assert_eq!(
+            grpc_station.name_roman_ipa,
+            Some("me.itet͡sɯ it͡ɕinomija".to_string())
+        );
     }
 }

--- a/stationapi/src/use_case/dto/train_type.rs
+++ b/stationapi/src/use_case/dto/train_type.rs
@@ -1,7 +1,7 @@
 use crate::{
     domain::{
         entity::train_type::TrainType,
-        ipa::{katakana_to_ipa, station_name_to_ipa},
+        ipa::{katakana_name_to_ipa, station_name_to_ipa},
     },
     proto::TrainType as GrpcTrainType,
 };
@@ -25,7 +25,7 @@ impl From<TrainType> for GrpcTrainType {
             lines,
             kind,
         } = train_type;
-        let name_ipa = katakana_to_ipa(&type_name_k).filter(|ipa| !ipa.is_empty());
+        let name_ipa = katakana_name_to_ipa(&type_name_k);
         let name_roman_ipa = station_name_to_ipa("", type_name_r.as_deref());
         Self {
             id: id.map(|id| id as u32).unwrap_or(0),

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -834,8 +834,7 @@ where
                         })
                         .collect();
 
-                    let name_ipa = crate::domain::ipa::katakana_to_ipa(&row.station_name_k)
-                        .filter(|ipa| !ipa.is_empty());
+                    let name_ipa = crate::domain::ipa::katakana_name_to_ipa(&row.station_name_k);
                     let name_roman_ipa = crate::domain::ipa::station_name_to_ipa(
                         &row.station_name_k,
                         row.station_name_r.as_deref(),


### PR DESCRIPTION
## Summary
- fix romanized IPA parsing for Meitetsu-prefixed station names such as Meitetsu Ichinomiya
- add regression tests for domain and DTO IPA generation using CSV-aligned station data
- simplify IPA call sites by centralizing empty-string filtering helpers

## Verification
- cargo fmt --check
- SQLX_OFFLINE=true cargo build -p stationapi
- SQLX_OFFLINE=true cargo test -p stationapi test_station_name_ipa_supports_meitetsu_prefixed_station_names_from_csv -- --nocapture
- SQLX_OFFLINE=true cargo test -p stationapi test_station_name_roman_ipa_uses_meitetsu_station_data -- --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * カタカナ表記からIPA（国際音声記号）への変換を強化し、空の変換結果を除外する処理を導入
  * ローマ字駅名でキャメルケース形式のトークン分割に対応

* **テスト**
  * スペース入りローマ字や特定事例（例: Meitetsu）のIPA出力を検証する新規テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->