### PR TITLE
信越本線（篠ノ井-長野・直江津-新潟）のラインカラーをスカイブルーに修正

### DIFF
--- a/data/2!lines.csv
+++ b/data/2!lines.csv
@@ -106,8 +106,8 @@ line_cd,company_cd,line_name,line_name_k,line_name_h,line_name_r,line_name_rn,li
 11345,100,ディズニーリゾートライン,ディズニーリゾートライン,ディズニーリゾートライン,Disney Resort Line,Disney Resort Line,迪士尼度假区线,디즈니 리조트 라인,#004499,5,,,,,,,,,,,,,0,11343,1087.75721
 11401,2,小海線,コウミセン,小海線,Koumi Line,Koumi Line,小海线,고우미선,#008000,2,,,,,,,,,,,,,0,11401,2573.34299
 11402,3,身延線,ミノブセン,身延線,Minobu Line,Minobu Line,身延线,미노부선,#6F2D98,2,CC,,,,#6F2D98,,,,HALF_SQUARE_WITHOUT_ROUND,,,,0,11402,2438.67983
-11403,2,信越本線,シンエツホンセン,信越本線,Shin’etsu Main Line,Shin’etsu Main Line,信越本线,신에쓰 본선,#FFD400,2,SE,,,,#00B3E6,,,,ROUND,,,,0,11403,2632.98923
-11404,2,信越本線,シンエツホンセン,信越本線,Shin’etsu Main Line,Shin’etsu Main Line,信越本线,신에쓰 본선,#FFD400,2,,,,,,,,,,,,,0,11404,3690.56278
+11403,2,信越本線,シンエツホンセン,信越本線,Shin’etsu Main Line,Shin’etsu Main Line,信越本线,신에쓰 본선,#00B3E6,2,SE,,,,#00B3E6,,,,ROUND,,,,0,11403,2632.98923
+11404,2,信越本線,シンエツホンセン,信越本線,Shin’etsu Main Line,Shin’etsu Main Line,信越本线,신에쓰 본선,#00B3E6,2,,,,,,,,,,,,,0,11404,3690.56278
 11405,4,北陸本線,ホクリクホンセン,北陸本線,Hokuriku Main Line,Hokuriku Main Line,北陆本线,호쿠리쿠 본선,#FFD400,2,,,,,,,,,,,,,2,11405,0
 11406,2,白新線,ハクシンセン,白新線,Hakushin Line,Hakushin Line,白新线,하쿠신선,#F387B7,2,,,,,,,,,,,,,0,11406,3269.33853
 11407,2,飯山線,イイヤマセン,飯山線,Iiyama Line,Iiyama Line,饭山线,이야마선,#7BC24B,2,,,,,,,,,,,,,0,11407,3491.78175


### PR DESCRIPTION
## 概要

信越本線のうち篠ノ井駅 - 長野駅間（line_cd: 11403）と直江津駅 - 新潟駅間（line_cd: 11404）の `line_color_c` が `#FFD400`（黄）になっていたため、実際のJR東日本のラインカラーであるスカイブルー `#00B3E6` に修正しました（上越線と同色）。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [x] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `data/2!lines.csv`: 信越本線 篠ノ井 - 長野間（11403）の `line_color_c` を `#FFD400` → `#00B3E6` に変更
- `data/2!lines.csv`: 信越本線 直江津 - 新潟間（11404）の `line_color_c` を `#FFD400` → `#00B3E6` に変更
- 高崎 - 横川間（11337）は黄緑色 `#9ACD32` のまま据え置き
- `cargo run -p data_validator` を実行し `[VALID] No errors reported.` を確認

## テスト

- [ ] `cargo fmt --all -- --check` が通ること
- [ ] `cargo clippy -- -D warnings` が通ること
- [ ] `cargo test`（`SQLX_OFFLINE=true`）が通ること

省略: コード本体（`stationapi/**` 等）への変更なし。データのみの変更のため `cargo run -p data_validator` で検証済み。

## 関連Issue

closes https://github.com/TrainLCD/Issues/issues/1153

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->
