### PR TITLE
Fix GLIBC version mismatch in Dockerfile

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1 AS builder
+FROM rust:1-bookworm AS builder
 
 RUN apt-get update && apt-get install -y \
     protobuf-compiler && \


### PR DESCRIPTION
## Summary
- `rust:1` ベースイメージが最新のDebian (trixie) を使用するようになり、GLIBC 2.38が必要なバイナリが生成されるが、ランタイムの `debian:bookworm-slim` はGLIBC 2.36のため `GLIBC_2.38 not found` エラーが発生していた
- ビルドステージを `rust:1-bookworm` に固定し、ランタイムステージとGLIBCバージョンを一致させることで修正

## Test plan
- [ ] `docker compose up` でAPIコンテナが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他（Chores）**
  * ビルド環境の基盤イメージを更新し、システムの互換性と安定性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->