### PR TITLE
Add Prometheus metrics for gRPC performance monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +140,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,11 +243,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -264,10 +298,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -309,6 +344,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +378,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -376,6 +430,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -504,6 +567,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +624,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "finl_unicode"
@@ -624,6 +699,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -907,6 +988,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1153,6 +1235,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "indexmap 2.7.1",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.55",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.2",
+ "metrics",
+ "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,10 +1332,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1305,7 +1434,7 @@ version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1330,6 +1459,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -1473,6 +1608,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1695,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1683,6 +1839,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1819,7 +1993,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1832,12 +2006,25 @@ version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -1865,6 +2052,7 @@ version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1903,8 +2091,21 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
- "core-foundation",
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1912,9 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1922,18 +2123,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2024,6 +2235,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -2173,7 +2390,7 @@ checksum = "4560278f0e00ce64938540546f59f590d60beee33fffbd3b9cd47851e5fff233"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -2216,7 +2433,7 @@ checksum = "c5b98a57f363ed6764d5b3a12bfedf62f07aa16e1856a7ddc2a0bb190a959613"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
  "byteorder",
  "chrono",
  "crc",
@@ -2279,6 +2496,10 @@ dependencies = [
  "chrono",
  "csv",
  "dotenv",
+ "http",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "pin-project-lite",
  "prost",
  "reqwest",
  "serde",
@@ -2291,6 +2512,7 @@ dependencies = [
  "tonic-health",
  "tonic-reflection",
  "tonic-web",
+ "tower 0.5.2",
  "tracing",
  "tracing-subscriber",
  "zip",
@@ -2626,7 +2848,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
  "bytes",
  "http",
  "http-body",
@@ -3229,7 +3451,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3239,6 +3461,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/stationapi/Cargo.toml
+++ b/stationapi/Cargo.toml
@@ -30,6 +30,11 @@ csv = "1.3.1"
 chrono = ">=0.4.20"
 reqwest = { version = "0.12.12", default-features = false, features = ["blocking", "rustls-tls"] }
 zip = ">=2.3.0"
+metrics = "0.24"
+metrics-exporter-prometheus = "0.16"
+pin-project-lite = "0.2"
+http = "1"
+tower = { version = "0.5", features = ["util"] }
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/stationapi/src/main.rs
+++ b/stationapi/src/main.rs
@@ -66,7 +66,9 @@ async fn run() -> std::result::Result<(), anyhow::Error> {
         .parse()
         .expect("Failed to parse metrics address");
     metrics_exporter_prometheus::PrometheusBuilder::new()
-        .set_buckets(&[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0])
+        .set_buckets(&[
+            0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+        ])
         .expect("Failed to set histogram buckets")
         .with_http_listener(metrics_addr)
         .install()
@@ -222,10 +224,7 @@ fn fetch_metrics_port() -> u16 {
         Ok(s) => s.parse().expect("Failed to parse $METRICS_PORT"),
         Err(env::VarError::NotPresent) => {
             let default = fetch_port() + 1;
-            warn!(
-                "$METRICS_PORT is not set. Falling back to {}.",
-                default
-            );
+            warn!("$METRICS_PORT is not set. Falling back to {}.", default);
             default
         }
         Err(VarError::NotUnicode(_)) => panic!("$METRICS_PORT should be written in Unicode."),

--- a/stationapi/src/main.rs
+++ b/stationapi/src/main.rs
@@ -60,9 +60,14 @@ async fn main() -> std::result::Result<(), anyhow::Error> {
 async fn run() -> std::result::Result<(), anyhow::Error> {
     tracing_subscriber::fmt::init();
 
+    if dotenv::from_filename(".env.local").is_err() {
+        warn!("Could not load .env.local");
+    };
+
     // Initialize Prometheus metrics exporter on a separate HTTP port
+    let metrics_host = fetch_metrics_host();
     let metrics_port = fetch_metrics_port();
-    let metrics_addr: SocketAddr = format!("0.0.0.0:{metrics_port}")
+    let metrics_addr: SocketAddr = format!("{metrics_host}:{metrics_port}")
         .parse()
         .expect("Failed to parse metrics address");
     metrics_exporter_prometheus::PrometheusBuilder::new()
@@ -74,10 +79,6 @@ async fn run() -> std::result::Result<(), anyhow::Error> {
         .install()
         .expect("Failed to install Prometheus exporter");
     info!("Prometheus metrics server listening on {}", metrics_addr);
-
-    if dotenv::from_filename(".env.local").is_err() {
-        warn!("Could not load .env.local");
-    };
 
     if let Err(e) = import::import_csv().await {
         return Err(anyhow::anyhow!("Failed to import CSV: {}", e));
@@ -219,11 +220,29 @@ fn fetch_addr() -> Result<SocketAddr, AddrParseError> {
     }
 }
 
+fn fetch_metrics_host() -> String {
+    match env::var("METRICS_HOST") {
+        Ok(s) => s,
+        Err(env::VarError::NotPresent) => {
+            warn!("$METRICS_HOST is not set. Falling back to 127.0.0.1.");
+            "127.0.0.1".to_owned()
+        }
+        Err(VarError::NotUnicode(_)) => panic!("$METRICS_HOST should be written in Unicode."),
+    }
+}
+
 fn fetch_metrics_port() -> u16 {
     match env::var("METRICS_PORT") {
         Ok(s) => s.parse().expect("Failed to parse $METRICS_PORT"),
         Err(env::VarError::NotPresent) => {
-            let default = fetch_port() + 1;
+            let port = fetch_port();
+            let default = port.checked_add(1).unwrap_or_else(|| {
+                tracing::error!(
+                    "Cannot derive default METRICS_PORT: PORT={} would overflow u16. Set $METRICS_PORT explicitly.",
+                    port
+                );
+                std::process::exit(1);
+            });
             warn!("$METRICS_PORT is not set. Falling back to {}.", default);
             default
         }

--- a/stationapi/src/main.rs
+++ b/stationapi/src/main.rs
@@ -8,6 +8,7 @@ use stationapi::infrastructure::line_repository::MyLineRepository;
 use stationapi::infrastructure::station_repository::MyStationRepository;
 use stationapi::infrastructure::train_type_repository::MyTrainTypeRepository;
 use stationapi::presentation::controller::grpc::MyApi;
+use stationapi::presentation::middleware::metrics::GrpcMetricsLayer;
 use stationapi::proto;
 use stationapi::proto::station_api_server::StationApiServer;
 use stationapi::use_case::interactor::query::QueryInteractor;
@@ -58,6 +59,19 @@ async fn main() -> std::result::Result<(), anyhow::Error> {
 
 async fn run() -> std::result::Result<(), anyhow::Error> {
     tracing_subscriber::fmt::init();
+
+    // Initialize Prometheus metrics exporter on a separate HTTP port
+    let metrics_port = fetch_metrics_port();
+    let metrics_addr: SocketAddr = format!("0.0.0.0:{metrics_port}")
+        .parse()
+        .expect("Failed to parse metrics address");
+    metrics_exporter_prometheus::PrometheusBuilder::new()
+        .set_buckets(&[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0])
+        .expect("Failed to set histogram buckets")
+        .with_http_listener(metrics_addr)
+        .install()
+        .expect("Failed to install Prometheus exporter");
+    info!("Prometheus metrics server listening on {}", metrics_addr);
 
     if dotenv::from_filename(".env.local").is_err() {
         warn!("Could not load .env.local");
@@ -159,6 +173,7 @@ async fn run() -> std::result::Result<(), anyhow::Error> {
 
     if disable_grpc_web {
         Server::builder()
+            .layer(GrpcMetricsLayer)
             .add_service(health_service)
             .add_service(svc)
             .add_service(reflection_svc)
@@ -167,6 +182,7 @@ async fn run() -> std::result::Result<(), anyhow::Error> {
     } else {
         Server::builder()
             .accept_http1(true)
+            .layer(GrpcMetricsLayer)
             .add_service(health_service)
             .add_service(tonic_web::enable(svc))
             .add_service(tonic_web::enable(reflection_svc))
@@ -198,6 +214,21 @@ fn fetch_addr() -> Result<SocketAddr, AddrParseError> {
             fallback_host.parse()
         }
         Err(VarError::NotUnicode(_)) => panic!("$HOST should be written in Unicode."),
+    }
+}
+
+fn fetch_metrics_port() -> u16 {
+    match env::var("METRICS_PORT") {
+        Ok(s) => s.parse().expect("Failed to parse $METRICS_PORT"),
+        Err(env::VarError::NotPresent) => {
+            let default = fetch_port() + 1;
+            warn!(
+                "$METRICS_PORT is not set. Falling back to {}.",
+                default
+            );
+            default
+        }
+        Err(VarError::NotUnicode(_)) => panic!("$METRICS_PORT should be written in Unicode."),
     }
 }
 

--- a/stationapi/src/presentation.rs
+++ b/stationapi/src/presentation.rs
@@ -1,2 +1,3 @@
 pub mod controller;
 pub mod error;
+pub mod middleware;

--- a/stationapi/src/presentation/middleware.rs
+++ b/stationapi/src/presentation/middleware.rs
@@ -1,0 +1,1 @@
+pub mod metrics;

--- a/stationapi/src/presentation/middleware/metrics.rs
+++ b/stationapi/src/presentation/middleware/metrics.rs
@@ -1,0 +1,88 @@
+use std::{
+    task::{Context, Poll},
+    time::Instant,
+};
+
+use http::Request;
+use metrics::{counter, histogram};
+use pin_project_lite::pin_project;
+use tower::{Layer, Service};
+
+/// Tower Layer that records gRPC request metrics (counters + latency histogram).
+#[derive(Clone, Debug)]
+pub struct GrpcMetricsLayer;
+
+impl<S> Layer<S> for GrpcMetricsLayer {
+    type Service = GrpcMetricsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        GrpcMetricsService { inner }
+    }
+}
+
+/// Tower Service wrapper that instruments each request.
+#[derive(Clone, Debug)]
+pub struct GrpcMetricsService<S> {
+    inner: S,
+}
+
+impl<S, B> Service<Request<B>> for GrpcMetricsService<S>
+where
+    S: Service<Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = GrpcMetricsFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let method = req.uri().path().to_owned();
+
+        counter!("grpc_requests_started_total", "method" => method.clone()).increment(1);
+
+        GrpcMetricsFuture {
+            inner: self.inner.call(req),
+            method,
+            start: Instant::now(),
+        }
+    }
+}
+
+pin_project! {
+    /// Future that records latency and completion metrics when the inner future resolves.
+    pub struct GrpcMetricsFuture<F> {
+        #[pin]
+        inner: F,
+        method: String,
+        start: Instant,
+    }
+}
+
+impl<F, Response, Error> std::future::Future for GrpcMetricsFuture<F>
+where
+    F: std::future::Future<Output = Result<Response, Error>>,
+{
+    type Output = Result<Response, Error>;
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.inner.poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(result) => {
+                let elapsed = this.start.elapsed().as_secs_f64();
+                let status = if result.is_ok() { "ok" } else { "error" };
+                let method = this.method.clone();
+
+                counter!("grpc_requests_total", "method" => method.clone(), "status" => status)
+                    .increment(1);
+                histogram!("grpc_request_duration_seconds", "method" => method, "status" => status)
+                    .record(elapsed);
+
+                Poll::Ready(result)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- gRPC全エンドポイントのリクエスト数・レイテンシを自動計測するTower middlewareを追加
- Prometheus `/metrics` エンドポイントを別ポート（デフォルト: メインポート+1）で公開
- 既存のRPCハンドラへの変更不要

## Metrics
| メトリクス名 | 種別 | ラベル |
|---|---|---|
| `grpc_requests_started_total` | Counter | `method` |
| `grpc_requests_total` | Counter | `method`, `status` |
| `grpc_request_duration_seconds` | Histogram | `method`, `status` |

## Configuration
- `METRICS_PORT` 環境変数でポートを変更可能（デフォルト: `PORT + 1`）

## Test plan
- [x] `SQLX_OFFLINE=true cargo build` でコンパイル確認済み
- [ ] サーバー起動後、`curl http://localhost:50052/metrics` でPrometheusメトリクスが返ることを確認
- [ ] gRPCリクエスト送信後、`grpc_request_duration_seconds`と`grpc_requests_total`が増加することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Prometheus形式のメトリクスをHTTPで公開するエクスポーターを追加しました。
  * gRPCリクエストの計測を導入し、リクエスト数・レイテンシ・結果ステータスを収集します。
  * メトリクス用ホスト/ポートを環境変数で指定可能。未指定時は既存のポートから自動決定します。

* **Chores**
  * メトリクス収集に関する依存パッケージを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->