### PR TITLE
GetStationsByLineIdList RPCのパフォーマンス改善

### DIFF
--- a/data/create_table.sql
+++ b/data/create_table.sql
@@ -96,6 +96,8 @@ DROP INDEX IF EXISTS public.idx_16421_station_station_types_station_cd;
 
 DROP INDEX IF EXISTS public.idx_16421_station_station_types_line_group_cd;
 
+DROP INDEX IF EXISTS public.idx_sst_station_linegroup_pass;
+
 DROP INDEX IF EXISTS public.idx_16407_lines_e_sort;
 
 DROP INDEX IF EXISTS public.idx_16407_lines_company_cd;
@@ -459,6 +461,12 @@ CREATE INDEX idx_16421_station_station_types_station_cd ON public.station_statio
 --
 
 CREATE INDEX idx_16421_station_station_types_type_cd ON public.station_station_types USING btree (type_cd);
+
+--
+-- Name: idx_sst_station_linegroup_pass; Type: INDEX; Schema: public; Owner: stationapi
+--
+
+CREATE INDEX idx_sst_station_linegroup_pass ON public.station_station_types USING btree (station_cd, line_group_cd, pass);
 
 --
 -- Name: idx_16426_stations_e_sort_station_cd; Type: INDEX; Schema: public; Owner: stationapi

--- a/stationapi/src/domain/repository/station_repository.rs
+++ b/stationapi/src/domain/repository/station_repository.rs
@@ -16,6 +16,10 @@ pub trait StationRepository: Send + Sync + 'static {
         direction_id: Option<u32>,
     ) -> Result<Vec<Station>, DomainError>;
     async fn get_by_line_id_vec(&self, line_ids: &[u32]) -> Result<Vec<Station>, DomainError>;
