### PR TITLE
Optimize GetStationsByLineIdList performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ This guide explains how automation agents and human contributors should work wit
 - Changes to the service contract require coordinated updates to `proto/stationapi.proto`, regenerated code via `tonic-build`, and corresponding adjustments in both presentation and use-case layers.
 
 ## Contribution Guidelines
+- **Prioritize quality and performance over implementation speed** – Always favor code quality and runtime performance over velocity. Be mindful of algorithmic complexity and look for opportunities to replace O(n×m) linear scans with O(n+m) indexed lookups (e.g., HashMaps). Avoid unnecessary JOINs and redundant queries at the SQL level. When a change affects performance, document the before/after complexity and query plan impact in the pull request.
 - Document the commands you executed (for example, ``cargo fmt && cargo clippy --all-targets --all-features && make test-unit``) and their outcomes in every pull request.
 - For database, gRPC, or schema updates, add architectural notes under `docs/` and synchronize README references so onboarding materials stay accurate.
 - When modifying `QueryInteractor`, ensure the enrichment steps (companies, train types, line symbols) still behave as expected. Double-check helper methods such as `update_station_vec_with_attributes` and `build_route_tree_map`.

--- a/stationapi/src/domain/repository/station_repository.rs
+++ b/stationapi/src/domain/repository/station_repository.rs
@@ -24,6 +24,10 @@ pub trait StationRepository: Send + Sync + 'static {
         &self,
         station_group_id_vec: &[u32],
     ) -> Result<Vec<Station>, DomainError>;
