### PR TITLE
Optimize GetStationsByLineGroupId/GetStationsByLineIdList performance

### DIFF
--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -279,8 +279,9 @@ where
         )?;
 
         // Build HashMap for O(1) company lookup instead of O(n) linear search
-        let company_map: std::collections::HashMap<i32, &Company> =
-            companies.iter().map(|c| (c.company_cd, c)).collect();
+        // Owns the values so we can add bus companies later
+        let mut company_map: std::collections::HashMap<i32, Company> =
+            companies.into_iter().map(|c| (c.company_cd, c)).collect();
 
         // Build HashMap for O(1) train_type lookup by station_cd
         let train_type_map: std::collections::HashMap<i32, &TrainType> = train_types
@@ -294,10 +295,10 @@ where
             .map(|s| ((s.line_cd, s.station_g_cd), s))
             .collect();
 
-        // Cache nearby bus stop candidates by grid key (~100m resolution).
-        // The candidate set is cached, but the 300m distance filter is applied
-        // per-station to ensure correctness.
-        let mut bus_candidate_cache: std::collections::HashMap<(i64, i64), Vec<Station>> =
+        // Cache nearby bus stop candidates by station_g_cd.
+        // Stations with the same station_g_cd are at the same physical location,
+        // so they share identical bus stop candidates.
+        let mut bus_candidate_cache: std::collections::HashMap<i32, Vec<Station>> =
             std::collections::HashMap::new();
         // Cache bus lines by station_group_ids to avoid repeated DB queries
         // for the same set of bus stop groups.