+    async fn get_by_line_id_vec_with_group_stations(
+        &self,
+        line_ids: &[u32],
+    ) -> Result<Vec<Station>, DomainError>;
     async fn get_by_station_group_id(
         &self,
         station_group_id: u32,
@@ -126,6 +130,25 @@ mod tests {
                 .stations
                 .values()
                 .filter(|station| line_ids.contains(&(station.line_cd as u32)))
+                .cloned()
+                .collect();
+            Ok(result)
+        }
+
+        async fn get_by_line_id_vec_with_group_stations(
+            &self,
+            line_ids: &[u32],
+        ) -> Result<Vec<Station>, DomainError> {
+            let group_ids: Vec<i32> = self
+                .stations
+                .values()
+                .filter(|s| line_ids.contains(&(s.line_cd as u32)))
+                .map(|s| s.station_g_cd)
+                .collect();
+            let result: Vec<Station> = self
+                .stations
+                .values()
+                .filter(|s| group_ids.contains(&s.station_g_cd))
                 .cloned()
                 .collect();
             Ok(result)

--- a/stationapi/src/infrastructure/station_repository.rs
+++ b/stationapi/src/infrastructure/station_repository.rs
@@ -346,6 +346,13 @@ impl StationRepository for MyStationRepository {
         let mut conn = self.pool.acquire().await?;
         InternalStationRepository::get_by_line_id_vec(line_ids, &mut conn).await
     }
+    async fn get_by_line_id_vec_with_group_stations(
+        &self,
+        line_ids: &[u32],
+    ) -> Result<Vec<Station>, DomainError> {
+        let mut conn = self.pool.acquire().await?;
+        InternalStationRepository::get_by_line_id_vec_with_group_stations(line_ids, &mut conn).await
+    }
     async fn get_by_station_group_id(
         &self,
         station_group_id: u32,
@@ -870,6 +877,103 @@ impl InternalStationRepository {
         for id in line_ids {
             query = query.bind(*id as i32);
         }
+        for id in line_ids {
+            query = query.bind(*id as i32);
+        }
+
+        let rows = query.fetch_all(conn).await?;
+        let stations: Vec<Station> = rows.into_iter().map(|row| row.into()).collect();
+
+        Ok(stations)
+    }
+
+    async fn get_by_line_id_vec_with_group_stations(
+        line_ids: &[u32],
+        conn: &mut PgConnection,
+    ) -> Result<Vec<Station>, DomainError> {
+        if line_ids.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let params = (1..=line_ids.len())
+            .map(|i| format!("${i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let query_str = format!(
+            r#"SELECT
+              s.station_cd,
+              s.station_g_cd,
+              s.station_name,
+              s.station_name_k,
+              s.station_name_r,
+              s.station_name_rn,
+              s.station_name_zh,
+              s.station_name_ko,
+              s.station_number1,
+              s.station_number2,
+              s.station_number3,
+              s.station_number4,
+              s.three_letter_code,
+              s.line_cd,
+              s.pref_cd,
+              s.post,
+              s.address,
+              s.lon,
+              s.lat,
+              s.open_ymd,
+              s.close_ymd,
+              s.e_status,
+              s.e_sort,
+              l.company_cd,
+              COALESCE(NULLIF(COALESCE(a.line_name, l.line_name), ''), NULL) AS line_name,
+              COALESCE(NULLIF(COALESCE(a.line_name_k, l.line_name_k), ''), NULL) AS line_name_k,
+              COALESCE(NULLIF(COALESCE(a.line_name_h, l.line_name_h), ''), NULL) AS line_name_h,
+              COALESCE(NULLIF(COALESCE(a.line_name_r, l.line_name_r), ''), NULL) AS line_name_r,
+              COALESCE(NULLIF(COALESCE(a.line_name_zh, l.line_name_zh), ''), NULL) AS line_name_zh,
+              COALESCE(NULLIF(COALESCE(a.line_name_ko, l.line_name_ko), ''), NULL) AS line_name_ko,
+              COALESCE(NULLIF(COALESCE(a.line_color_c, l.line_color_c), ''), NULL) AS line_color_c,
+              l.line_type,
+              l.line_symbol1,
+              l.line_symbol2,
+              l.line_symbol3,
+              l.line_symbol4,
+              l.line_symbol1_color,
+              l.line_symbol2_color,
+              l.line_symbol3_color,
+              l.line_symbol4_color,
+              l.line_symbol1_shape,
+              l.line_symbol2_shape,
+              l.line_symbol3_shape,
+              l.line_symbol4_shape,
+              COALESCE(l.average_distance, 0.0)::DOUBLE PRECISION AS average_distance,
+              NULL::int AS type_id,
+              NULL::int AS sst_id,
+              NULL::int AS type_cd,
+              NULL::int AS line_group_cd,
+              NULL::int AS pass,
+              NULL::text AS type_name,
+              NULL::text AS type_name_k,
+              NULL::text AS type_name_r,
+              NULL::text AS type_name_zh,
+              NULL::text AS type_name_ko,
+              NULL::text AS color,
+              NULL::int AS direction,
+              NULL::int AS kind,
+              s.transport_type
+            FROM stations AS s
+            JOIN lines AS l ON l.line_cd = s.line_cd
+            LEFT JOIN line_aliases AS la ON la.station_cd = s.station_cd
+            LEFT JOIN aliases AS a ON a.id = la.alias_cd
+            WHERE s.station_g_cd IN (
+              SELECT DISTINCT s2.station_g_cd FROM stations AS s2
+              WHERE s2.line_cd IN ( {params} ) AND s2.e_status = 0
+            )
+              AND s.e_status = 0
+              AND l.e_status = 0"#
+        );
+
+        let mut query = sqlx::query_as::<_, StationRow>(&query_str);
         for id in line_ids {
             query = query.bind(*id as i32);
         }

--- a/stationapi/src/main.rs
+++ b/stationapi/src/main.rs
@@ -127,10 +127,29 @@ async fn run() -> std::result::Result<(), anyhow::Error> {
     });
 
     let db_url = &fetch_database_url();
-    let max_connections: u32 = std::env::var("DATABASE_MAX_CONNECTIONS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(20);
+    const DEFAULT_MAX_CONNECTIONS: u32 = 20;
+    let max_connections: u32 = match std::env::var("DATABASE_MAX_CONNECTIONS") {
+        Ok(v) => match v.parse::<u32>() {
+            Ok(n) if (1..=1000).contains(&n) => n,
+            Ok(n) => {
+                tracing::warn!(
+                    "DATABASE_MAX_CONNECTIONS={} is out of range (1..=1000), using default {}",
+                    n,
+                    DEFAULT_MAX_CONNECTIONS
+                );
+                DEFAULT_MAX_CONNECTIONS
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to parse DATABASE_MAX_CONNECTIONS: {}, using default {}",
+                    e,
+                    DEFAULT_MAX_CONNECTIONS
+                );
+                DEFAULT_MAX_CONNECTIONS
+            }
+        },
+        Err(_) => DEFAULT_MAX_CONNECTIONS,
+    };
     let pool = Arc::new(
         match PgPoolOptions::new()
             .max_connections(max_connections)

--- a/stationapi/src/main.rs
+++ b/stationapi/src/main.rs
@@ -127,9 +127,13 @@ async fn run() -> std::result::Result<(), anyhow::Error> {
     });
 
     let db_url = &fetch_database_url();
+    let max_connections: u32 = std::env::var("DATABASE_MAX_CONNECTIONS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(20);
     let pool = Arc::new(
         match PgPoolOptions::new()
-            .max_connections(5)
+            .max_connections(max_connections)
             .connect(db_url)
             .await
         {

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -203,15 +203,49 @@ where
         line_ids: &[u32],
         transport_type: TransportTypeFilter,
     ) -> Result<Vec<Station>, UseCaseError> {
-        let stations = self.station_repository.get_by_line_id_vec(line_ids).await?;
+        // Fetch all stations at station groups matching the requested line IDs.
+        // This returns a superset that includes stations on other lines at the same
+        // physical locations, eliminating the need for a separate group station query.
+        let all_group_stations = self
+            .station_repository
+            .get_by_line_id_vec_with_group_stations(line_ids)
+            .await?;
 
-        let stations: Vec<Station> = stations
-            .into_iter()
-            .filter(|s| matches_transport_filter(s.transport_type, transport_type))
+        // Build input order map for sorting main stations by requested line_id order
+        let line_id_order: std::collections::HashMap<i32, usize> = line_ids
+            .iter()
+            .enumerate()
+            .map(|(i, &id)| (id as i32, i))
             .collect();
 
+        // Filter for main stations: only those on requested lines + matching transport type
+        let mut stations: Vec<Station> = all_group_stations
+            .iter()
+            .filter(|s| {
+                line_id_order.contains_key(&s.line_cd)
+                    && matches_transport_filter(s.transport_type, transport_type)
+            })
+            .cloned()
+            .collect();
+
+        // Sort by input line_id order, then by e_sort, station_cd (matching original query ORDER BY)
+        stations.sort_by(|a, b| {
+            let order_a = line_id_order.get(&a.line_cd).copied().unwrap_or(usize::MAX);
+            let order_b = line_id_order.get(&b.line_cd).copied().unwrap_or(usize::MAX);
+            order_a
+                .cmp(&order_b)
+                .then(a.e_sort.cmp(&b.e_sort))
+                .then(a.station_cd.cmp(&b.station_cd))
+        });
+
         let stations = self
-            .update_station_vec_with_attributes(stations, None, transport_type, true)
+            .update_station_vec_with_attributes_inner(
+                stations,
+                None,
+                transport_type,
+                true,
+                Some(all_group_stations),
+            )
             .await?;
 
         Ok(stations)
@@ -987,10 +1021,28 @@ where
 
     async fn update_station_vec_with_attributes(
         &self,
+        stations: Vec<Station>,
+        line_group_id: Option<u32>,
+        transport_type: TransportTypeFilter,
+        skip_types_join: bool,
+    ) -> Result<Vec<Station>, UseCaseError> {
+        self.update_station_vec_with_attributes_inner(
+            stations,
+            line_group_id,
+            transport_type,
+            skip_types_join,
+            None,
+        )
+        .await
+    }
+
+    async fn update_station_vec_with_attributes_inner(
+        &self,
         mut stations: Vec<Station>,
         line_group_id: Option<u32>,
         transport_type: TransportTypeFilter,
         skip_types_join: bool,
+        prefetched_group_stations: Option<Vec<Station>>,
     ) -> Result<Vec<Station>, UseCaseError> {
         let mut station_group_ids: Vec<u32> = stations
             .iter()
@@ -1019,11 +1071,20 @@ where
         // station_station_types and types tables (used by GetStationsByLineIdList)
         // Also batch-fetch bus stop candidates in parallel
         let (stations_by_group_ids, lines, bus_candidates_flat) = if skip_types_join {
-            tokio::try_join!(
-                self.get_stations_by_group_id_vec_no_types(&station_group_ids),
-                self.get_lines_by_station_group_id_vec_no_types(&station_group_ids),
-                self.get_bus_stops_near_stations(&unique_bus_coords, 50),
-            )?
+            if let Some(prefetched) = prefetched_group_stations {
+                // Group stations already fetched by expanded primary query
+                let (lines, bus) = tokio::try_join!(
+                    self.get_lines_by_station_group_id_vec_no_types(&station_group_ids),
+                    self.get_bus_stops_near_stations(&unique_bus_coords, 50),
+                )?;
+                (prefetched, lines, bus)
+            } else {
+                tokio::try_join!(
+                    self.get_stations_by_group_id_vec_no_types(&station_group_ids),
+                    self.get_lines_by_station_group_id_vec_no_types(&station_group_ids),
+                    self.get_bus_stops_near_stations(&unique_bus_coords, 50),
+                )?
+            }
         } else {
             let (s, l) = tokio::try_join!(
                 self.get_stations_by_group_id_vec(&station_group_ids),
@@ -1563,6 +1624,12 @@ mod tests {
             async fn get_by_line_id_vec(&self, _: &[u32]) -> Result<Vec<Station>, DomainError> {
                 Ok(vec![])
             }
+            async fn get_by_line_id_vec_with_group_stations(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
             async fn get_by_station_group_id(&self, _: u32) -> Result<Vec<Station>, DomainError> {
                 Ok(vec![])
             }
@@ -1987,6 +2054,12 @@ mod tests {
             }
             async fn get_by_line_id_vec(&self, _: &[u32]) -> Result<Vec<Station>, DomainError> {
                 Ok(vec![])
+            }
+            async fn get_by_line_id_vec_with_group_stations(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(self.stations_by_group.clone())
             }
             async fn get_by_station_group_id(&self, _: u32) -> Result<Vec<Station>, DomainError> {
                 Ok(vec![])

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -211,12 +211,13 @@ where
             .get_by_line_id_vec_with_group_stations(line_ids)
             .await?;
 
-        // Build input order map for sorting main stations by requested line_id order
-        let line_id_order: std::collections::HashMap<i32, usize> = line_ids
-            .iter()
-            .enumerate()
-            .map(|(i, &id)| (id as i32, i))
-            .collect();
+        // Build input order map for sorting main stations by requested line_id order.
+        // Preserve first-occurrence order for duplicate line IDs (matching SQL CASE WHEN behavior).
+        let mut line_id_order: std::collections::HashMap<i32, usize> =
+            std::collections::HashMap::new();
+        for (i, &id) in line_ids.iter().enumerate() {
+            line_id_order.entry(id as i32).or_insert(i);
+        }
 
         // Filter for main stations: only those on requested lines + matching transport type
         let mut stations: Vec<Station> = all_group_stations


### PR DESCRIPTION
## Summary
- コネクションプールサイズを5から20に拡大（`DATABASE_MAX_CONNECTIONS`環境変数で設定可能）
- `station_station_types (station_cd, line_group_cd, pass)` の複合インデックスを追加し、NOT EXISTSサブクエリを高速化
- 主クエリを拡張して関連する全`station_g_cd`の駅を一度に取得するように変更し、`update_station_vec_with_attributes`内のPhase 1から駅クエリを省略（並列クエリ3→2に削減、全体のDBクエリ数6-7→4-5に削減）

## Test plan
- [x] `SQLX_OFFLINE=true cargo build` でビルド確認
- [x] `cargo clippy` でlint確認
- [x] `cargo fmt --check` でフォーマット確認
- [x] `cargo test` で全26テスト通過確認
- [ ] 実際のDBに対して`GetStationsByLineIdList`を多数のline_idで呼び出し、レスポンスタイムを比較

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 指定した路線に関連するグループ駅も含めた駅一覧取得が可能になりました。
  * 駅一覧の並び順が入力順・ソート順・駅コードで決まるように安定化しました。

* **パフォーマンス改善**
  * 駅検索用のデータベースインデックス調整により検索応答を改善しました。

* **その他**
  * データベース接続プールの最大接続数が環境変数で調整可能になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->