+    async fn get_by_station_group_id_vec_no_types(
+        &self,
+        station_group_id_vec: &[u32],
+    ) -> Result<Vec<Station>, DomainError>;
     async fn get_by_coordinates(
         &self,
         latitude: f64,
@@ -146,6 +150,13 @@ mod tests {
                 .cloned()
                 .collect();
             Ok(result)
+        }
+
+        async fn get_by_station_group_id_vec_no_types(
+            &self,
+            station_group_id_vec: &[u32],
+        ) -> Result<Vec<Station>, DomainError> {
+            self.get_by_station_group_id_vec(station_group_id_vec).await
         }
 
         async fn get_by_coordinates(

--- a/stationapi/src/infrastructure/station_repository.rs
+++ b/stationapi/src/infrastructure/station_repository.rs
@@ -229,6 +229,17 @@ impl StationRepository for MyStationRepository {
         InternalStationRepository::get_by_station_group_id_vec(station_group_id_vec, &mut conn)
             .await
     }
+    async fn get_by_station_group_id_vec_no_types(
+        &self,
+        station_group_id_vec: &[u32],
+    ) -> Result<Vec<Station>, DomainError> {
+        let mut conn = self.pool.acquire().await?;
+        InternalStationRepository::get_by_station_group_id_vec_no_types(
+            station_group_id_vec,
+            &mut conn,
+        )
+        .await
+    }
 
     // ほぼ確実にキャッシュがヒットしないと思うのでキャッシュを使わない
     async fn get_by_coordinates(
@@ -1020,6 +1031,101 @@ impl InternalStationRepository {
         let lines: Vec<Station> = rows.into_iter().map(|row| row.into()).collect();
 
         Ok(lines)
+    }
+
+    async fn get_by_station_group_id_vec_no_types(
+        group_id_vec: &[u32],
+        conn: &mut PgConnection,
+    ) -> Result<Vec<Station>, DomainError> {
+        if group_id_vec.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let params = (1..=group_id_vec.len())
+            .map(|i| format!("${i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let query_str = format!(
+            r#"SELECT
+            s.station_cd,
+            s.station_g_cd,
+            s.station_name,
+            s.station_name_k,
+            s.station_name_r,
+            s.station_name_rn,
+            s.station_name_zh,
+            s.station_name_ko,
+            s.station_number1,
+            s.station_number2,
+            s.station_number3,
+            s.station_number4,
+            s.three_letter_code,
+            s.line_cd,
+            s.pref_cd,
+            s.post,
+            s.address,
+            s.lon,
+            s.lat,
+            s.open_ymd,
+            s.close_ymd,
+            s.e_status,
+            s.e_sort,
+            l.company_cd,
+            COALESCE(NULLIF(COALESCE(a.line_name, l.line_name), ''), NULL) AS line_name,
+            COALESCE(NULLIF(COALESCE(a.line_name_k, l.line_name_k), ''), NULL) AS line_name_k,
+            COALESCE(NULLIF(COALESCE(a.line_name_h, l.line_name_h), ''), NULL) AS line_name_h,
+            COALESCE(NULLIF(COALESCE(a.line_name_r, l.line_name_r), ''), NULL) AS line_name_r,
+            COALESCE(NULLIF(COALESCE(a.line_name_zh, l.line_name_zh), ''), NULL) AS line_name_zh,
+            COALESCE(NULLIF(COALESCE(a.line_name_ko, l.line_name_ko), ''), NULL) AS line_name_ko,
+            COALESCE(NULLIF(COALESCE(a.line_color_c, l.line_color_c), ''), NULL) AS line_color_c,
+            l.line_type,
+            l.line_symbol1,
+            l.line_symbol2,
+            l.line_symbol3,
+            l.line_symbol4,
+            l.line_symbol1_color,
+            l.line_symbol2_color,
+            l.line_symbol3_color,
+            l.line_symbol4_color,
+            l.line_symbol1_shape,
+            l.line_symbol2_shape,
+            l.line_symbol3_shape,
+            l.line_symbol4_shape,
+            COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,
+            NULL::int AS sst_id,
+            NULL::int AS type_cd,
+            NULL::int AS line_group_cd,
+            NULL::int AS pass,
+            NULL::int AS type_id,
+            NULL::text AS type_name,
+            NULL::text AS type_name_k,
+            NULL::text AS type_name_r,
+            NULL::text AS type_name_zh,
+            NULL::text AS type_name_ko,
+            NULL::text AS color,
+            NULL::int AS direction,
+            NULL::int AS kind,
+            s.transport_type
+          FROM
+            stations AS s
+            JOIN lines AS l ON l.line_cd = s.line_cd AND l.e_status = 0
+            LEFT JOIN line_aliases AS la ON la.station_cd = s.station_cd
+            LEFT JOIN aliases AS a ON a.id = la.alias_cd
+          WHERE
+            s.station_g_cd IN ( {params} )
+            AND s.line_cd = l.line_cd
+            AND s.e_status = 0"#
+        );
+
+        let mut query = sqlx::query_as::<_, StationRow>(&query_str);
+        for id in group_id_vec {
+            query = query.bind(*id as i32);
+        }
+
+        let rows = query.fetch_all(conn).await?;
+        let stations: Vec<Station> = rows.into_iter().map(|row| row.into()).collect();
+
+        Ok(stations)
     }
 
     async fn get_by_coordinates(

--- a/stationapi/src/presentation/controller/grpc.rs
+++ b/stationapi/src/presentation/controller/grpc.rs
@@ -713,6 +713,7 @@ mod tests {
             stations: Vec<Station>,
             _line_group_id: Option<u32>,
             _transport_type: TransportTypeFilter,
+            _skip_types_join: bool,
         ) -> Result<Vec<Station>, UseCaseError> {
             Ok(stations)
         }

--- a/stationapi/src/presentation/controller/grpc.rs
+++ b/stationapi/src/presentation/controller/grpc.rs
@@ -708,16 +708,6 @@ mod tests {
             Ok(vec![])
         }
 
-        async fn update_station_vec_with_attributes(
-            &self,
-            stations: Vec<Station>,
-            _line_group_id: Option<u32>,
-            _transport_type: TransportTypeFilter,
-            _skip_types_join: bool,
-        ) -> Result<Vec<Station>, UseCaseError> {
-            Ok(stations)
-        }
-
         async fn get_lines_by_station_group_id(
             &self,
             _station_group_id: u32,

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -318,6 +318,15 @@ where
                 .cloned()
                 .cloned()
                 .map(Box::new);
+            if let Some(ref mut line) = station.line {
+                if let Some(ref mut nested_station) = line.station {
+                    nested_station.train_type = train_type_map
+                        .get(&nested_station.station_cd)
+                        .cloned()
+                        .cloned()
+                        .map(Box::new);
+                }
+            }
             for line in station.lines.iter_mut() {
                 if let Some(ref mut nested_station) = line.station {
                     nested_station.train_type = train_type_map
@@ -2810,14 +2819,31 @@ mod tests {
         async fn test_update_station_vec_with_attributes_skip_types_join_enriches_correctly() {
             let company = create_test_company(1, "JR東日本");
 
-            let mut station = create_test_station(101, 1001, 100, None);
+            // stations_by_group にはtype系フィールドを持つstationを設定する。
+            // skip_types_join=true の場合、get_by_station_group_id_vec_no_types が呼ばれ
+            // type系フィールドが除去された状態で返される。
+            let mut station_with_types = create_test_station(101, 1001, 100, Some(5000));
+            station_with_types.company_cd = Some(1);
+            station_with_types.has_train_types = true;
+            station_with_types.type_name = Some("快速".to_string());
+            station_with_types.type_name_k = Some("カイソク".to_string());
+            station_with_types.type_name_r = Some("Rapid".to_string());
+            station_with_types.type_cd = Some(1);
+            station_with_types.type_id = Some(1);
+            station_with_types.pass = Some(0);
+            station_with_types.color = Some("FF0000".to_string());
+            station_with_types.direction = Some(0);
+            station_with_types.kind = Some(0);
+
+            // 入力stationはtype系フィールドあり（enrichment対象）
+            let mut station = create_test_station(101, 1001, 100, Some(5000));
             station.company_cd = Some(1);
 
             let mut line = create_test_line(100);
             line.station_g_cd = Some(1001);
 
             let interactor = create_configurable_interactor(
-                vec![station.clone()],
+                vec![station_with_types],
                 vec![],
                 vec![line],
                 vec![],
@@ -2838,7 +2864,7 @@ mod tests {
             assert!(station_result.line.is_some());
             assert!(!station_result.station_numbers.is_empty());
 
-            // train_type should be None since line_group_id is None
+            // train_type should be None since line_group_id is None for train_type_map lookup
             assert!(station_result.train_type.is_none());
 
             // Lines should have company populated
@@ -2846,6 +2872,43 @@ mod tests {
                 assert!(line.company.is_some());
                 assert!(!line.line_symbols.is_empty());
             }
+
+            // skip_types_join=true なので lines[*].station のtype系フィールドは
+            // get_by_station_group_id_vec_no_types により除去されているべき
+            for line in &station_result.lines {
+                if let Some(ref nested_station) = line.station {
+                    assert!(
+                        nested_station.line_group_cd.is_none(),
+                        "nested station line_group_cd should be None with skip_types_join"
+                    );
+                    assert!(
+                        nested_station.type_name.is_none(),
+                        "nested station type_name should be None with skip_types_join"
+                    );
+                    assert!(
+                        nested_station.pass.is_none(),
+                        "nested station pass should be None with skip_types_join"
+                    );
+                    assert!(
+                        !nested_station.has_train_types,
+                        "nested station has_train_types should be false with skip_types_join"
+                    );
+                }
+            }
+
+            // station.line.station は入力stationのcloneなので、元の値を保持する
+            // （station_lookupからではなく直接cloneされるため）
+            let line_station = station_result
+                .line
+                .as_ref()
+                .unwrap()
+                .station
+                .as_ref()
+                .unwrap();
+            assert_eq!(
+                line_station.station_cd, 101,
+                "line.station should reference the correct station"
+            );
         }
 
         #[tokio::test]
@@ -2896,6 +2959,13 @@ mod tests {
             );
             assert_eq!(s1.train_type.as_ref().unwrap().type_name, "快速");
             assert_eq!(s1.train_type.as_ref().unwrap().station_cd, Some(101));
+            // station.line.station.train_type も設定されていること
+            let line_station1 = s1.line.as_ref().unwrap().station.as_ref().unwrap();
+            assert!(
+                line_station1.train_type.is_some(),
+                "station 101 line.station should have train_type"
+            );
+            assert_eq!(line_station1.train_type.as_ref().unwrap().type_name, "快速");
 
             let s2 = result.iter().find(|s| s.station_cd == 201).unwrap();
             assert!(
@@ -2904,6 +2974,13 @@ mod tests {
             );
             assert_eq!(s2.train_type.as_ref().unwrap().type_name, "特急");
             assert_eq!(s2.train_type.as_ref().unwrap().station_cd, Some(201));
+            // station.line.station.train_type も設定されていること
+            let line_station2 = s2.line.as_ref().unwrap().station.as_ref().unwrap();
+            assert!(
+                line_station2.train_type.is_some(),
+                "station 201 line.station should have train_type"
+            );
+            assert_eq!(line_station2.train_type.as_ref().unwrap().type_name, "特急");
         }
 
         #[tokio::test]
@@ -2956,6 +3033,20 @@ mod tests {
                 station_result.train_type.as_ref().unwrap().type_name,
                 "快速"
             );
+
+            // station.line.station.train_type も設定されていること
+            let line_station = station_result
+                .line
+                .as_ref()
+                .unwrap()
+                .station
+                .as_ref()
+                .unwrap();
+            assert!(
+                line_station.train_type.is_some(),
+                "line.station should have train_type"
+            );
+            assert_eq!(line_station.train_type.as_ref().unwrap().type_name, "快速");
 
             // nested stations in lines[] should also have train_type
             for line in &station_result.lines {

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -258,10 +258,19 @@ where
         station_group_ids.dedup();
 
         // Phase 1: independent queries in parallel
-        let (stations_by_group_ids, lines) = tokio::try_join!(
-            self.get_stations_by_group_id_vec(&station_group_ids),
-            self.get_lines_by_station_group_id_vec(&station_group_ids),
-        )?;
+        // When line_group_id is None, train type data won't be used, so skip the
+        // expensive JOINs to station_station_types and types tables
+        let (stations_by_group_ids, lines) = if line_group_id.is_some() {
+            tokio::try_join!(
+                self.get_stations_by_group_id_vec(&station_group_ids),
+                self.get_lines_by_station_group_id_vec(&station_group_ids),
+            )?
+        } else {
+            tokio::try_join!(
+                self.get_stations_by_group_id_vec_no_types(&station_group_ids),
+                self.get_lines_by_station_group_id_vec(&station_group_ids),
+            )?
+        };
 
         let station_ids = stations_by_group_ids
             .iter()
@@ -295,6 +304,15 @@ where
             .map(|s| ((s.line_cd, s.station_g_cd), s))
             .collect();
 
+        // Pre-index lines by station_g_cd for O(1) lookup instead of O(n*m) linear scan
+        let mut lines_by_g_cd: std::collections::HashMap<i32, Vec<usize>> =
+            std::collections::HashMap::new();
+        for (idx, line) in lines.iter().enumerate() {
+            if let Some(g_cd) = line.station_g_cd {
+                lines_by_g_cd.entry(g_cd).or_default().push(idx);
+            }
+        }
+
         // Cache nearby bus stop candidates by station_g_cd.
         // Stations with the same station_g_cd are at the same physical location,
         // so they share identical bus stop candidates.
@@ -324,15 +342,24 @@ where
             };
 
             let mut seen_line_cds = std::collections::HashSet::new();
-            let mut lines: Vec<Line> = lines
-                .iter()
-                .filter(|&l| {
-                    l.station_g_cd.unwrap_or(0) == station.station_g_cd
-                        && seen_line_cds.insert(l.line_cd)
-                        && matches_transport_filter(l.transport_type, transport_type)
+            let mut station_lines: Vec<Line> = lines_by_g_cd
+                .get(&station.station_g_cd)
+                .map(|indices| {
+                    indices
+                        .iter()
+                        .filter_map(|&idx| {
+                            let l = &lines[idx];
+                            if seen_line_cds.insert(l.line_cd)
+                                && matches_transport_filter(l.transport_type, transport_type)
+                            {
+                                Some(l.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect()
                 })
-                .cloned()
-                .collect();
+                .unwrap_or_default();
 
             // For rail stations, add nearby bus routes to lines array
             // Only add bus routes if transport_type is RailAndBus
@@ -408,14 +435,14 @@ where
 
                     for bus_line in bus_lines {
                         if seen_line_cds.insert(bus_line.line_cd) {
-                            lines.push(bus_line);
+                            station_lines.push(bus_line);
                         }
                     }
                 }
             }
 
             // Fetch any missing companies (e.g., bus-only operators not in initial lines)
-            let missing_company_ids: Vec<u32> = lines
+            let missing_company_ids: Vec<u32> = station_lines
                 .iter()
                 .filter(|l| !company_map.contains_key(&l.company_cd))
                 .map(|l| l.company_cd as u32)
@@ -429,7 +456,7 @@ where
                 }
             }
 
-            for line in lines.iter_mut() {
+            for line in station_lines.iter_mut() {
                 line.company = company_map.get(&line.company_cd).cloned();
                 line.line_symbols = self.get_line_symbols(line);
                 if let Some(station_ref) = station_lookup.get(&(line.line_cd, station.station_g_cd))
@@ -451,7 +478,7 @@ where
             }
             let station_numbers: Vec<StationNumber> = self.get_station_numbers(station);
             station.station_numbers = station_numbers;
-            station.lines = lines;
+            station.lines = station_lines;
         }
 
         Ok(stations)
@@ -1139,6 +1166,18 @@ where
     TR: TrainTypeRepository,
     CR: CompanyRepository,
 {
+    async fn get_stations_by_group_id_vec_no_types(
+        &self,
+        station_group_id_vec: &[u32],
+    ) -> Result<Vec<Station>, UseCaseError> {
+        let stations = self
+            .station_repository
+            .get_by_station_group_id_vec_no_types(station_group_id_vec)
+            .await?;
+
+        Ok(stations)
+    }
+
     fn build_route_tree_map<'a>(&self, stops: &'a [Station]) -> BTreeMap<i32, Vec<&'a Station>> {
         stops.iter().fold(
             BTreeMap::new(),
@@ -1451,6 +1490,12 @@ mod tests {
                 Ok(vec![])
             }
             async fn get_by_station_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id_vec_no_types(
                 &self,
                 _: &[u32],
             ) -> Result<Vec<Station>, DomainError> {
@@ -1861,6 +1906,12 @@ mod tests {
                 _: &[u32],
             ) -> Result<Vec<Station>, DomainError> {
                 Ok(self.stations_by_group.clone())
+            }
+            async fn get_by_station_group_id_vec_no_types(
+                &self,
+                station_group_id_vec: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                self.get_by_station_group_id_vec(station_group_id_vec).await
             }
             async fn get_by_coordinates(
                 &self,

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -250,246 +250,6 @@ where
 
         Ok(companies)
     }
-    async fn update_station_vec_with_attributes(
-        &self,
-        mut stations: Vec<Station>,
-        line_group_id: Option<u32>,
-        transport_type: TransportTypeFilter,
-        skip_types_join: bool,
-    ) -> Result<Vec<Station>, UseCaseError> {
-        let mut station_group_ids: Vec<u32> = stations
-            .iter()
-            .map(|station| station.station_g_cd as u32)
-            .collect();
-        station_group_ids.sort_unstable();
-        station_group_ids.dedup();
-
-        // Phase 1: independent queries in parallel
-        // When skip_types_join is true, skip the expensive JOINs to
-        // station_station_types and types tables (used by GetStationsByLineIdList)
-        let (stations_by_group_ids, lines) = if skip_types_join {
-            tokio::try_join!(
-                self.get_stations_by_group_id_vec_no_types(&station_group_ids),
-                self.get_lines_by_station_group_id_vec(&station_group_ids),
-            )?
-        } else {
-            tokio::try_join!(
-                self.get_stations_by_group_id_vec(&station_group_ids),
-                self.get_lines_by_station_group_id_vec(&station_group_ids),
-            )?
-        };
-
-        let station_ids = stations_by_group_ids
-            .iter()
-            .map(|station| station.station_cd as u32)
-            .collect::<Vec<u32>>();
-
-        let mut company_ids: Vec<u32> = lines.iter().map(|l| l.company_cd as u32).collect();
-        company_ids.sort_unstable();
-        company_ids.dedup();
-
-        // Phase 2: dependent queries in parallel
-        let (companies, train_types) = tokio::try_join!(
-            self.find_company_by_id_vec(&company_ids),
-            self.get_train_types_by_station_id_vec(&station_ids, line_group_id),
-        )?;
-
-        // Build HashMap for O(1) company lookup instead of O(n) linear search
-        // Owns the values so we can add bus companies later
-        let mut company_map: std::collections::HashMap<i32, Company> =
-            companies.into_iter().map(|c| (c.company_cd, c)).collect();
-
-        // Build HashMap for O(1) train_type lookup by station_cd
-        let train_type_map: std::collections::HashMap<i32, &TrainType> = train_types
-            .iter()
-            .filter_map(|tt| tt.station_cd.map(|cd| (cd, tt)))
-            .collect();
-
-        // Build lookup map for stations_by_group_ids: (line_cd, station_g_cd) -> Station
-        let station_lookup: std::collections::HashMap<(i32, i32), &Station> = stations_by_group_ids
-            .iter()
-            .map(|s| ((s.line_cd, s.station_g_cd), s))
-            .collect();
-
-        // Pre-index lines by station_g_cd for O(1) lookup instead of O(n*m) linear scan
-        let mut lines_by_g_cd: std::collections::HashMap<i32, Vec<usize>> =
-            std::collections::HashMap::new();
-        for (idx, line) in lines.iter().enumerate() {
-            if let Some(g_cd) = line.station_g_cd {
-                lines_by_g_cd.entry(g_cd).or_default().push(idx);
-            }
-        }
-
-        // Cache nearby bus stop candidates by station_g_cd.
-        // Stations with the same station_g_cd are at the same physical location,
-        // so they share identical bus stop candidates.
-        let mut bus_candidate_cache: std::collections::HashMap<i32, Vec<Station>> =
-            std::collections::HashMap::new();
-        // Cache bus lines by station_group_ids to avoid repeated DB queries
-        // for the same set of bus stop groups.
-        let mut bus_lines_cache: std::collections::HashMap<Vec<u32>, Vec<Line>> =
-            std::collections::HashMap::new();
-
-        for station in stations.iter_mut() {
-            let mut line = self.extract_line_from_station(station);
-            line.line_symbols = self.get_line_symbols(&line);
-            line.company = company_map.get(&line.company_cd).cloned();
-            line.station = Some(station.clone());
-
-            let station_numbers: Vec<StationNumber> = self.get_station_numbers(station);
-            station.station_numbers = station_numbers;
-            station.line = Some(Box::new(line));
-            if let Some(tt) = train_type_map
-                .get(&station.station_cd)
-                .cloned()
-                .cloned()
-                .map(Box::new)
-            {
-                station.train_type = Some(tt);
-            };
-
-            let mut seen_line_cds = std::collections::HashSet::new();
-            let mut station_lines: Vec<Line> = lines_by_g_cd
-                .get(&station.station_g_cd)
-                .map(|indices| {
-                    indices
-                        .iter()
-                        .filter_map(|&idx| {
-                            let l = &lines[idx];
-                            if seen_line_cds.insert(l.line_cd)
-                                && matches_transport_filter(l.transport_type, transport_type)
-                            {
-                                Some(l.clone())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect()
-                })
-                .unwrap_or_default();
-
-            // For rail stations, add nearby bus routes to lines array
-            // Only add bus routes if transport_type is RailAndBus
-            let should_include_bus_routes = transport_type == TransportTypeFilter::RailAndBus;
-            if station.transport_type == TransportType::Rail && should_include_bus_routes {
-                let cache_key = station.station_g_cd;
-                let candidates = if let Some(cached) = bus_candidate_cache.get(&cache_key) {
-                    cached.clone()
-                } else {
-                    let result = self
-                        .station_repository
-                        .get_by_coordinates(
-                            station.lat,
-                            station.lon,
-                            Some(50),
-                            Some(TransportType::Bus),
-                        )
-                        .await?;
-                    bus_candidate_cache.insert(cache_key, result.clone());
-                    result
-                };
-
-                // Apply 300m filter from this station's exact coordinates
-                let nearby_bus_stops: Vec<&Station> = candidates
-                    .iter()
-                    .filter(|bus_stop| {
-                        haversine_distance(station.lat, station.lon, bus_stop.lat, bus_stop.lon)
-                            <= NEARBY_BUS_STOP_RADIUS_METERS
-                    })
-                    .collect();
-
-                if !nearby_bus_stops.is_empty() {
-                    let mut bus_station_group_ids: Vec<u32> = nearby_bus_stops
-                        .iter()
-                        .map(|s| s.station_g_cd as u32)
-                        .collect();
-                    bus_station_group_ids.sort_unstable();
-                    bus_station_group_ids.dedup();
-
-                    let mut bus_lines =
-                        if let Some(cached) = bus_lines_cache.get(&bus_station_group_ids) {
-                            cached.clone()
-                        } else {
-                            let result = self
-                                .line_repository
-                                .get_by_station_group_id_vec(&bus_station_group_ids)
-                                .await?;
-                            bus_lines_cache.insert(bus_station_group_ids, result.clone());
-                            result
-                        };
-
-                    let mut seen_bus_line_cds = std::collections::HashSet::new();
-                    bus_lines.retain(|line| {
-                        line.transport_type == TransportType::Bus
-                            && seen_bus_line_cds.insert(line.line_cd)
-                    });
-
-                    let bus_stop_by_line_cd: std::collections::HashMap<i32, &Station> =
-                        nearby_bus_stops
-                            .iter()
-                            .filter(|s| seen_bus_line_cds.contains(&s.line_cd))
-                            .map(|s| (s.line_cd, *s))
-                            .collect();
-
-                    for bus_line in bus_lines.iter_mut() {
-                        bus_line.line_symbols = self.get_line_symbols(bus_line);
-                        if let Some(&bus_stop) = bus_stop_by_line_cd.get(&bus_line.line_cd) {
-                            let mut station_copy = bus_stop.clone();
-                            station_copy.station_numbers = self.get_station_numbers(&station_copy);
-                            bus_line.station = Some(station_copy);
-                        }
-                    }
-
-                    for bus_line in bus_lines {
-                        if seen_line_cds.insert(bus_line.line_cd) {
-                            station_lines.push(bus_line);
-                        }
-                    }
-                }
-            }
-
-            // Fetch any missing companies (e.g., bus-only operators not in initial lines)
-            let missing_company_ids: Vec<u32> = station_lines
-                .iter()
-                .filter(|l| !company_map.contains_key(&l.company_cd))
-                .map(|l| l.company_cd as u32)
-                .collect::<std::collections::HashSet<u32>>()
-                .into_iter()
-                .collect();
-            if !missing_company_ids.is_empty() {
-                let extra_companies = self.find_company_by_id_vec(&missing_company_ids).await?;
-                for c in extra_companies {
-                    company_map.insert(c.company_cd, c);
-                }
-            }
-
-            for line in station_lines.iter_mut() {
-                line.company = company_map.get(&line.company_cd).cloned();
-                line.line_symbols = self.get_line_symbols(line);
-                if let Some(station_ref) = station_lookup.get(&(line.line_cd, station.station_g_cd))
-                {
-                    let mut station_copy = (*station_ref).clone();
-                    let station_numbers: Vec<StationNumber> =
-                        self.get_station_numbers(&station_copy);
-                    station_copy.station_numbers = station_numbers;
-                    if let Some(tt) = train_type_map
-                        .get(&station_copy.station_cd)
-                        .cloned()
-                        .cloned()
-                        .map(Box::new)
-                    {
-                        station_copy.train_type = Some(tt);
-                    };
-                    line.station = Some(station_copy);
-                }
-            }
-            let station_numbers: Vec<StationNumber> = self.get_station_numbers(station);
-            station.station_numbers = station_numbers;
-            station.lines = station_lines;
-        }
-
-        Ok(stations)
-    }
     async fn get_lines_by_station_group_id(
         &self,
         station_group_id: u32,
@@ -1186,6 +946,247 @@ where
             .station_repository
             .get_by_station_group_id_vec_no_types(station_group_id_vec)
             .await?;
+
+        Ok(stations)
+    }
+
+    async fn update_station_vec_with_attributes(
+        &self,
+        mut stations: Vec<Station>,
+        line_group_id: Option<u32>,
+        transport_type: TransportTypeFilter,
+        skip_types_join: bool,
+    ) -> Result<Vec<Station>, UseCaseError> {
+        let mut station_group_ids: Vec<u32> = stations
+            .iter()
+            .map(|station| station.station_g_cd as u32)
+            .collect();
+        station_group_ids.sort_unstable();
+        station_group_ids.dedup();
+
+        // Phase 1: independent queries in parallel
+        // When skip_types_join is true, skip the expensive JOINs to
+        // station_station_types and types tables (used by GetStationsByLineIdList)
+        let (stations_by_group_ids, lines) = if skip_types_join {
+            tokio::try_join!(
+                self.get_stations_by_group_id_vec_no_types(&station_group_ids),
+                self.get_lines_by_station_group_id_vec(&station_group_ids),
+            )?
+        } else {
+            tokio::try_join!(
+                self.get_stations_by_group_id_vec(&station_group_ids),
+                self.get_lines_by_station_group_id_vec(&station_group_ids),
+            )?
+        };
+
+        let station_ids = stations_by_group_ids
+            .iter()
+            .map(|station| station.station_cd as u32)
+            .collect::<Vec<u32>>();
+
+        let mut company_ids: Vec<u32> = lines.iter().map(|l| l.company_cd as u32).collect();
+        company_ids.sort_unstable();
+        company_ids.dedup();
+
+        // Phase 2: dependent queries in parallel
+        let (companies, train_types) = tokio::try_join!(
+            self.find_company_by_id_vec(&company_ids),
+            self.get_train_types_by_station_id_vec(&station_ids, line_group_id),
+        )?;
+
+        // Build HashMap for O(1) company lookup instead of O(n) linear search
+        // Owns the values so we can add bus companies later
+        let mut company_map: std::collections::HashMap<i32, Company> =
+            companies.into_iter().map(|c| (c.company_cd, c)).collect();
+
+        // Build HashMap for O(1) train_type lookup by station_cd
+        let train_type_map: std::collections::HashMap<i32, &TrainType> = train_types
+            .iter()
+            .filter_map(|tt| tt.station_cd.map(|cd| (cd, tt)))
+            .collect();
+
+        // Build lookup map for stations_by_group_ids: (line_cd, station_g_cd) -> Station
+        let station_lookup: std::collections::HashMap<(i32, i32), &Station> = stations_by_group_ids
+            .iter()
+            .map(|s| ((s.line_cd, s.station_g_cd), s))
+            .collect();
+
+        // Pre-index lines by station_g_cd for O(1) lookup instead of O(n*m) linear scan
+        let mut lines_by_g_cd: std::collections::HashMap<i32, Vec<usize>> =
+            std::collections::HashMap::new();
+        for (idx, line) in lines.iter().enumerate() {
+            if let Some(g_cd) = line.station_g_cd {
+                lines_by_g_cd.entry(g_cd).or_default().push(idx);
+            }
+        }
+
+        // Cache nearby bus stop candidates by station_g_cd.
+        // Stations with the same station_g_cd are at the same physical location,
+        // so they share identical bus stop candidates.
+        let mut bus_candidate_cache: std::collections::HashMap<i32, Vec<Station>> =
+            std::collections::HashMap::new();
+        // Cache bus lines by station_group_ids to avoid repeated DB queries
+        // for the same set of bus stop groups.
+        let mut bus_lines_cache: std::collections::HashMap<Vec<u32>, Vec<Line>> =
+            std::collections::HashMap::new();
+
+        for station in stations.iter_mut() {
+            let mut line = self.extract_line_from_station(station);
+            line.line_symbols = self.get_line_symbols(&line);
+            line.company = company_map.get(&line.company_cd).cloned();
+            line.station = Some(station.clone());
+
+            let station_numbers: Vec<StationNumber> = self.get_station_numbers(station);
+            station.station_numbers = station_numbers;
+            station.line = Some(Box::new(line));
+            if let Some(tt) = train_type_map
+                .get(&station.station_cd)
+                .cloned()
+                .cloned()
+                .map(Box::new)
+            {
+                station.train_type = Some(tt);
+            };
+
+            let mut seen_line_cds = std::collections::HashSet::new();
+            let mut station_lines: Vec<Line> = lines_by_g_cd
+                .get(&station.station_g_cd)
+                .map(|indices| {
+                    indices
+                        .iter()
+                        .filter_map(|&idx| {
+                            let l = &lines[idx];
+                            if seen_line_cds.insert(l.line_cd)
+                                && matches_transport_filter(l.transport_type, transport_type)
+                            {
+                                Some(l.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            // For rail stations, add nearby bus routes to lines array
+            // Only add bus routes if transport_type is RailAndBus
+            let should_include_bus_routes = transport_type == TransportTypeFilter::RailAndBus;
+            if station.transport_type == TransportType::Rail && should_include_bus_routes {
+                let cache_key = station.station_g_cd;
+                let candidates = if let Some(cached) = bus_candidate_cache.get(&cache_key) {
+                    cached.clone()
+                } else {
+                    let result = self
+                        .station_repository
+                        .get_by_coordinates(
+                            station.lat,
+                            station.lon,
+                            Some(50),
+                            Some(TransportType::Bus),
+                        )
+                        .await?;
+                    bus_candidate_cache.insert(cache_key, result.clone());
+                    result
+                };
+
+                // Apply 300m filter from this station's exact coordinates
+                let nearby_bus_stops: Vec<&Station> = candidates
+                    .iter()
+                    .filter(|bus_stop| {
+                        haversine_distance(station.lat, station.lon, bus_stop.lat, bus_stop.lon)
+                            <= NEARBY_BUS_STOP_RADIUS_METERS
+                    })
+                    .collect();
+
+                if !nearby_bus_stops.is_empty() {
+                    let mut bus_station_group_ids: Vec<u32> = nearby_bus_stops
+                        .iter()
+                        .map(|s| s.station_g_cd as u32)
+                        .collect();
+                    bus_station_group_ids.sort_unstable();
+                    bus_station_group_ids.dedup();
+
+                    let mut bus_lines =
+                        if let Some(cached) = bus_lines_cache.get(&bus_station_group_ids) {
+                            cached.clone()
+                        } else {
+                            let result = self
+                                .line_repository
+                                .get_by_station_group_id_vec(&bus_station_group_ids)
+                                .await?;
+                            bus_lines_cache.insert(bus_station_group_ids, result.clone());
+                            result
+                        };
+
+                    let mut seen_bus_line_cds = std::collections::HashSet::new();
+                    bus_lines.retain(|line| {
+                        line.transport_type == TransportType::Bus
+                            && seen_bus_line_cds.insert(line.line_cd)
+                    });
+
+                    let bus_stop_by_line_cd: std::collections::HashMap<i32, &Station> =
+                        nearby_bus_stops
+                            .iter()
+                            .filter(|s| seen_bus_line_cds.contains(&s.line_cd))
+                            .map(|s| (s.line_cd, *s))
+                            .collect();
+
+                    for bus_line in bus_lines.iter_mut() {
+                        bus_line.line_symbols = self.get_line_symbols(bus_line);
+                        if let Some(&bus_stop) = bus_stop_by_line_cd.get(&bus_line.line_cd) {
+                            let mut station_copy = bus_stop.clone();
+                            station_copy.station_numbers = self.get_station_numbers(&station_copy);
+                            bus_line.station = Some(station_copy);
+                        }
+                    }
+
+                    for bus_line in bus_lines {
+                        if seen_line_cds.insert(bus_line.line_cd) {
+                            station_lines.push(bus_line);
+                        }
+                    }
+                }
+            }
+
+            // Fetch any missing companies (e.g., bus-only operators not in initial lines)
+            let missing_company_ids: Vec<u32> = station_lines
+                .iter()
+                .filter(|l| !company_map.contains_key(&l.company_cd))
+                .map(|l| l.company_cd as u32)
+                .collect::<std::collections::HashSet<u32>>()
+                .into_iter()
+                .collect();
+            if !missing_company_ids.is_empty() {
+                let extra_companies = self.find_company_by_id_vec(&missing_company_ids).await?;
+                for c in extra_companies {
+                    company_map.insert(c.company_cd, c);
+                }
+            }
+
+            for line in station_lines.iter_mut() {
+                line.company = company_map.get(&line.company_cd).cloned();
+                line.line_symbols = self.get_line_symbols(line);
+                if let Some(station_ref) = station_lookup.get(&(line.line_cd, station.station_g_cd))
+                {
+                    let mut station_copy = (*station_ref).clone();
+                    let station_numbers: Vec<StationNumber> =
+                        self.get_station_numbers(&station_copy);
+                    station_copy.station_numbers = station_numbers;
+                    if let Some(tt) = train_type_map
+                        .get(&station_copy.station_cd)
+                        .cloned()
+                        .cloned()
+                        .map(Box::new)
+                    {
+                        station_copy.train_type = Some(tt);
+                    };
+                    line.station = Some(station_copy);
+                }
+            }
+            let station_numbers: Vec<StationNumber> = self.get_station_numbers(station);
+            station.station_numbers = station_numbers;
+            station.lines = station_lines;
+        }
 
         Ok(stations)
     }
@@ -1941,6 +1942,8 @@ mod tests {
                         s.color = None;
                         s.direction = None;
                         s.kind = None;
+                        s.has_train_types = false;
+                        s.train_type = None;
                         s
                     })
                     .collect();
@@ -2796,6 +2799,48 @@ mod tests {
             assert!(line_names.contains(&"京浜東北線"));
 
             // Each line in the array should have company and line_symbols populated
+            for line in &station_result.lines {
+                assert!(line.company.is_some());
+                assert!(!line.line_symbols.is_empty());
+            }
+        }
+
+        #[tokio::test]
+        async fn test_update_station_vec_with_attributes_skip_types_join_enriches_correctly() {
+            let company = create_test_company(1, "JR東日本");
+
+            let mut station = create_test_station(101, 1001, 100, None);
+            station.company_cd = Some(1);
+
+            let mut line = create_test_line(100);
+            line.station_g_cd = Some(1001);
+
+            let interactor = create_configurable_interactor(
+                vec![station.clone()],
+                vec![],
+                vec![line],
+                vec![],
+                vec![company],
+            );
+
+            let stations = vec![station];
+            let result = interactor
+                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, true)
+                .await
+                .expect("Should succeed");
+
+            assert_eq!(result.len(), 1);
+            let station_result = &result[0];
+
+            // lines, company, station_numbers should still be enriched
+            assert!(!station_result.lines.is_empty());
+            assert!(station_result.line.is_some());
+            assert!(!station_result.station_numbers.is_empty());
+
+            // train_type should be None since line_group_id is None
+            assert!(station_result.train_type.is_none());
+
+            // Lines should have company populated
             for line in &station_result.lines {
                 assert!(line.company.is_some());
                 assert!(!line.line_symbols.is_empty());

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -1034,11 +1034,9 @@ where
             let mut line = self.extract_line_from_station(station);
             line.line_symbols = self.get_line_symbols(&line);
             line.company = company_map.get(&line.company_cd).cloned();
-            line.station = Some(station.clone());
 
             let station_numbers: Vec<StationNumber> = self.get_station_numbers(station);
             station.station_numbers = station_numbers;
-            station.line = Some(Box::new(line));
             if let Some(tt) = train_type_map
                 .get(&station.station_cd)
                 .cloned()
@@ -1046,7 +1044,10 @@ where
                 .map(Box::new)
             {
                 station.train_type = Some(tt);
-            };
+            }
+
+            line.station = Some(station.clone());
+            station.line = Some(Box::new(line));
 
             let mut seen_line_cds = std::collections::HashSet::new();
             let mut station_lines: Vec<Line> = lines_by_g_cd

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -72,7 +72,7 @@ where
             return Ok(None);
         }
         let stations = self
-            .update_station_vec_with_attributes(vec![station], None, transport_type)
+            .update_station_vec_with_attributes(vec![station], None, transport_type, false)
             .await?;
 
         Ok(stations.into_iter().next())
@@ -89,7 +89,7 @@ where
             .filter(|s| matches_transport_filter(s.transport_type, transport_type))
             .collect();
         let stations = self
-            .update_station_vec_with_attributes(stations, None, transport_type)
+            .update_station_vec_with_attributes(stations, None, transport_type, false)
             .await?;
 
         Ok(stations)
@@ -111,7 +111,7 @@ where
             .collect();
 
         let stations = self
-            .update_station_vec_with_attributes(stations, Some(station_group_id), transport_type)
+            .update_station_vec_with_attributes(stations, Some(station_group_id), transport_type, false)
             .await?;
 
         Ok(stations)
@@ -156,7 +156,7 @@ where
             .await?;
 
         let stations = self
-            .update_station_vec_with_attributes(stations, None, transport_type)
+            .update_station_vec_with_attributes(stations, None, transport_type, false)
             .await?;
 
         Ok(stations)
@@ -187,6 +187,7 @@ where
                 stations,
                 line_group_id.map(|id| id as u32),
                 transport_type,
+                false,
             )
             .await?;
 
@@ -205,7 +206,7 @@ where
             .collect();
 
         let stations = self
-            .update_station_vec_with_attributes(stations, None, transport_type)
+            .update_station_vec_with_attributes(stations, None, transport_type, true)
             .await?;
 
         Ok(stations)
@@ -228,7 +229,7 @@ where
             .await?;
 
         let stations = self
-            .update_station_vec_with_attributes(stations, None, transport_type)
+            .update_station_vec_with_attributes(stations, None, transport_type, false)
             .await?;
 
         Ok(stations)
@@ -249,6 +250,7 @@ where
         mut stations: Vec<Station>,
         line_group_id: Option<u32>,
         transport_type: TransportTypeFilter,
+        skip_types_join: bool,
     ) -> Result<Vec<Station>, UseCaseError> {
         let mut station_group_ids: Vec<u32> = stations
             .iter()
@@ -258,16 +260,16 @@ where
         station_group_ids.dedup();
 
         // Phase 1: independent queries in parallel
-        // When line_group_id is None, train type data won't be used, so skip the
-        // expensive JOINs to station_station_types and types tables
-        let (stations_by_group_ids, lines) = if line_group_id.is_some() {
+        // When skip_types_join is true, skip the expensive JOINs to
+        // station_station_types and types tables (used by GetStationsByLineIdList)
+        let (stations_by_group_ids, lines) = if skip_types_join {
             tokio::try_join!(
-                self.get_stations_by_group_id_vec(&station_group_ids),
+                self.get_stations_by_group_id_vec_no_types(&station_group_ids),
                 self.get_lines_by_station_group_id_vec(&station_group_ids),
             )?
         } else {
             tokio::try_join!(
-                self.get_stations_by_group_id_vec_no_types(&station_group_ids),
+                self.get_stations_by_group_id_vec(&station_group_ids),
                 self.get_lines_by_station_group_id_vec(&station_group_ids),
             )?
         };
@@ -505,7 +507,7 @@ where
             .await?;
 
         let stations = self
-            .update_station_vec_with_attributes(stations, Some(line_group_id), transport_type)
+            .update_station_vec_with_attributes(stations, Some(line_group_id), transport_type, false)
             .await?;
 
         Ok(stations)
@@ -527,7 +529,7 @@ where
 
         // lines, companies, station_numbers等を付与（train_typeはNoneで空になる）
         let mut stations = self
-            .update_station_vec_with_attributes(stations, None, transport_type)
+            .update_station_vec_with_attributes(stations, None, transport_type, false)
             .await?;
 
         // 複数line_group_idの列車種別を一括取得してセット
@@ -1909,9 +1911,30 @@ mod tests {
             }
             async fn get_by_station_group_id_vec_no_types(
                 &self,
-                station_group_id_vec: &[u32],
+                _: &[u32],
             ) -> Result<Vec<Station>, DomainError> {
-                self.get_by_station_group_id_vec(station_group_id_vec).await
+                let stations = self
+                    .stations_by_group
+                    .iter()
+                    .map(|s| {
+                        let mut s = s.clone();
+                        s.line_group_cd = None;
+                        s.pass = None;
+                        s.sst_id = None;
+                        s.type_cd = None;
+                        s.type_id = None;
+                        s.type_name = None;
+                        s.type_name_k = None;
+                        s.type_name_r = None;
+                        s.type_name_zh = None;
+                        s.type_name_ko = None;
+                        s.color = None;
+                        s.direction = None;
+                        s.kind = None;
+                        s
+                    })
+                    .collect();
+                Ok(stations)
             }
             async fn get_by_coordinates(
                 &self,
@@ -2251,7 +2274,7 @@ mod tests {
 
             let stations = vec![station1, station2];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail)
+                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
                 .await
                 .expect("Should succeed");
 
@@ -2301,7 +2324,7 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, Some(1000), TransportTypeFilter::Rail)
+                .update_station_vec_with_attributes(stations, Some(1000), TransportTypeFilter::Rail, false)
                 .await
                 .expect("Should succeed");
 
@@ -2333,7 +2356,7 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail)
+                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
                 .await
                 .expect("Should succeed");
 
@@ -2387,7 +2410,7 @@ mod tests {
             let stations = vec![rail_station];
             // Bus routes are added only when transport_type is RailAndBus
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::RailAndBus)
+                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::RailAndBus, false)
                 .await
                 .expect("Should succeed");
 
@@ -2440,7 +2463,7 @@ mod tests {
             // When transport_type is Rail, bus routes should NOT be added
             let stations = vec![rail_station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail)
+                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
                 .await
                 .expect("Should succeed");
 
@@ -2477,7 +2500,7 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail)
+                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
                 .await
                 .expect("Should succeed even with missing company");
 
@@ -2515,7 +2538,7 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail)
+                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
                 .await
                 .expect("Should succeed even with missing train type");
 
@@ -2550,7 +2573,7 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail)
+                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
                 .await
                 .expect("Should succeed");
 
@@ -2567,7 +2590,7 @@ mod tests {
 
             let stations: Vec<Station> = vec![];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail)
+                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
                 .await
                 .expect("Should succeed with empty input");
 
@@ -2599,7 +2622,7 @@ mod tests {
 
             let stations = vec![station1, station2];
             let result = interactor
-                .update_station_vec_with_attributes(stations, Some(1000), TransportTypeFilter::Rail)
+                .update_station_vec_with_attributes(stations, Some(1000), TransportTypeFilter::Rail, false)
                 .await
                 .expect("Should succeed");
 
@@ -2647,7 +2670,7 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail)
+                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
                 .await
                 .expect("Should succeed");
 
@@ -2684,7 +2707,7 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail)
+                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
                 .await
                 .expect("Should succeed");
 

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -111,7 +111,12 @@ where
             .collect();
 
         let stations = self
-            .update_station_vec_with_attributes(stations, Some(station_group_id), transport_type, false)
+            .update_station_vec_with_attributes(
+                stations,
+                Some(station_group_id),
+                transport_type,
+                false,
+            )
             .await?;
 
         Ok(stations)
@@ -507,7 +512,12 @@ where
             .await?;
 
         let stations = self
-            .update_station_vec_with_attributes(stations, Some(line_group_id), transport_type, false)
+            .update_station_vec_with_attributes(
+                stations,
+                Some(line_group_id),
+                transport_type,
+                false,
+            )
             .await?;
 
         Ok(stations)
@@ -2274,7 +2284,12 @@ mod tests {
 
             let stations = vec![station1, station2];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
+                .update_station_vec_with_attributes(
+                    stations,
+                    None,
+                    TransportTypeFilter::Rail,
+                    false,
+                )
                 .await
                 .expect("Should succeed");
 
@@ -2324,7 +2339,12 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, Some(1000), TransportTypeFilter::Rail, false)
+                .update_station_vec_with_attributes(
+                    stations,
+                    Some(1000),
+                    TransportTypeFilter::Rail,
+                    false,
+                )
                 .await
                 .expect("Should succeed");
 
@@ -2356,7 +2376,12 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
+                .update_station_vec_with_attributes(
+                    stations,
+                    None,
+                    TransportTypeFilter::Rail,
+                    false,
+                )
                 .await
                 .expect("Should succeed");
 
@@ -2410,7 +2435,12 @@ mod tests {
             let stations = vec![rail_station];
             // Bus routes are added only when transport_type is RailAndBus
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::RailAndBus, false)
+                .update_station_vec_with_attributes(
+                    stations,
+                    None,
+                    TransportTypeFilter::RailAndBus,
+                    false,
+                )
                 .await
                 .expect("Should succeed");
 
@@ -2463,7 +2493,12 @@ mod tests {
             // When transport_type is Rail, bus routes should NOT be added
             let stations = vec![rail_station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
+                .update_station_vec_with_attributes(
+                    stations,
+                    None,
+                    TransportTypeFilter::Rail,
+                    false,
+                )
                 .await
                 .expect("Should succeed");
 
@@ -2500,7 +2535,12 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
+                .update_station_vec_with_attributes(
+                    stations,
+                    None,
+                    TransportTypeFilter::Rail,
+                    false,
+                )
                 .await
                 .expect("Should succeed even with missing company");
 
@@ -2538,7 +2578,12 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
+                .update_station_vec_with_attributes(
+                    stations,
+                    None,
+                    TransportTypeFilter::Rail,
+                    false,
+                )
                 .await
                 .expect("Should succeed even with missing train type");
 
@@ -2573,7 +2618,12 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
+                .update_station_vec_with_attributes(
+                    stations,
+                    None,
+                    TransportTypeFilter::Rail,
+                    false,
+                )
                 .await
                 .expect("Should succeed");
 
@@ -2590,7 +2640,12 @@ mod tests {
 
             let stations: Vec<Station> = vec![];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
+                .update_station_vec_with_attributes(
+                    stations,
+                    None,
+                    TransportTypeFilter::Rail,
+                    false,
+                )
                 .await
                 .expect("Should succeed with empty input");
 
@@ -2622,7 +2677,12 @@ mod tests {
 
             let stations = vec![station1, station2];
             let result = interactor
-                .update_station_vec_with_attributes(stations, Some(1000), TransportTypeFilter::Rail, false)
+                .update_station_vec_with_attributes(
+                    stations,
+                    Some(1000),
+                    TransportTypeFilter::Rail,
+                    false,
+                )
                 .await
                 .expect("Should succeed");
 
@@ -2670,7 +2730,12 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
+                .update_station_vec_with_attributes(
+                    stations,
+                    None,
+                    TransportTypeFilter::Rail,
+                    false,
+                )
                 .await
                 .expect("Should succeed");
 
@@ -2707,7 +2772,12 @@ mod tests {
 
             let stations = vec![station];
             let result = interactor
-                .update_station_vec_with_attributes(stations, None, TransportTypeFilter::Rail, false)
+                .update_station_vec_with_attributes(
+                    stations,
+                    None,
+                    TransportTypeFilter::Rail,
+                    false,
+                )
                 .await
                 .expect("Should succeed");
 

--- a/stationapi/src/use_case/traits/query.rs
+++ b/stationapi/src/use_case/traits/query.rs
@@ -65,6 +65,7 @@ pub trait QueryUseCase: Send + Sync + 'static {
         stations: Vec<Station>,
         line_group_id: Option<u32>,
         transport_type: TransportTypeFilter,
+        skip_types_join: bool,
     ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_lines_by_station_group_id(
         &self,

--- a/stationapi/src/use_case/traits/query.rs
+++ b/stationapi/src/use_case/traits/query.rs
@@ -60,13 +60,6 @@ pub trait QueryUseCase: Send + Sync + 'static {
         &self,
         company_id_vec: &[u32],
     ) -> Result<Vec<Company>, UseCaseError>;
-    async fn update_station_vec_with_attributes(
-        &self,
-        stations: Vec<Station>,
-        line_group_id: Option<u32>,
-        transport_type: TransportTypeFilter,
-        skip_types_join: bool,
-    ) -> Result<Vec<Station>, UseCaseError>;
     async fn get_lines_by_station_group_id(
         &self,
         station_group_id: u32,


### PR DESCRIPTION
## Summary
- **HashMap pre-indexing**: Pre-index lines by `station_g_cd` into a `HashMap<i32, Vec<usize>>` before the enrichment loop, replacing O(n×m) linear scan with O(1) lookup per station
- **Lightweight station group query**: Add `get_by_station_group_id_vec_no_types` that skips `station_station_types` and `types` JOINs when `line_group_id` is None (i.e., `GetStationsByLineIdList`), since train type data is unused in that path
- **AGENTS.md**: Add contribution guideline prioritizing quality and performance over implementation speed

### Complexity improvement
| Bottleneck | Before | After |
|---|---|---|
| Per-station line filtering | O(n×m) where n=stations, m=lines | O(n+m) with HashMap |
| Station group query | 4 JOINs (stations, lines, station_station_types, types) | 2 JOINs (stations, lines) when train types unused |

## Test plan
- [x] `SQLX_OFFLINE=true cargo build` passes
- [x] `SQLX_OFFLINE=true cargo test` — all 26 tests pass
- [ ] Verify response correctness with 10+ line_ids via gRPC call
- [ ] Compare Prometheus latency metrics before/after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **パフォーマンス改善**
  * 種類情報の結合を省く軽量な駅取得経路を追加し、特定クエリで応答速度とスケーラビリティを向上。
  * 駅と路線の突合処理を事前インデックス化して冗長な走査を削減。

* **ドキュメント**
  * コントリビューター向けガイドを更新し、コード品質とランタイム性能の優先・レビュー基準を明確化。

* **テスト / リファクタ**
  * 取得経路追加に伴う内部インターフェース整理とテスト更新を実施。省略動作を検証するユニットを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->