### PR TITLE
Add Prometheus + Grafana monitoring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 Do you like this project? Join our Discord community!
 [https://discord.gg/qKT7zSGQre](https://discord.gg/qKT7zSGQre)
 
+## Monitoring
+
+Prometheus + Grafana による gRPC メトリクスの可視化環境が同梱されています。
+
+```bash
+docker compose up -d prometheus grafana
+```
+
+- **Grafana**: http://localhost:3001 (ログイン: `admin` / `admin`)
+- **Prometheus**: http://localhost:9090
+
+Grafana には「StationAPI gRPC Metrics」ダッシュボードが自動でプロビジョニングされ、リクエストレート、エラーレート、レイテンシパーセンタイル等を確認できます。
+
 ## Development
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Do you like this project? Join our Discord community!
 Prometheus + Grafana による gRPC メトリクスの可視化環境が同梱されています。
 
 ```bash
-docker compose up -d prometheus grafana
+docker compose up -d api prometheus grafana
 ```
 
 - **Grafana**: http://localhost:3001 (ログイン: `admin` / `admin`)

--- a/compose.yml
+++ b/compose.yml
@@ -14,8 +14,10 @@ services:
       DISABLE_GRPC_WEB: false
       DISABLE_BUS_FEATURE: false
       HOST: 0.0.0.0
+      METRICS_HOST: 0.0.0.0
     ports:
       - 50051:50051
+      - 50052:50052
     restart: always
 
   psql:
@@ -29,3 +31,32 @@ services:
       - 5432:5432
     volumes:
       - ./docker/postgres:/docker-entrypoint-initdb.d:ro
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    ports:
+      - 9090:9090
+    restart: always
+
+  grafana:
+    image: grafana/grafana:latest
+    depends_on:
+      - prometheus
+    volumes:
+      - ./docker/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./docker/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    ports:
+      - 3001:3000
+    restart: always
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/compose.yml
+++ b/compose.yml
@@ -33,7 +33,7 @@ services:
       - ./docker/postgres:/docker-entrypoint-initdb.d:ro
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.2.1}
     volumes:
       - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
@@ -42,7 +42,7 @@ services:
     restart: always
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:${GRAFANA_VERSION:-11.5.2}
     depends_on:
       - prometheus
     volumes:

--- a/docker/grafana/dashboards/stationapi-grpc.json
+++ b/docker/grafana/dashboards/stationapi-grpc.json
@@ -204,7 +204,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(grpc_requests_total{status=\"error\"}[5m])) / sum(rate(grpc_requests_total[5m]))",
+          "expr": "sum(rate(grpc_requests_total{status=\"error\"}[5m])) / (sum(rate(grpc_requests_total[5m])) > 0) or vector(0)",
           "legendFormat": "Error Ratio",
           "refId": "A"
         }

--- a/docker/grafana/dashboards/stationapi-grpc.json
+++ b/docker/grafana/dashboards/stationapi-grpc.json
@@ -1,0 +1,267 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "title": "Request Rate (per second)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "pointSize": 5,
+            "showPoints": "auto"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(grpc_requests_total[1m])) by (method)",
+          "legendFormat": "{{ method }}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "title": "Error Rate (per second)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "pointSize": 5,
+            "showPoints": "auto"
+          },
+          "color": { "mode": "fixed", "fixedColor": "red" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(grpc_requests_total{status=\"error\"}[1m])) by (method)",
+          "legendFormat": "{{ method }}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "title": "Request Latency (p50 / p90 / p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(grpc_request_duration_seconds_bucket[5m])) by (le, method))",
+          "legendFormat": "p50 {{ method }}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(grpc_request_duration_seconds_bucket[5m])) by (le, method))",
+          "legendFormat": "p90 {{ method }}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(grpc_request_duration_seconds_bucket[5m])) by (le, method))",
+          "legendFormat": "p99 {{ method }}",
+          "refId": "C"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "title": "Latency Heatmap",
+      "type": "heatmap",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(increase(grpc_request_duration_seconds_bucket[1m])) by (le)",
+          "legendFormat": "{{ le }}",
+          "refId": "A",
+          "format": "heatmap"
+        }
+      ],
+      "options": {
+        "calculate": false,
+        "yAxis": { "unit": "s" },
+        "color": { "scheme": "Oranges" },
+        "tooltip": { "show": true }
+      }
+    },
+    {
+      "title": "Total Requests (Started)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(grpc_requests_started_total)",
+          "legendFormat": "Total Started",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value"
+      }
+    },
+    {
+      "title": "Total Requests (Completed)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(grpc_requests_total)",
+          "legendFormat": "Total Completed",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value"
+      }
+    },
+    {
+      "title": "Error Ratio",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(grpc_requests_total{status=\"error\"}[5m])) / sum(rate(grpc_requests_total[5m]))",
+          "legendFormat": "Error Ratio",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "title": "Request Duration per Method",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 28 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(grpc_request_duration_seconds_sum[5m]) / rate(grpc_request_duration_seconds_count[5m])",
+          "legendFormat": "avg {{ method }}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "name": "DS_PROMETHEUS",
+        "query": "prometheus",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-30m", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "StationAPI gRPC Metrics",
+  "uid": "stationapi-grpc",
+  "version": 1
+}

--- a/docker/grafana/provisioning/dashboards/dashboards.yml
+++ b/docker/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "StationAPI"
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "stationapi"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["api:50052"]
+        labels:
+          service: "stationapi"


### PR DESCRIPTION
## Summary
- Prometheus + Grafana を docker-compose に追加し、gRPC メトリクス (`localhost:50052/metrics`) を可視化できるようにした
- リクエストレート、エラーレート、レイテンシ (p50/p90/p99)、ヒートマップ、エラー率ゲージ等を含むプリセットダッシュボードを同梱
- README に Monitoring セクションを追加

## 詳細
- `compose.yml`: `prometheus`, `grafana` サービス追加。api に `METRICS_HOST` と ポート 50052 を追加
- `docker/prometheus/prometheus.yml`: `api:50052` を 15 秒間隔でスクレイプ
- `docker/grafana/`: データソース・ダッシュボードの自動プロビジョニング設定
- Grafana は `localhost:3001` (admin/admin)、Prometheus は `localhost:9090`

## Test plan
- [ ] `docker compose up -d` で全サービスが起動することを確認
- [ ] `localhost:9090/targets` で Prometheus が api ターゲットを正常にスクレイプしていることを確認
- [ ] `localhost:3001` で Grafana にログインし、「StationAPI gRPC Metrics」ダッシュボードが表示されることを確認
- [ ] gRPC リクエストを送信後、ダッシュボードにメトリクスが反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ローカルで動作する監視環境（Prometheus + Grafana）を同梱し、StationAPIのgRPCメトリクスを可視化するダッシュボードを追加。

* **ドキュメント**
  * READMEに起動手順（docker composeでの起動コマンド）とGrafana/Prometheusのローカルアクセス情報、及び自動プロビジョニングされる「StationAPI gRPC Metrics」ダッシュボードと表示される主な指標（リクエスト率、エラー率、レイテンシ百分位など）を追記。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->