@@ -307,7 +308,7 @@ where
         for station in stations.iter_mut() {
             let mut line = self.extract_line_from_station(station);
             line.line_symbols = self.get_line_symbols(&line);
-            line.company = company_map.get(&line.company_cd).cloned().cloned();
+            line.company = company_map.get(&line.company_cd).cloned();
             line.station = Some(station.clone());
 
             let station_numbers: Vec<StationNumber> = self.get_station_numbers(station);
@@ -337,10 +338,7 @@ where
             // Only add bus routes if transport_type is RailAndBus
             let should_include_bus_routes = transport_type == TransportTypeFilter::RailAndBus;
             if station.transport_type == TransportType::Rail && should_include_bus_routes {
-                let cache_key = (
-                    (station.lat * 1000.0).round() as i64,
-                    (station.lon * 1000.0).round() as i64,
-                );
+                let cache_key = station.station_g_cd;
                 let candidates = if let Some(cached) = bus_candidate_cache.get(&cache_key) {
                     cached.clone()
                 } else {
@@ -416,8 +414,23 @@ where
                 }
             }
 
+            // Fetch any missing companies (e.g., bus-only operators not in initial lines)
+            let missing_company_ids: Vec<u32> = lines
+                .iter()
+                .filter(|l| !company_map.contains_key(&l.company_cd))
+                .map(|l| l.company_cd as u32)
+                .collect::<std::collections::HashSet<u32>>()
+                .into_iter()
+                .collect();
+            if !missing_company_ids.is_empty() {
+                let extra_companies = self.find_company_by_id_vec(&missing_company_ids).await?;
+                for c in extra_companies {
+                    company_map.insert(c.company_cd, c);
+                }
+            }
+
             for line in lines.iter_mut() {
-                line.company = company_map.get(&line.company_cd).cloned().cloned();
+                line.company = company_map.get(&line.company_cd).cloned();
                 line.line_symbols = self.get_line_symbols(line);
                 if let Some(station_ref) = station_lookup.get(&(line.line_cd, station.station_g_cd))
                 {

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -255,32 +255,31 @@ where
             .map(|station| station.station_g_cd as u32)
             .collect::<Vec<u32>>();
 
-        let stations_by_group_ids = self
-            .get_stations_by_group_id_vec(&station_group_ids)
-            .await?;
+        // Phase 1: independent queries in parallel
+        let (stations_by_group_ids, lines) = tokio::try_join!(
+            self.get_stations_by_group_id_vec(&station_group_ids),
+            self.get_lines_by_station_group_id_vec(&station_group_ids),
+        )?;
 
         let station_ids = stations_by_group_ids
             .iter()
             .map(|station| station.station_cd as u32)
             .collect::<Vec<u32>>();
 
-        let lines = &self
-            .get_lines_by_station_group_id_vec(&station_group_ids)
-            .await?;
-
-        let company_ids = &lines
+        let company_ids = lines
             .iter()
             .map(|station| station.company_cd as u32)
             .collect::<Vec<u32>>();
-        let companies = self.find_company_by_id_vec(company_ids).await?;
+
+        // Phase 2: dependent queries in parallel
+        let (companies, train_types) = tokio::try_join!(
+            self.find_company_by_id_vec(&company_ids),
+            self.get_train_types_by_station_id_vec(&station_ids, line_group_id),
+        )?;
 
         // Build HashMap for O(1) company lookup instead of O(n) linear search
         let company_map: std::collections::HashMap<i32, &Company> =
             companies.iter().map(|c| (c.company_cd, c)).collect();
-
-        let train_types = self
-            .get_train_types_by_station_id_vec(&station_ids, line_group_id)
-            .await?;
 
         // Build HashMap for O(1) train_type lookup by station_cd
         let train_type_map: std::collections::HashMap<i32, &TrainType> = train_types
@@ -293,6 +292,9 @@ where
             .iter()
             .map(|s| ((s.line_cd, s.station_g_cd), s))
             .collect();
+
+        let mut bus_line_cache: std::collections::HashMap<(i64, i64), Vec<Line>> =
+            std::collections::HashMap::new();
 
         for station in stations.iter_mut() {
             let mut line = self.extract_line_from_station(station);
@@ -327,7 +329,17 @@ where
             // Only add bus routes if transport_type is RailAndBus
             let should_include_bus_routes = transport_type == TransportTypeFilter::RailAndBus;
             if station.transport_type == TransportType::Rail && should_include_bus_routes {
-                let nearby_bus_lines = self.get_nearby_bus_lines(station.lat, station.lon).await?;
+                let cache_key = (
+                    (station.lat * 1000.0).round() as i64,
+                    (station.lon * 1000.0).round() as i64,
+                );
+                let nearby_bus_lines = if let Some(cached) = bus_line_cache.get(&cache_key) {
+                    cached.clone()
+                } else {
+                    let result = self.get_nearby_bus_lines(station.lat, station.lon).await?;
+                    bus_line_cache.insert(cache_key, result.clone());
+                    result
+                };
                 for bus_line in nearby_bus_lines {
                     if seen_line_cds.insert(bus_line.line_cd) {
                         lines.push(bus_line);
@@ -668,6 +680,9 @@ where
         station_id_vec: &[u32],
         line_group_id: Option<u32>,
     ) -> Result<Vec<TrainType>, UseCaseError> {
+        if line_group_id.is_none() {
+            return Ok(vec![]);
+        }
         let train_types = self
             .train_type_repository
             .get_types_by_station_id_vec(station_id_vec, line_group_id)
@@ -2171,7 +2186,7 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail)
+                .update_station_vec_with_attributes(stations, Some(1000), TransportTypeFilter::Rail)
                 .await
                 .expect("Should succeed");
 
@@ -2436,7 +2451,7 @@ mod tests {
 
             let stations = vec![station1, station2];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail)
+                .update_station_vec_with_attributes(stations, Some(1000), TransportTypeFilter::Rail)
                 .await
                 .expect("Should succeed");
 

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -293,7 +293,10 @@ where
             .map(|s| ((s.line_cd, s.station_g_cd), s))
             .collect();
 
-        let mut bus_line_cache: std::collections::HashMap<(i64, i64), Vec<Line>> =
+        // Cache nearby bus stop candidates by grid key (~100m resolution).
+        // The candidate set is cached, but the 300m distance filter is applied
+        // per-station to ensure correctness.
+        let mut bus_candidate_cache: std::collections::HashMap<(i64, i64), Vec<Station>> =
             std::collections::HashMap::new();
 
         for station in stations.iter_mut() {
@@ -333,16 +336,64 @@ where
                     (station.lat * 1000.0).round() as i64,
                     (station.lon * 1000.0).round() as i64,
                 );
-                let nearby_bus_lines = if let Some(cached) = bus_line_cache.get(&cache_key) {
+                let candidates = if let Some(cached) = bus_candidate_cache.get(&cache_key) {
                     cached.clone()
                 } else {
-                    let result = self.get_nearby_bus_lines(station.lat, station.lon).await?;
-                    bus_line_cache.insert(cache_key, result.clone());
+                    let result = self
+                        .station_repository
+                        .get_by_coordinates(station.lat, station.lon, Some(50), Some(TransportType::Bus))
+                        .await?;
+                    bus_candidate_cache.insert(cache_key, result.clone());
                     result
                 };
-                for bus_line in nearby_bus_lines {
-                    if seen_line_cds.insert(bus_line.line_cd) {
-                        lines.push(bus_line);
+
+                // Apply 300m filter from this station's exact coordinates
+                let nearby_bus_stops: Vec<&Station> = candidates
+                    .iter()
+                    .filter(|bus_stop| {
+                        haversine_distance(station.lat, station.lon, bus_stop.lat, bus_stop.lon)
+                            <= NEARBY_BUS_STOP_RADIUS_METERS
+                    })
+                    .collect();
+
+                if !nearby_bus_stops.is_empty() {
+                    let bus_station_group_ids: Vec<u32> = nearby_bus_stops
+                        .iter()
+                        .map(|s| s.station_g_cd as u32)
+                        .collect();
+
+                    let mut bus_lines = self
+                        .line_repository
+                        .get_by_station_group_id_vec(&bus_station_group_ids)
+                        .await?;
+
+                    let mut seen_bus_line_cds = std::collections::HashSet::new();
+                    bus_lines.retain(|line| {
+                        line.transport_type == TransportType::Bus
+                            && seen_bus_line_cds.insert(line.line_cd)
+                    });
+
+                    let bus_stop_by_line_cd: std::collections::HashMap<i32, &Station> =
+                        nearby_bus_stops
+                            .iter()
+                            .filter(|s| seen_bus_line_cds.contains(&s.line_cd))
+                            .map(|s| (s.line_cd, *s))
+                            .collect();
+
+                    for bus_line in bus_lines.iter_mut() {
+                        bus_line.line_symbols = self.get_line_symbols(bus_line);
+                        if let Some(&bus_stop) = bus_stop_by_line_cd.get(&bus_line.line_cd) {
+                            let mut station_copy = bus_stop.clone();
+                            station_copy.station_numbers =
+                                self.get_station_numbers(&station_copy);
+                            bus_line.station = Some(station_copy);
+                        }
+                    }
+
+                    for bus_line in bus_lines {
+                        if seen_line_cds.insert(bus_line.line_cd) {
+                            lines.push(bus_line);
+                        }
                     }
                 }
             }
@@ -1942,11 +1993,20 @@ mod tests {
         /// Configurable mock train type repository for testing
         struct ConfigurableMockTrainTypeRepository {
             train_types: Vec<TrainType>,
+            expected_line_group_id: Option<u32>,
         }
 
         impl ConfigurableMockTrainTypeRepository {
             fn new(train_types: Vec<TrainType>) -> Self {
-                Self { train_types }
+                Self {
+                    train_types,
+                    expected_line_group_id: None,
+                }
+            }
+
+            fn with_expected_line_group_id(mut self, line_group_id: Option<u32>) -> Self {
+                self.expected_line_group_id = line_group_id;
+                self
             }
         }
 
@@ -2004,9 +2064,20 @@ mod tests {
             async fn get_types_by_station_id_vec(
                 &self,
                 _: &[u32],
-                _: Option<u32>,
+                line_group_id: Option<u32>,
             ) -> Result<Vec<TrainType>, DomainError> {
-                Ok(self.train_types.clone())
+                if let Some(expected) = self.expected_line_group_id {
+                    assert_eq!(
+                        line_group_id,
+                        Some(expected),
+                        "get_types_by_station_id_vec called with unexpected line_group_id"
+                    );
+                }
+                // Only return train types when line_group_id matches
+                match line_group_id {
+                    Some(_) => Ok(self.train_types.clone()),
+                    None => Ok(vec![]),
+                }
             }
             async fn get_by_line_group_id_vec(
                 &self,
@@ -2101,13 +2172,37 @@ mod tests {
             ConfigurableMockTrainTypeRepository,
             ConfigurableMockCompanyRepository,
         > {
+            create_configurable_interactor_with_line_group_id(
+                stations_by_group,
+                bus_stops,
+                lines,
+                train_types,
+                companies,
+                None,
+            )
+        }
+
+        fn create_configurable_interactor_with_line_group_id(
+            stations_by_group: Vec<Station>,
+            bus_stops: Vec<Station>,
+            lines: Vec<Line>,
+            train_types: Vec<TrainType>,
+            companies: Vec<Company>,
+            expected_line_group_id: Option<u32>,
+        ) -> QueryInteractor<
+            ConfigurableMockStationRepository,
+            ConfigurableMockLineRepository,
+            ConfigurableMockTrainTypeRepository,
+            ConfigurableMockCompanyRepository,
+        > {
             QueryInteractor {
                 station_repository: ConfigurableMockStationRepository::new(
                     stations_by_group,
                     bus_stops,
                 ),
                 line_repository: ConfigurableMockLineRepository::new(lines),
-                train_type_repository: ConfigurableMockTrainTypeRepository::new(train_types),
+                train_type_repository: ConfigurableMockTrainTypeRepository::new(train_types)
+                    .with_expected_line_group_id(expected_line_group_id),
                 company_repository: ConfigurableMockCompanyRepository::new(companies),
             }
         }
@@ -2176,12 +2271,13 @@ mod tests {
 
             let line = create_test_line_for_station_group(100, 1001);
 
-            let interactor = create_configurable_interactor(
+            let interactor = create_configurable_interactor_with_line_group_id(
                 vec![station.clone()],
                 vec![],
                 vec![line],
                 vec![train_type.clone()],
                 vec![company],
+                Some(1000),
             );
 
             let stations = vec![station];
@@ -2415,6 +2511,38 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_update_station_vec_with_attributes_no_train_type_when_line_group_id_none() {
+            let company = create_test_company(1, "JR東日本");
+            let train_type = create_test_train_type_for_station(101, "快速");
+
+            let mut station = create_test_station(101, 1001, 100, Some(1000));
+            station.company_cd = Some(1);
+
+            let line = create_test_line_for_station_group(100, 1001);
+
+            // Even though train_types are provided, line_group_id=None should skip the query
+            let interactor = create_configurable_interactor(
+                vec![station.clone()],
+                vec![],
+                vec![line],
+                vec![train_type],
+                vec![company],
+            );
+
+            let stations = vec![station];
+            let result = interactor
+                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail)
+                .await
+                .expect("Should succeed");
+
+            assert_eq!(result.len(), 1);
+            assert!(
+                result[0].train_type.is_none(),
+                "Train type should be None when line_group_id is None"
+            );
+        }
+
+        #[tokio::test]
         async fn test_update_station_vec_with_attributes_empty_input() {
             let interactor = create_configurable_interactor(vec![], vec![], vec![], vec![], vec![]);
 
@@ -2441,12 +2569,13 @@ mod tests {
 
             let line = create_test_line_for_station_group(100, 1001);
 
-            let interactor = create_configurable_interactor(
+            let interactor = create_configurable_interactor_with_line_group_id(
                 vec![station1.clone(), station2.clone()],
                 vec![],
                 vec![line],
                 vec![train_type1, train_type2],
                 vec![company.clone()],
+                Some(1000),
             );
 
             let stations = vec![station1, station2];

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -1126,69 +1126,6 @@ where
     TR: TrainTypeRepository,
     CR: CompanyRepository,
 {
-    /// Get bus lines (routes) within 300m radius of the given coordinates
-    async fn get_nearby_bus_lines(
-        &self,
-        ref_lat: f64,
-        ref_lon: f64,
-    ) -> Result<Vec<Line>, crate::use_case::error::UseCaseError> {
-        let nearby_candidates = self
-            .station_repository
-            .get_by_coordinates(ref_lat, ref_lon, Some(50), Some(TransportType::Bus))
-            .await?;
-
-        let nearby_bus_stops: Vec<Station> = nearby_candidates
-            .into_iter()
-            .filter(|bus_stop| {
-                let distance = haversine_distance(ref_lat, ref_lon, bus_stop.lat, bus_stop.lon);
-                distance <= NEARBY_BUS_STOP_RADIUS_METERS
-            })
-            .collect();
-
-        if nearby_bus_stops.is_empty() {
-            return Ok(vec![]);
-        }
-
-        // Get bus lines for nearby bus stops
-        let bus_station_group_ids: Vec<u32> = nearby_bus_stops
-            .iter()
-            .map(|s| s.station_g_cd as u32)
-            .collect();
-
-        let mut bus_lines = self
-            .line_repository
-            .get_by_station_group_id_vec(&bus_station_group_ids)
-            .await?;
-
-        // Add line symbols and filter to only bus lines
-        let mut seen_line_cds = std::collections::HashSet::new();
-        bus_lines.retain(|line| {
-            line.transport_type == TransportType::Bus && seen_line_cds.insert(line.line_cd)
-        });
-
-        // Build HashMap for O(1) bus stop lookup by line_cd
-        // Deduplicate by line_cd, keeping the first (closest) bus stop for each line
-        let mut seen_bus_line_cds = std::collections::HashSet::new();
-        let bus_stop_by_line_cd: std::collections::HashMap<i32, &Station> = nearby_bus_stops
-            .iter()
-            .filter(|s| seen_bus_line_cds.insert(s.line_cd))
-            .map(|s| (s.line_cd, s))
-            .collect();
-
-        for line in bus_lines.iter_mut() {
-            line.line_symbols = self.get_line_symbols(line);
-
-            // Find the matching bus stop for this line and embed it
-            if let Some(&bus_stop) = bus_stop_by_line_cd.get(&line.line_cd) {
-                let mut station_copy = bus_stop.clone();
-                station_copy.station_numbers = self.get_station_numbers(&station_copy);
-                line.station = Some(station_copy);
-            }
-        }
-
-        Ok(bus_lines)
-    }
-
     fn build_route_tree_map<'a>(&self, stops: &'a [Station]) -> BTreeMap<i32, Vec<&'a Station>> {
         stops.iter().fold(
             BTreeMap::new(),

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -250,10 +250,12 @@ where
         line_group_id: Option<u32>,
         transport_type: TransportTypeFilter,
     ) -> Result<Vec<Station>, UseCaseError> {
-        let station_group_ids = stations
+        let mut station_group_ids: Vec<u32> = stations
             .iter()
             .map(|station| station.station_g_cd as u32)
-            .collect::<Vec<u32>>();
+            .collect();
+        station_group_ids.sort_unstable();
+        station_group_ids.dedup();
 
         // Phase 1: independent queries in parallel
         let (stations_by_group_ids, lines) = tokio::try_join!(
@@ -266,10 +268,9 @@ where
             .map(|station| station.station_cd as u32)
             .collect::<Vec<u32>>();
 
-        let company_ids = lines
-            .iter()
-            .map(|station| station.company_cd as u32)
-            .collect::<Vec<u32>>();
+        let mut company_ids: Vec<u32> = lines.iter().map(|l| l.company_cd as u32).collect();
+        company_ids.sort_unstable();
+        company_ids.dedup();
 
         // Phase 2: dependent queries in parallel
         let (companies, train_types) = tokio::try_join!(
@@ -297,6 +298,10 @@ where
         // The candidate set is cached, but the 300m distance filter is applied
         // per-station to ensure correctness.
         let mut bus_candidate_cache: std::collections::HashMap<(i64, i64), Vec<Station>> =
+            std::collections::HashMap::new();
+        // Cache bus lines by station_group_ids to avoid repeated DB queries
+        // for the same set of bus stop groups.
+        let mut bus_lines_cache: std::collections::HashMap<Vec<u32>, Vec<Line>> =
             std::collections::HashMap::new();
 
         for station in stations.iter_mut() {
@@ -341,7 +346,12 @@ where
                 } else {
                     let result = self
                         .station_repository
-                        .get_by_coordinates(station.lat, station.lon, Some(50), Some(TransportType::Bus))
+                        .get_by_coordinates(
+                            station.lat,
+                            station.lon,
+                            Some(50),
+                            Some(TransportType::Bus),
+                        )
                         .await?;
                     bus_candidate_cache.insert(cache_key, result.clone());
                     result
@@ -357,15 +367,24 @@ where
                     .collect();
 
                 if !nearby_bus_stops.is_empty() {
-                    let bus_station_group_ids: Vec<u32> = nearby_bus_stops
+                    let mut bus_station_group_ids: Vec<u32> = nearby_bus_stops
                         .iter()
                         .map(|s| s.station_g_cd as u32)
                         .collect();
+                    bus_station_group_ids.sort_unstable();
+                    bus_station_group_ids.dedup();
 
-                    let mut bus_lines = self
-                        .line_repository
-                        .get_by_station_group_id_vec(&bus_station_group_ids)
-                        .await?;
+                    let mut bus_lines =
+                        if let Some(cached) = bus_lines_cache.get(&bus_station_group_ids) {
+                            cached.clone()
+                        } else {
+                            let result = self
+                                .line_repository
+                                .get_by_station_group_id_vec(&bus_station_group_ids)
+                                .await?;
+                            bus_lines_cache.insert(bus_station_group_ids, result.clone());
+                            result
+                        };
 
                     let mut seen_bus_line_cds = std::collections::HashSet::new();
                     bus_lines.retain(|line| {
@@ -384,8 +403,7 @@ where
                         bus_line.line_symbols = self.get_line_symbols(bus_line);
                         if let Some(&bus_stop) = bus_stop_by_line_cd.get(&bus_line.line_cd) {
                             let mut station_copy = bus_stop.clone();
-                            station_copy.station_numbers =
-                                self.get_station_numbers(&station_copy);
+                            station_copy.station_numbers = self.get_station_numbers(&station_copy);
                             bus_line.station = Some(station_copy);
                         }
                     }


### PR DESCRIPTION
## Summary
- **train typeクエリの早期リターン**: `line_group_id`が`None`の場合、SQLで`column = NULL`は常にfalseで空結果になるため、クエリをスキップ
- **バス路線取得の候補キャッシュ**: 座標を~100mグリッドに丸めて`get_by_coordinates`の候補セットをキャッシュし、300mフィルタは駅ごとに正確に再適用。バス路線クエリ(`get_by_station_group_id_vec`)もキャッシュして重複排除
- **独立DBクエリの並列化**: `tokio::try_join!`で4つの逐次クエリを2フェーズに並列化
- **クエリIDの重複除去**: `station_group_ids`/`company_ids`をdedup してIN句サイズを削減
- **テストモック強化**: `ConfigurableMockTrainTypeRepository`が`line_group_id`に応じて返す値を分岐するように修正し、`line_group_id=None`でtrain typeがスキップされるテストを追加

## Test plan
- [x] `SQLX_OFFLINE=true cargo test` 全テスト通過（新規テスト含む）
- [ ] サーバー起動後、Prometheusメトリクスの`grpc_request_duration_seconds`で改善を確認
- [ ] `GetStationsByLineGroupId`と`GetStationsByLineIdList`の応答時間を実測比較

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **パフォーマンス改善**
  * 複数フェーズの取得処理をさらに並列化し応答効率を向上しました。
  * 会社情報や列車種別の取得を並列化して待ち時間を短縮しました。

* **最適化**
  * 駅グループ単位・停留所候補のキャッシュを導入し重複処理を削減しました。
  * 緯度経度による300mフィルタなどで候補絞り込みを効率化しました。
  * バス路線・停留所の重複除去を改善しました。

* **変更**
  * 条件により列車種別の空結果を即時返す挙動を明確化しました。
  * 不足する会社情報は処理中に随時取得するようになりました。

* **テスト**
  * 挙動検証を強化するためのテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->