### PR TITLE
Add segmented TTS metadata for mixed-language names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ This guide explains how automation agents and human contributors should work wit
 - **Lines** – `GetLineById`, `GetLinesByIdList`, `GetLinesByName`. Results include company data and computed line symbols based on repository helpers.
 - **Routes** – `GetRoutes`, `GetRoutesMinimal`. The minimal variant returns `RouteMinimalResponse` with deduplicated `LineMinimal` data; paging tokens are currently empty (pagination not implemented).
 - **Train types** – `GetTrainTypesByStationId`, `GetRouteTypes`. Train types aggregate by line group and include related lines plus optional train type metadata.
+- **TTS metadata** – `Station`, `StationMinimal`, `Line`, and `TrainType` expose `name_ipa` / `name_roman_ipa` plus `name_tts_segments` for multi-segment pronunciation output. Use `name_tts_segments` when clients need per-token SSML construction for mixed-language names such as `Kasai-Rinkai Park`.
 - **Connected routes** – `GetConnectedRoutes`. `QueryInteractor::get_connected_stations` is not implemented yet and returns an empty vector; update the use-case and infrastructure layers together when adding real logic.
 - Changes to the service contract require coordinated updates to `proto/stationapi.proto`, regenerated code via `tonic-build`, and corresponding adjustments in both presentation and use-case layers.
 

--- a/stationapi/build.rs
+++ b/stationapi/build.rs
@@ -19,6 +19,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "StationNumber",
             "#[derive(serde::Serialize, serde::Deserialize)]",
         )
+        .type_attribute(
+            "TtsAlphabet",
+            "#[derive(serde::Serialize, serde::Deserialize)]",
+        )
+        .type_attribute(
+            "TtsSegment",
+            "#[derive(serde::Serialize, serde::Deserialize)]",
+        )
         .type_attribute("Line", "#[derive(serde::Serialize, serde::Deserialize)]")
         .type_attribute("Station", "#[derive(serde::Serialize, serde::Deserialize)]")
         .type_attribute(

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -69,6 +69,7 @@ pub fn station_name_to_ipa(name_katakana: &str, name_roman: Option<&str>) -> Opt
             .map(str::trim)
             .filter(|name| !name.is_empty())
             .and_then(romanized_name_to_ipa)
+            .filter(|ipa| !ipa.is_empty())
             .or_else(|| katakana_to_ipa(name_katakana)),
     )
 }

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -257,8 +257,13 @@ fn split_compound_token_to_tts_segments(
             continue;
         }
 
