### PR TITLE
GetStationsByLineGroupIdList RPCのパフォーマンス改善

### DIFF
--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -298,8 +298,9 @@ where
             .collect();
 
         // lines, companies, station_numbers等を付与（train_typeはNoneで空になる）
+        // train_typeは後続のget_by_line_group_id_vecで取得するためJOIN不要
         let mut stations = self
-            .update_station_vec_with_attributes(stations, None, transport_type, false)
+            .update_station_vec_with_attributes(stations, None, transport_type, true)
             .await?;
 
         // 複数line_group_idの列車種別を一括取得してセット


### PR DESCRIPTION
## Summary
- `update_station_vec_with_attributes`の`skip_types_join`を`true`に変更
- `line_group_id=None`で呼び出すため内部のtrain_type取得は常に空Vecを返しており、`station_station_types`/`types`テーブルへのJOINは不要だった
- train_typeは後続の`train_type_repository.get_by_line_group_id_vec`で別途取得・上書き済み

### 改善内容
- 2つのSQLクエリ(`get_stations_by_group_id_vec`, `get_lines_by_station_group_id_vec`)から不要なJOINを削除（`_no_types`バリアントに切り替え）
- バス停クエリが`tokio::try_join!`で他クエリと並列実行されるようになる

## Test plan
- [x] `cargo fmt --check` パス
- [x] `cargo clippy` 警告なし
- [x] `cargo test` 全380テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * 駅データ取得クエリの効率を向上させました。複数の路線グループIDから駅情報を検索する際のレスポンス時間が改善されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->