### PR TITLE
IPA生成をAzure TTS向けに修正（ジ表記をdʑに統一・路線name_ipaを日本語読みに）

### DIFF
--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -31,10 +31,9 @@ fn compute_ipa(name_katakana: &str, name_roman: Option<&str>) -> IpaResult {
 }
 
 fn compute_line_ipa(name_katakana: &str, name_roman: Option<&str>) -> IpaResult {
-    let name_ipa = {
-        let (stem, suffix_ipa) = replace_line_name_suffix(name_katakana);
-        non_empty_ipa(katakana_name_to_ipa(stem).map(|ipa| format!("{ipa}{suffix_ipa}")))
-    };
+    // name_ipa は日本語読み。路線名の「線」も日本語 (セン→seɴ) として読ませ、
+    // 英語 (laɪn / meɪn laɪn など) を混入させない。英語読みは name_roman_ipa が担う。
+    let name_ipa = katakana_name_to_ipa(name_katakana);
     let tts_segments = station_name_to_tts_segments(name_katakana, name_roman);
     let name_roman_ipa = station_name_to_ipa("", name_roman);
     IpaResult {
@@ -73,37 +72,6 @@ pub fn compute_line_ipa_cached(name_katakana: &str, name_roman: Option<&str>) ->
     cached_lookup(&LINE_IPA_CACHE, &key, || {
         compute_line_ipa(name_katakana, name_roman)
     })
-}
-
-/// Katakana line-name suffixes paired with their English IPA replacements.
-/// Ordered longest-first for greedy matching.
-const LINE_NAME_SUFFIX_MAP: &[(&str, &str)] = &[
-    ("ホンセン", " meɪn laɪn"),
-    ("シセン", " laɪn"),
-    ("セン", " laɪn"),
-];
-/// Suffixes that should NOT be replaced even though they end with セン.
-const LINE_NAME_SUFFIX_EXCEPTIONS: &[&str] = &["シンカンセン"];
-
-/// Replace a common line-name suffix (線/本線/支線) in a katakana string
-/// with its English IPA equivalent (Line / Main Line).
-/// 新幹線 (Shinkansen) is preserved as it is used as-is in English.
-/// Returns the stem and the English IPA suffix to append.
-/// If no known suffix is found, returns the full input with an empty suffix.
-pub fn replace_line_name_suffix(input: &str) -> (&str, &str) {
-    for exception in LINE_NAME_SUFFIX_EXCEPTIONS {
-        if input.ends_with(exception) {
-            return (input, "");
-        }
-    }
-    for (suffix, replacement) in LINE_NAME_SUFFIX_MAP {
-        if let Some(stem) = input.strip_suffix(suffix) {
-            if !stem.is_empty() {
-                return (stem, replacement);
-            }
-        }
-    }
-    (input, "")
 }
 
 /// Convert a katakana string to its IPA transcription.
@@ -1003,7 +971,7 @@ fn lookup_single(c: char) -> Option<Phoneme> {
         'ゴ' => "go",
         // ザ行
         'ザ' => "za",
-        'ジ' => "ʤi",
+        'ジ' => "dʑi",
         'ズ' => "zɯ",
         'ゼ' => "ze",
         'ゾ' => "zo",
@@ -1086,7 +1054,6 @@ fn nasal_for_following(next_ipa: &str) -> &'static str {
         "m" // bilabial assimilation
     } else if next_ipa.starts_with('ɲ')
         || next_ipa.starts_with("dʑ")
-        || next_ipa.starts_with('ʤ')
         || next_ipa.starts_with('ɕ')
         || next_ipa.starts_with("gʲ")
         || next_ipa.starts_with("kʲ")
@@ -1137,7 +1104,7 @@ fn apply_phonological_rules(phonemes: &[Phoneme]) -> String {
                 if let Some(next_ipa) = find_next_regular(&phonemes[i + 1..]) {
                     if next_ipa.starts_with("t͡ɕ") || next_ipa.starts_with("t͡s") {
                         output.push('t');
-                    } else if next_ipa.starts_with("dʑ") || next_ipa.starts_with("ʤ") {
+                    } else if next_ipa.starts_with("dʑ") {
                         output.push('d');
                     } else {
                         let (onset, _) = split_onset(next_ipa);
@@ -1333,7 +1300,7 @@ mod tests {
 
     #[test]
     fn test_mejiro() {
-        assert_eq!(ipa("メジロ"), "meʤiɾo");
+        assert_eq!(ipa("メジロ"), "medʑiɾo");
     }
 
     #[test]
@@ -1533,57 +1500,5 @@ mod tests {
             ipa("ドッキョウダイガクマエ ソウカマツバラ"),
             "dokkʲo.ɯda.igakɯma.e so.ɯkamat͡sɯbaɾa"
         );
-    }
-
-    // ============================================
-    // replace_line_name_suffix tests
-    // ============================================
-
-    #[test]
-    fn test_replace_sen() {
-        assert_eq!(
-            replace_line_name_suffix("セイブイケブクロセン"),
-            ("セイブイケブクロ", " laɪn")
-        );
-    }
-
-    #[test]
-    fn test_replace_honsen() {
-        assert_eq!(
-            replace_line_name_suffix("トウカイドウホンセン"),
-            ("トウカイドウ", " meɪn laɪn")
-        );
-    }
-
-    #[test]
-    fn test_replace_shinkansen_preserved() {
-        // 新幹線(Shinkansen)は英語でもそのまま使われるので除去しない
-        assert_eq!(
-            replace_line_name_suffix("トウホクシンカンセン"),
-            ("トウホクシンカンセン", "")
-        );
-    }
-
-    #[test]
-    fn test_replace_shisen() {
-        assert_eq!(
-            replace_line_name_suffix("ナガノハラクサツグチシセン"),
-            ("ナガノハラクサツグチ", " laɪn")
-        );
-    }
-
-    #[test]
-    fn test_replace_no_suffix() {
-        // ライン等セン以外の末尾はそのまま返す
-        assert_eq!(
-            replace_line_name_suffix("ショウナンシンジュクライン"),
-            ("ショウナンシンジュクライン", "")
-        );
-    }
-
-    #[test]
-    fn test_replace_bare_sen_returns_unchanged() {
-        // "セン" だけの場合、stemが空になるので除去しない
-        assert_eq!(replace_line_name_suffix("セン"), ("セン", ""));
     }
 }

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -66,7 +66,7 @@ pub fn compute_ipa_cached(name_katakana: &str, name_roman: Option<&str>) -> IpaR
     })
 }
 
