### PR TITLE
PRラベラの修正

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,3 +22,9 @@ data:
   - changed-files:
       - any-glob-to-any-file:
           - "*.csv"
+deploy-prod:
+  - base-branch: ["^master$"]
+deploy-dev:
+  - base-branch: ["^dev$"]
+deploy-staging:
+  - base-branch: ["^staging$"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,5 +26,3 @@ deploy-prod:
   - base-branch: ["^master$"]
 deploy-dev:
   - base-branch: ["^dev$"]
-deploy-staging:
-  - base-branch: ["^staging$"]

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,11 +1,5 @@
-# Head branch (source) patterns
 feature: feature/*
 fix: fix/*
 chore: chore/*
 data: data/*
 release: release/*
-
-# Base branch (target) patterns
-deploy:production: master
-deploy:dev: dev
-deploy:staging: staging


### PR DESCRIPTION
## 概要

今までmasterブランチへのPRでdeploy:devが誤って自動的に貼られていたが、deploy-prodが貼られるように修正。
ほかにもdevブランチ向けのlabeler修正あり。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `cargo fmt --all -- --check` が通ること
- [ ] `cargo clippy -- -D warnings` が通ること
- [ ] `cargo test`（`SQLX_OFFLINE=true`）が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* PR自動ラベリング設定が更新されました。デプロイメント環境向けの新しいラベリングルールが追加され、ソースブランチ識別用ラベルマッピングが整理されました。これにより、プルリクエストの自動分類がより正確で効率的になり、開発ワークフロー管理がシンプル化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->