### PR TITLE
ステージングデプロイのトリガーブランチを dev に変更

### DIFF
--- a/.github/workflows/deploy_ecs_staging_stationapi.yml
+++ b/.github/workflows/deploy_ecs_staging_stationapi.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - dev
     paths:
       - ".sqlx/**"
       - "data/**"


### PR DESCRIPTION
## 概要

ステージング環境向け ECS デプロイワークフローの自動トリガー対象ブランチを `master` から `dev` に変更します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

- `.github/workflows/deploy_ecs_staging_stationapi.yml` の `push.branches` を `master` → `dev` に変更

## テスト

<!-- どのようにテストしたかを記述してください -->

省略: コード本体の変更なし（GitHub Actions ワークフロー定義のみの修正）。

- [ ] `cargo fmt --all -- --check` が通ること
- [ ] `cargo clippy -- -D warnings` が通ること
- [ ] `cargo test`(`SQLX_OFFLINE=true`) が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* ステージング環境へのデプロイメント構成を更新しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/StationAPI/pull/1509)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->