-/// Compute IPA for line names (with suffix replacement) with memoization.
+/// Compute IPA for line names with memoization.
 pub fn compute_line_ipa_cached(name_katakana: &str, name_roman: Option<&str>) -> IpaResult {
     let key = (name_katakana.to_string(), name_roman.map(str::to_string));
     cached_lookup(&LINE_IPA_CACHE, &key, || {

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -380,28 +380,23 @@ mod tests {
     // ============================================
 
     #[test]
-    fn test_name_ipa_sen_suffix_replaced_with_line() {
-        // name_ipa はカタカナ由来
+    fn test_name_ipa_sen_read_in_japanese() {
+        // name_ipa は日本語読み。「線」は seɴ として読み、英語 (laɪn) を混入させない。
         let mut line = create_test_line(TransportType::Rail, None);
         line.line_name_k = "セイブイケブクロセン".to_string();
         let grpc_line: GrpcLine = line.into();
 
-        assert_eq!(
-            grpc_line.name_ipa,
-            Some("se.ibɯ.ikebɯkɯɾo laɪn".to_string())
-        );
+        assert_eq!(grpc_line.name_ipa, Some("se.ibɯ.ikebɯkɯɾoseɴ".to_string()));
     }
 
     #[test]
-    fn test_name_ipa_honsen_suffix_replaced_with_main_line() {
+    fn test_name_ipa_honsen_read_in_japanese() {
+        // 「本線」も日本語読み (honseɴ)。英語 (meɪn laɪn) を混入させない。
         let mut line = create_test_line(TransportType::Rail, None);
         line.line_name_k = "トウカイドウホンセン".to_string();
         let grpc_line: GrpcLine = line.into();
 
-        assert_eq!(
-            grpc_line.name_ipa,
-            Some("to.ɯka.ido.ɯ meɪn laɪn".to_string())
-        );
+        assert_eq!(grpc_line.name_ipa, Some("to.ɯka.ido.ɯhonseɴ".to_string()));
     }
 
     #[test]
@@ -420,7 +415,8 @@ mod tests {
         line.line_name_r = Some("Keisei Main Line".to_string());
         let grpc_line: GrpcLine = line.into();
 
-        assert_eq!(grpc_line.name_ipa, Some("ke.ise.i meɪn laɪn".to_string()));
+        // name_ipa は日本語読み、name_roman_ipa はローマ字 (英語) 読み。
+        assert_eq!(grpc_line.name_ipa, Some("ke.ise.ihonseɴ".to_string()));
         assert_eq!(
             grpc_line.name_roman_ipa,
             Some("keːseː meɪn laɪn".to_string())


### PR DESCRIPTION
## 概要

Google TTS から Azure TTS への移行に向けて、SSML 向け IPA 生成の不具合を修正します。Azure では認識できない／非標準な記号があると発音が崩れるため、原因記号の是正と日本語フィールドへの英語混入の除去を行います。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- ジの IPA 表記を廃止済み合字 `ʤ`（U+02A4）から `dʑ` に統一。Azure が要求する分解（decomposed）Unicode に準拠させ、拗音（ジャ行 `dʑ`）との表記不整合も解消（`domain/ipa.rs`）。
  - これに伴い、ン同化・促音処理内の `ʤ` 分岐（`dʑ` 分岐で同等に処理されるデッドコード）を削除。
- 路線の `name_ipa`（日本語読み）に英語 `laɪn` / `meɪn laɪn` が混入していた問題を修正。「線」も日本語読み（セン→`seɴ`）で出力し、英語読みは従来どおり `name_roman_ipa` が担当するよう役割を明確化（`domain/ipa.rs`, `use_case/dto/line.rs`）。
  - 例: セイブイケブクロセン `…kɯɾo laɪn` → `…kɯɾoseɴ`、トウカイドウホンセン `…ɯ meɪn laɪn` → `…ɯhonseɴ`
  - 用途を失った `replace_line_name_suffix` 一式と専用テストを削除。
- 上記に合わせて `domain/ipa.rs` / `use_case/dto/line.rs` のテストを更新（期待値を日本語読みへ）。

## テスト

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 路線名のIPA（音声記号）生成ルールを見直し、末尾表記の扱いや「ジ」系の表記を含む発音表現をより自然に調整しました。

* **Tests**
  * IPA表記の変更に合わせて期待値を更新し、関連するテストケースを見直しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->