### PR TITLE
Filter non-gRPC paths from metrics labels

### DIFF
--- a/stationapi/src/presentation/middleware/metrics.rs
+++ b/stationapi/src/presentation/middleware/metrics.rs
@@ -39,7 +39,18 @@ where
     }
 
     fn call(&mut self, req: Request<B>) -> Self::Future {
-        let method = req.uri().path().to_owned();
+        let path = req.uri().path();
+
+        // Only record metrics for valid gRPC paths (e.g. /app.trainlcd.grpc.StationAPI/Method)
+        // to avoid cardinality explosion from bot/scanner requests like /$(pwd)/netlify.toml
+        let method = if path.starts_with("/app.trainlcd.grpc.")
+            || path.starts_with("/grpc.health.")
+            || path.starts_with("/grpc.reflection.")
+        {
+            path.to_owned()
+        } else {
+            "unknown".to_owned()
+        };
 
         counter!("grpc_requests_started_total", "method" => method.clone()).increment(1);
 

--- a/stationapi/src/presentation/middleware/metrics.rs
+++ b/stationapi/src/presentation/middleware/metrics.rs
@@ -41,16 +41,10 @@ where
     fn call(&mut self, req: Request<B>) -> Self::Future {
         let path = req.uri().path();
 
-        // Only record metrics for valid gRPC paths (e.g. /app.trainlcd.grpc.StationAPI/Method)
-        // to avoid cardinality explosion from bot/scanner requests like /$(pwd)/netlify.toml
-        let method = if path.starts_with("/app.trainlcd.grpc.")
-            || path.starts_with("/grpc.health.")
-            || path.starts_with("/grpc.reflection.")
-        {
-            path.to_owned()
-        } else {
-            "unknown".to_owned()
-        };
+        // Map each gRPC path prefix to a fixed bucket name and extract only the
+        // canonical method token (alphanumeric + dots/slashes/underscores) to
+        // prevent unbounded label cardinality from raw path strings.
+        let method = normalize_grpc_method(path);
 
         counter!("grpc_requests_started_total", "method" => method.clone()).increment(1);
 
@@ -60,6 +54,37 @@ where
             start: Instant::now(),
         }
     }
+}
+
+/// Normalizes a request path into a bounded metric label.
+///
+/// Known gRPC prefixes are mapped to fixed bucket names with only a validated
+/// method token appended (characters limited to alphanumeric, `.`, `/`, `_`).
+/// Any path that does not match a known prefix or contains unexpected
+/// characters is labelled `"unknown"`.
+fn normalize_grpc_method(path: &str) -> String {
+    const PREFIXES: &[(&str, &str)] = &[
+        ("/app.trainlcd.grpc.", "trainlcd"),
+        ("/grpc.health.", "grpc_health"),
+        ("/grpc.reflection.", "grpc_reflection"),
+    ];
+
+    for &(prefix, bucket) in PREFIXES {
+        if let Some(rest) = path.strip_prefix(prefix) {
+            // Validate that the remainder contains only safe characters
+            if !rest.is_empty()
+                && rest
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '/' || c == '_')
+            {
+                return format!("{}/{}", bucket, rest);
+            }
+            // Prefix matched but method token is missing or invalid
+            return bucket.to_owned();
+        }
+    }
+
+    "unknown".to_owned()
 }
 
 pin_project! {


### PR DESCRIPTION
## Summary
- ボット/スキャナーが `/$(pwd)/netlify.toml` 等の任意パスでリクエストを送ると、そのパスがそのまま Prometheus メトリクスの `method` ラベルに記録され、Grafana ダッシュボードに不正な指標が表示されていた
- 正規の gRPC プレフィックス (`/app.trainlcd.grpc.`, `/grpc.health.`, `/grpc.reflection.`) のみ記録し、それ以外は `"unknown"` にまとめることでカーディナリティ爆発を防止

## Test plan
- [x] `cargo fmt --check` パス
- [x] `cargo clippy -- -D warnings` パス
- [x] `cargo test` 全26テストパス
- [ ] デプロイ後、Grafana ダッシュボードから不正な指標が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * メトリクスの method ラベルを正規化し、既知の gRPC エンドポイントを特定のバケット名に集約します。未知のパスや不正なトークンは「unknown」として扱われ、ラベルの種類が限定されることで監視データのノイズとカードinalityが低減され、モニタリングの信頼性と集計効率が向上します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->