-        let stem_len = normalized.len() - suffix.len();
-        let stem = &original[..stem_len];
+        let stem_char_count = normalized.chars().count() - suffix.chars().count();
+        let stem_byte_offset = original
+            .char_indices()
+            .nth(stem_char_count)
+            .map(|(index, _)| index)
+            .unwrap_or(original.len());
+        let stem = &original[..stem_byte_offset];
         let mut stem_segments = word_to_tts_segments(stem)?;
         let suffix_segments = word_to_tts_segments(suffix)?;
         if stem_segments.is_empty() || suffix_segments.is_empty() {

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -64,27 +64,41 @@ pub fn katakana_to_ipa(input: &str) -> Option<String> {
 /// Prefers the official romanized/English name when present so mixed names like
 /// "Kasai-Rinkai Park" use English pronunciation for translated segments.
 pub fn station_name_to_ipa(name_katakana: &str, name_roman: Option<&str>) -> Option<String> {
-    name_roman
-        .map(str::trim)
-        .filter(|name| !name.is_empty())
-        .and_then(romanized_name_to_ipa)
-        .filter(|ipa| !ipa.is_empty())
-        .or_else(|| katakana_to_ipa(name_katakana))
-        .filter(|ipa| !ipa.is_empty())
+    non_empty_ipa(
+        name_roman
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .and_then(romanized_name_to_ipa)
+            .or_else(|| katakana_to_ipa(name_katakana)),
+    )
+}
+
+pub fn katakana_name_to_ipa(input: &str) -> Option<String> {
+    non_empty_ipa(katakana_to_ipa(input))
+}
+
+pub fn non_empty_ipa(ipa: Option<String>) -> Option<String> {
+    ipa.filter(|ipa| !ipa.is_empty())
 }
 
 fn romanized_name_to_ipa(input: &str) -> Option<String> {
     let mut output = String::new();
     let mut token = String::new();
     let mut emitted_word = false;
+    let mut prev_token_char: Option<char> = None;
 
     for c in input.chars() {
         if is_name_token_char(c) {
+            if should_split_camel_case_token(prev_token_char, c) {
+                flush_name_token(&mut output, &mut token, &mut emitted_word)?;
+            }
             token.push(c);
+            prev_token_char = Some(c);
             continue;
         }
 
         flush_name_token(&mut output, &mut token, &mut emitted_word)?;
+        prev_token_char = None;
 
         if is_separator_like(c) && emitted_word && !output.ends_with(' ') {
             output.push(' ');
@@ -94,6 +108,10 @@ fn romanized_name_to_ipa(input: &str) -> Option<String> {
     flush_name_token(&mut output, &mut token, &mut emitted_word)?;
 
     Some(output.trim().to_string())
+}
+
+fn should_split_camel_case_token(prev: Option<char>, current: char) -> bool {
+    matches!(prev, Some(prev) if prev.is_ascii_lowercase() && current.is_ascii_uppercase())
 }
 
 fn flush_name_token(
@@ -1308,6 +1326,35 @@ mod tests {
             station_name_to_ipa("カイソク", Some("Commuter Rapid")),
             Some("kəmjuːtɚ ɹæpɪd".to_string())
         );
+    }
+
+    #[test]
+    fn test_station_name_ipa_supports_spaced_romanized_names_from_csv() {
+        assert_eq!(
+            station_name_to_ipa("メイテツイチノミヤ", Some("Meitetsu Ichinomiya")),
+            Some("me.itet͡sɯ it͡ɕinomija".to_string())
+        );
+    }
+
+    #[test]
+    fn test_station_name_ipa_supports_meitetsu_prefixed_station_names_from_csv() {
+        let cases = [
+            ("メイテツナゴヤ", "Meitetsu Nagoya", "me.itet͡sɯ nagoja"),
+            (
+                "メイテツイチノミヤ",
+                "Meitetsu Ichinomiya",
+                "me.itet͡sɯ it͡ɕinomija",
+            ),
+            ("メイテツギフ", "Meitetsu Gifu", "me.itet͡sɯ giɸɯ"),
+        ];
+
+        for (katakana, roman, expected) in cases {
+            assert_eq!(
+                station_name_to_ipa(katakana, Some(roman)),
+                Some(expected.to_string()),
+                "failed for {roman}"
+            );
+        }
     }
 
     #[test]

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -64,14 +64,8 @@ pub fn katakana_to_ipa(input: &str) -> Option<String> {
 /// Prefers the official romanized/English name when present so mixed names like
 /// "Kasai-Rinkai Park" use English pronunciation for translated segments.
 pub fn station_name_to_ipa(name_katakana: &str, name_roman: Option<&str>) -> Option<String> {
-    non_empty_ipa(
-        name_roman
-            .map(str::trim)
-            .filter(|name| !name.is_empty())
-            .and_then(romanized_name_to_ipa)
-            .filter(|ipa| !ipa.is_empty())
-            .or_else(|| katakana_to_ipa(name_katakana)),
-    )
+    let segments = station_name_to_tts_segments(name_katakana, name_roman);
+    non_empty_ipa(join_tts_segment_pronunciations(&segments))
 }
 
 pub fn katakana_name_to_ipa(input: &str) -> Option<String> {
@@ -82,106 +76,212 @@ pub fn non_empty_ipa(ipa: Option<String>) -> Option<String> {
     ipa.filter(|ipa| !ipa.is_empty())
 }
 
-fn romanized_name_to_ipa(input: &str) -> Option<String> {
-    let mut output = String::new();
-    let mut token = String::new();
-    let mut emitted_word = false;
-    let mut prev_token_char: Option<char> = None;
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TtsAlphabetKind {
+    Ipa,
+    Yomigana,
+    Plain,
+}
 
-    for c in input.chars() {
-        if is_name_token_char(c) {
-            if should_split_camel_case_token(prev_token_char, c) {
-                flush_name_token(&mut output, &mut token, &mut emitted_word)?;
-            }
-            token.push(c);
-            prev_token_char = Some(c);
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TtsNameSegment {
+    pub surface: String,
+    pub fallback_text: String,
+    pub pronunciation: String,
+    pub alphabet: TtsAlphabetKind,
+    pub lang: &'static str,
+    pub separator: String,
+}
+
+pub fn station_name_to_tts_segments(
+    name_katakana: &str,
+    name_roman: Option<&str>,
+) -> Vec<TtsNameSegment> {
+    name_roman
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .and_then(romanized_name_to_tts_segments)
+        .filter(|segments| !segments.is_empty())
+        .or_else(|| katakana_name_to_tts_segments(name_katakana))
+        .unwrap_or_default()
+}
+
+fn join_tts_segment_pronunciations(segments: &[TtsNameSegment]) -> Option<String> {
+    let mut output = String::new();
+
+    for segment in segments {
+        if segment.pronunciation.is_empty() {
             continue;
         }
-
-        flush_name_token(&mut output, &mut token, &mut emitted_word)?;
-        prev_token_char = None;
-
-        if is_separator_like(c) && emitted_word && !output.ends_with(' ') {
-            output.push(' ');
-        }
+        output.push_str(&segment.pronunciation);
+        output.push_str(&segment.separator);
     }
 
-    flush_name_token(&mut output, &mut token, &mut emitted_word)?;
+    non_empty_ipa(Some(output.trim().to_string()))
+}
 
-    Some(output.trim().to_string())
+fn katakana_name_to_tts_segments(input: &str) -> Option<Vec<TtsNameSegment>> {
+    let pronunciation = katakana_name_to_ipa(input)?;
+    Some(vec![TtsNameSegment {
+        surface: input.to_string(),
+        fallback_text: katakana_to_hiragana(input),
+        pronunciation,
+        alphabet: TtsAlphabetKind::Ipa,
+        lang: "ja-JP",
+        separator: String::new(),
+    }])
 }
 
 fn should_split_camel_case_token(prev: Option<char>, current: char) -> bool {
     matches!(prev, Some(prev) if prev.is_ascii_lowercase() && current.is_ascii_uppercase())
 }
 
-fn flush_name_token(
-    output: &mut String,
-    token: &mut String,
-    emitted_word: &mut bool,
-) -> Option<()> {
-    if token.is_empty() {
-        return Some(());
+fn romanized_name_to_tts_segments(input: &str) -> Option<Vec<TtsNameSegment>> {
+    let mut tokens: Vec<String> = Vec::new();
+    let mut token = String::new();
+    let mut prev_token_char: Option<char> = None;
+
+    for c in input.chars() {
+        if is_name_token_char(c) {
+            if should_split_camel_case_token(prev_token_char, c) {
+                flush_name_token(&mut tokens, &mut token);
+            }
+            token.push(c);
+            prev_token_char = Some(c);
+            continue;
+        }
+
+        flush_name_token(&mut tokens, &mut token);
+        prev_token_char = None;
     }
 
-    let ipa = word_to_ipa(token)?;
-    if *emitted_word && !output.ends_with(' ') {
-        output.push(' ');
+    flush_name_token(&mut tokens, &mut token);
+
+    if tokens.is_empty() {
+        return Some(vec![]);
     }
-    output.push_str(&ipa);
-    *emitted_word = true;
-    token.clear();
-    Some(())
+
+    let mut segments = Vec::new();
+    for (index, token) in tokens.iter().enumerate() {
+        let mut word_segments = word_to_tts_segments(token)?;
+        if let Some(last) = word_segments.last_mut() {
+            last.separator = if index + 1 < tokens.len() {
+                " ".to_string()
+            } else {
+                String::new()
+            };
+        }
+        segments.extend(word_segments);
+    }
+
+    Some(segments)
 }
 
-fn word_to_ipa(token: &str) -> Option<String> {
-    let normalized = normalize_name_token(token);
-    if normalized.is_empty() {
-        return Some(String::new());
+fn flush_name_token(tokens: &mut Vec<String>, token: &mut String) {
+    if token.is_empty() {
+        return;
     }
 
-    if let Some(ipa) = split_compound_token_to_ipa(&normalized) {
-        return Some(ipa);
+    tokens.push(token.clone());
+    token.clear();
+}
+
+fn word_to_tts_segments(token: &str) -> Option<Vec<TtsNameSegment>> {
+    let normalized = normalize_name_token(token);
+    if normalized.is_empty() {
+        return Some(vec![]);
+    }
+
+    if let Some(segments) = split_compound_token_to_tts_segments(token, &normalized) {
+        return Some(segments);
     }
 
     if let Some(ipa) = lookup_english_word_ipa(&normalized) {
-        return Some(ipa.to_string());
+        return Some(vec![TtsNameSegment {
+            surface: token.to_string(),
+            fallback_text: token.to_string(),
+            pronunciation: ipa.to_string(),
+            alphabet: TtsAlphabetKind::Ipa,
+            lang: "en-US",
+            separator: String::new(),
+        }]);
     }
 
     if normalized.chars().all(|c| c.is_ascii_digit()) {
         if let Some(ipa) = number_to_ipa(&normalized) {
-            return Some(ipa.to_string());
+            return Some(vec![TtsNameSegment {
+                surface: token.to_string(),
+                fallback_text: token.to_string(),
+                pronunciation: ipa.to_string(),
+                alphabet: TtsAlphabetKind::Ipa,
+                lang: "en-US",
+                separator: String::new(),
+            }]);
         }
 
-        let mut output = String::new();
+        let mut pronunciation = String::new();
         for digit in normalized.chars() {
             let ipa = number_to_ipa(&digit.to_string())?;
-            output.push_str(ipa);
+            pronunciation.push_str(ipa);
         }
-        return Some(output);
+        return Some(vec![TtsNameSegment {
+            surface: token.to_string(),
+            fallback_text: token.to_string(),
+            pronunciation,
+            alphabet: TtsAlphabetKind::Ipa,
+            lang: "en-US",
+            separator: String::new(),
+        }]);
     }
 
-    romaji_to_katakana(&normalized).and_then(|katakana| katakana_to_ipa(&katakana))
+    let katakana = romaji_to_katakana(&normalized)?;
+    let pronunciation = katakana_to_ipa(&katakana)?;
+    Some(vec![TtsNameSegment {
+        surface: token.to_string(),
+        fallback_text: katakana_to_hiragana(&katakana),
+        pronunciation,
+        alphabet: TtsAlphabetKind::Ipa,
+        lang: "ja-JP",
+        separator: String::new(),
+    }])
 }
 
-fn split_compound_token_to_ipa(token: &str) -> Option<String> {
+fn split_compound_token_to_tts_segments(
+    original: &str,
+    normalized: &str,
+) -> Option<Vec<TtsNameSegment>> {
     const JAPANESE_SUFFIXES: &[&str] = &["kaigan"];
 
     for suffix in JAPANESE_SUFFIXES {
-        if token.len() <= suffix.len() || !token.ends_with(suffix) {
+        if normalized.len() <= suffix.len() || !normalized.ends_with(suffix) {
             continue;
         }
 
-        let stem = &token[..token.len() - suffix.len()];
-        let stem_ipa = word_to_ipa(stem)?;
-        let suffix_ipa = word_to_ipa(suffix)?;
-        if stem_ipa.is_empty() || suffix_ipa.is_empty() {
+        let stem_len = normalized.len() - suffix.len();
+        let stem = &original[..stem_len];
+        let mut stem_segments = word_to_tts_segments(stem)?;
+        let suffix_segments = word_to_tts_segments(suffix)?;
+        if stem_segments.is_empty() || suffix_segments.is_empty() {
             return None;
         }
-        return Some(format!("{stem_ipa} {suffix_ipa}"));
+        if let Some(last) = stem_segments.last_mut() {
+            last.separator = " ".to_string();
+        }
+        stem_segments.extend(suffix_segments);
+        return Some(stem_segments);
     }
 
     None
+}
+
+fn katakana_to_hiragana(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| match c {
+            'ァ'..='ヶ' => char::from_u32(c as u32 - 0x60).unwrap_or(c),
+            _ => c,
+        })
+        .collect()
 }
 
 fn is_name_token_char(c: char) -> bool {
@@ -189,29 +289,6 @@ fn is_name_token_char(c: char) -> bool {
         || matches!(
             c,
             '\'' | '.' | 'Ā' | 'Ī' | 'Ū' | 'Ē' | 'Ō' | 'ā' | 'ī' | 'ū' | 'ē' | 'ō'
-        )
-}
-
-fn is_separator_like(c: char) -> bool {
-    c.is_whitespace()
-        || matches!(
-            c,
-            '-' | '‐'
-                | '‑'
-                | '‒'
-                | '–'
-                | '—'
-                | '―'
-                | '/'
-                | '･'
-                | '・'
-                | '·'
-                | '('
-                | ')'
-                | '（'
-                | '）'
-                | ','
-                | '、'
         )
 }
 

--- a/stationapi/src/use_case/dto.rs
+++ b/stationapi/src/use_case/dto.rs
@@ -4,3 +4,4 @@ pub mod line_symbol;
 pub mod station;
 pub mod station_number;
 pub mod train_type;
+pub mod tts;

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -18,7 +18,7 @@ impl From<Line> for GrpcLine {
         };
         let name_roman_ipa = station_name_to_ipa("", line.line_name_r.as_deref());
         let name_tts_segments = to_proto_tts_segments(station_name_to_tts_segments(
-            "",
+            &line.line_name_k,
             line.line_name_r.as_deref(),
         ));
         // バス路線の場合は line_type を OtherLineType (0) に強制

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -1,7 +1,7 @@
 use crate::{
     domain::{
         entity::{gtfs::TransportType, line::Line},
-        ipa::{katakana_to_ipa, replace_line_name_suffix, station_name_to_ipa},
+        ipa::{katakana_name_to_ipa, non_empty_ipa, replace_line_name_suffix, station_name_to_ipa},
     },
     proto::{Line as GrpcLine, TransportType as GrpcTransportType},
 };
@@ -10,11 +10,9 @@ impl From<Line> for GrpcLine {
     fn from(line: Line) -> Self {
         let name_ipa = {
             let (stem, suffix_ipa) = replace_line_name_suffix(&line.line_name_k);
-            katakana_to_ipa(stem).map(|ipa| format!("{ipa}{suffix_ipa}"))
-        }
-        .filter(|ipa| !ipa.is_empty());
-        let name_roman_ipa =
-            station_name_to_ipa("", line.line_name_r.as_deref()).filter(|ipa| !ipa.is_empty());
+            non_empty_ipa(katakana_name_to_ipa(stem).map(|ipa| format!("{ipa}{suffix_ipa}")))
+        };
+        let name_roman_ipa = station_name_to_ipa("", line.line_name_r.as_deref());
         // バス路線の場合は line_type を OtherLineType (0) に強制
         // (鉄道用の line_type が誤って設定されている可能性があるため)
         let line_type = if line.transport_type == TransportType::Bus {

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -1,9 +1,13 @@
 use crate::{
     domain::{
         entity::{gtfs::TransportType, line::Line},
-        ipa::{katakana_name_to_ipa, non_empty_ipa, replace_line_name_suffix, station_name_to_ipa},
+        ipa::{
+            katakana_name_to_ipa, non_empty_ipa, replace_line_name_suffix, station_name_to_ipa,
+            station_name_to_tts_segments,
+        },
     },
     proto::{Line as GrpcLine, TransportType as GrpcTransportType},
+    use_case::dto::tts::to_proto_tts_segments,
 };
 
 impl From<Line> for GrpcLine {
@@ -13,6 +17,10 @@ impl From<Line> for GrpcLine {
             non_empty_ipa(katakana_name_to_ipa(stem).map(|ipa| format!("{ipa}{suffix_ipa}")))
         };
         let name_roman_ipa = station_name_to_ipa("", line.line_name_r.as_deref());
+        let name_tts_segments = to_proto_tts_segments(station_name_to_tts_segments(
+            "",
+            line.line_name_r.as_deref(),
+        ));
         // バス路線の場合は line_type を OtherLineType (0) に強制
         // (鉄道用の line_type が誤って設定されている可能性があるため)
         let line_type = if line.transport_type == TransportType::Bus {
@@ -42,6 +50,7 @@ impl From<Line> for GrpcLine {
             transport_type: convert_transport_type(line.transport_type),
             name_ipa,
             name_roman_ipa,
+            name_tts_segments,
         }
     }
 }

--- a/stationapi/src/use_case/dto/station.rs
+++ b/stationapi/src/use_case/dto/station.rs
@@ -188,6 +188,7 @@ mod tests {
         assert_eq!(grpc_station.name_tts_segments[0].separator, " ");
         assert_eq!(grpc_station.name_tts_segments[1].surface, "Rinkai");
         assert_eq!(grpc_station.name_tts_segments[1].fallback_text, "りんかい");
+        assert_eq!(grpc_station.name_tts_segments[1].pronunciation, "ɾiŋka.i");
         assert_eq!(grpc_station.name_tts_segments[1].separator, " ");
         assert_eq!(grpc_station.name_tts_segments[2].surface, "Park");
         assert_eq!(grpc_station.name_tts_segments[2].fallback_text, "Park");

--- a/stationapi/src/use_case/dto/station.rs
+++ b/stationapi/src/use_case/dto/station.rs
@@ -1,7 +1,7 @@
 use crate::{
     domain::{
         entity::{gtfs::TransportType, station::Station},
-        ipa::{katakana_to_ipa, station_name_to_ipa},
+        ipa::{katakana_name_to_ipa, station_name_to_ipa},
     },
     proto::{Station as GrpcStation, TransportType as GrpcTransportType},
 };
@@ -17,7 +17,7 @@ impl From<TransportType> for i32 {
 
 impl From<Station> for GrpcStation {
     fn from(station: Station) -> Self {
-        let name_ipa = katakana_to_ipa(&station.station_name_k).filter(|ipa| !ipa.is_empty());
+        let name_ipa = katakana_name_to_ipa(&station.station_name_k);
         let name_roman_ipa =
             station_name_to_ipa(&station.station_name_k, station.station_name_r.as_deref());
         Self {
@@ -149,5 +149,20 @@ mod tests {
         let grpc_station: GrpcStation = create_test_station("渋谷", "シブヤ", Some("???")).into();
 
         assert_eq!(grpc_station.name_roman_ipa, Some("ɕibɯja".to_string()));
+    }
+
+    #[test]
+    fn test_station_name_roman_ipa_uses_meitetsu_station_data() {
+        let grpc_station: GrpcStation = create_test_station(
+            "名鉄一宮",
+            "メイテツイチノミヤ",
+            Some("Meitetsu Ichinomiya"),
+        )
+        .into();
+
+        assert_eq!(
+            grpc_station.name_roman_ipa,
+            Some("me.itet͡sɯ it͡ɕinomija".to_string())
+        );
     }
 }

--- a/stationapi/src/use_case/dto/station.rs
+++ b/stationapi/src/use_case/dto/station.rs
@@ -1,9 +1,10 @@
 use crate::{
     domain::{
         entity::{gtfs::TransportType, station::Station},
-        ipa::{katakana_name_to_ipa, station_name_to_ipa},
+        ipa::{katakana_name_to_ipa, station_name_to_ipa, station_name_to_tts_segments},
     },
     proto::{Station as GrpcStation, TransportType as GrpcTransportType},
+    use_case::dto::tts::to_proto_tts_segments,
 };
 
 impl From<TransportType> for i32 {
@@ -20,6 +21,10 @@ impl From<Station> for GrpcStation {
         let name_ipa = katakana_name_to_ipa(&station.station_name_k);
         let name_roman_ipa =
             station_name_to_ipa(&station.station_name_k, station.station_name_r.as_deref());
+        let name_tts_segments = to_proto_tts_segments(station_name_to_tts_segments(
+            &station.station_name_k,
+            station.station_name_r.as_deref(),
+        ));
         Self {
             id: station.station_cd as u32,
             group_id: station.station_g_cd as u32,
@@ -51,6 +56,7 @@ impl From<Station> for GrpcStation {
             transport_type: station.transport_type.into(),
             name_ipa,
             name_roman_ipa,
+            name_tts_segments,
         }
     }
 }
@@ -164,5 +170,28 @@ mod tests {
             grpc_station.name_roman_ipa,
             Some("me.itet͡sɯ it͡ɕinomija".to_string())
         );
+    }
+
+    #[test]
+    fn test_station_name_tts_segments_split_mixed_english_station_name() {
+        let grpc_station: GrpcStation = create_test_station(
+            "葛西臨海公園",
+            "カサイリンカイコウエン",
+            Some("Kasai-Rinkai Park"),
+        )
+        .into();
+
+        assert_eq!(grpc_station.name_tts_segments.len(), 3);
+        assert_eq!(grpc_station.name_tts_segments[0].surface, "Kasai");
+        assert_eq!(grpc_station.name_tts_segments[0].fallback_text, "かさい");
+        assert_eq!(grpc_station.name_tts_segments[0].pronunciation, "kasa.i");
+        assert_eq!(grpc_station.name_tts_segments[0].separator, " ");
+        assert_eq!(grpc_station.name_tts_segments[1].surface, "Rinkai");
+        assert_eq!(grpc_station.name_tts_segments[1].fallback_text, "りんかい");
+        assert_eq!(grpc_station.name_tts_segments[1].separator, " ");
+        assert_eq!(grpc_station.name_tts_segments[2].surface, "Park");
+        assert_eq!(grpc_station.name_tts_segments[2].fallback_text, "Park");
+        assert_eq!(grpc_station.name_tts_segments[2].pronunciation, "pɑɹk");
+        assert_eq!(grpc_station.name_tts_segments[2].separator, "");
     }
 }

--- a/stationapi/src/use_case/dto/train_type.rs
+++ b/stationapi/src/use_case/dto/train_type.rs
@@ -1,7 +1,7 @@
 use crate::{
     domain::{
         entity::train_type::TrainType,
-        ipa::{katakana_to_ipa, station_name_to_ipa},
+        ipa::{katakana_name_to_ipa, station_name_to_ipa},
     },
     proto::TrainType as GrpcTrainType,
 };
@@ -25,7 +25,7 @@ impl From<TrainType> for GrpcTrainType {
             lines,
             kind,
         } = train_type;
-        let name_ipa = katakana_to_ipa(&type_name_k).filter(|ipa| !ipa.is_empty());
+        let name_ipa = katakana_name_to_ipa(&type_name_k);
         let name_roman_ipa = station_name_to_ipa("", type_name_r.as_deref());
         Self {
             id: id.map(|id| id as u32).unwrap_or(0),

--- a/stationapi/src/use_case/dto/train_type.rs
+++ b/stationapi/src/use_case/dto/train_type.rs
@@ -1,9 +1,10 @@
 use crate::{
     domain::{
         entity::train_type::TrainType,
-        ipa::{katakana_name_to_ipa, station_name_to_ipa},
+        ipa::{katakana_name_to_ipa, station_name_to_ipa, station_name_to_tts_segments},
     },
     proto::TrainType as GrpcTrainType,
+    use_case::dto::tts::to_proto_tts_segments,
 };
 
 impl From<TrainType> for GrpcTrainType {
@@ -27,6 +28,10 @@ impl From<TrainType> for GrpcTrainType {
         } = train_type;
         let name_ipa = katakana_name_to_ipa(&type_name_k);
         let name_roman_ipa = station_name_to_ipa("", type_name_r.as_deref());
+        let name_tts_segments = to_proto_tts_segments(station_name_to_tts_segments(
+            &type_name_k,
+            type_name_r.as_deref(),
+        ));
         Self {
             id: id.map(|id| id as u32).unwrap_or(0),
             type_id: type_cd.map(|id| id as u32).unwrap_or(0),
@@ -43,6 +48,7 @@ impl From<TrainType> for GrpcTrainType {
             kind: kind.unwrap_or(0),
             name_ipa,
             name_roman_ipa,
+            name_tts_segments,
         }
     }
 }

--- a/stationapi/src/use_case/dto/tts.rs
+++ b/stationapi/src/use_case/dto/tts.rs
@@ -1,0 +1,22 @@
+use crate::{
+    domain::ipa::{TtsAlphabetKind, TtsNameSegment},
+    proto::{TtsAlphabet, TtsSegment},
+};
+
+pub fn to_proto_tts_segments(segments: Vec<TtsNameSegment>) -> Vec<TtsSegment> {
+    segments
+        .into_iter()
+        .map(|segment| TtsSegment {
+            surface: segment.surface,
+            fallback_text: segment.fallback_text,
+            pronunciation: segment.pronunciation,
+            alphabet: match segment.alphabet {
+                TtsAlphabetKind::Ipa => TtsAlphabet::Ipa as i32,
+                TtsAlphabetKind::Yomigana => TtsAlphabet::Yomigana as i32,
+                TtsAlphabetKind::Plain => TtsAlphabet::Plain as i32,
+            },
+            lang: segment.lang.to_string(),
+            separator: segment.separator,
+        })
+        .collect()
+}

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -834,8 +834,7 @@ where
                         })
                         .collect();
 
-                    let name_ipa = crate::domain::ipa::katakana_to_ipa(&row.station_name_k)
-                        .filter(|ipa| !ipa.is_empty());
+                    let name_ipa = crate::domain::ipa::katakana_name_to_ipa(&row.station_name_k);
                     let name_roman_ipa = crate::domain::ipa::station_name_to_ipa(
                         &row.station_name_k,
                         row.station_name_r.as_deref(),

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -839,6 +839,12 @@ where
                         &row.station_name_k,
                         row.station_name_r.as_deref(),
                     );
+                    let name_tts_segments = crate::use_case::dto::tts::to_proto_tts_segments(
+                        crate::domain::ipa::station_name_to_tts_segments(
+                            &row.station_name_k,
+                            row.station_name_r.as_deref(),
+                        ),
+                    );
                     proto::StationMinimal {
                         id: row.station_cd as u32,
                         group_id: row.station_g_cd as u32,
@@ -852,6 +858,7 @@ where
                         train_type_id: row.type_id.map(|id| id as u32),
                         name_ipa,
                         name_roman_ipa,
+                        name_tts_segments,
                     }
                 })
                 .collect::<Vec<proto::StationMinimal>>();


### PR DESCRIPTION
## Summary
- add segmented TTS metadata for Station, StationMinimal, Line, and TrainType
- preserve existing IPA fields while introducing per-token TTS segments for mixed-language names
- update the gRPCProto submodule and IPA handling to support mixed-language TTS construction

## Verification
- cargo fmt --check
- SQLX_OFFLINE=true cargo build -p stationapi
- SQLX_OFFLINE=true cargo test -p stationapi

## Related
- gRPCProto PR: https://github.com/TrainLCD/gRPCProto/pull/21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * TTS メタデータ公開に関する説明を追加

* **新機能**
  * Station、StationMinimal、Line、TrainType が name_tts_segments を公開し、各セグメント単位の発音データ（表記、フォールバック、発音、言語、区切り）を取得可能に

* **テスト**
  * 混在言語の駅名に対する TTS セグメント分割の検証テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->