### PR TITLE
TTS用IPA生成の不具合修正（null/空）

### DIFF
--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -102,7 +102,9 @@ pub fn katakana_to_ipa(input: &str) -> Option<String> {
         i += 1;
     }
 
-    Some(apply_phonological_rules(&result))
+    // 区切り文字由来の先頭・末尾・連続した空白を 1 つに正規化する。
+    let ipa = apply_phonological_rules(&result);
+    Some(ipa.split_whitespace().collect::<Vec<_>>().join(" "))
 }
 
 /// Convert a station name to IPA.
@@ -997,8 +999,10 @@ fn lookup_single(c: char) -> Option<Phoneme> {
         'ン' => return Some(Phoneme::MoraicNasal),
         'ッ' => return Some(Phoneme::Geminate),
         'ー' => return Some(Phoneme::LongVowel),
-        // 空白（全角・半角）はそのまま透過
-        '　' | ' ' => return Some(Phoneme::Regular(" ")),
+        // 区切り文字（全角・半角空白、中黒、括弧）は語の区切りとして空白に変換。
+        // 「チュウオウ・ソウブセン」「トウキョウサクラトラム（トデンアラカワセン）」など、
+        // これらを含む路線名で name_ipa 全体が None にならないようにする。
+        '　' | ' ' | '・' | '（' | '）' | '(' | ')' => return Some(Phoneme::Regular(" ")),
         _ => return None,
     };
     Some(Phoneme::Regular(ipa))
@@ -1482,6 +1486,18 @@ mod tests {
                 "failed for {roman}"
             );
         }
+    }
+
+    #[test]
+    fn test_nakaguro_treated_as_word_separator() {
+        // 中黒「・」は語の区切りとして空白に変換し、全体が None にならないようにする
+        assert_eq!(ipa("チュウオウ・ソウブ"), "t͡ɕɯ.ɯ.o.ɯ so.ɯbɯ");
+    }
+
+    #[test]
+    fn test_fullwidth_parentheses_treated_as_word_separator() {
+        // 全角括弧「（）」も空白として扱い、先頭・末尾・連続の空白は正規化される
+        assert_eq!(ipa("トラム（トデン）"), "toɾamɯ todeɴ");
     }
 
     #[test]

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -424,6 +424,31 @@ mod tests {
     }
 
     #[test]
+    fn test_name_ipa_with_nakaguro_is_not_null() {
+        // 「・」を含む路線名でも name_ipa / name_tts_segments が null / 空にならない
+        let mut line = create_test_line(TransportType::Rail, None);
+        line.line_name_k = "チュウオウ・ソウブセン".to_string();
+        line.line_name_r = None;
+        let grpc_line: GrpcLine = line.into();
+
+        assert_eq!(grpc_line.name_ipa, Some("t͡ɕɯ.ɯ.o.ɯ so.ɯbɯseɴ".to_string()));
+        assert!(!grpc_line.name_tts_segments.is_empty());
+    }
+
+    #[test]
+    fn test_name_ipa_with_fullwidth_parentheses_is_not_null() {
+        // 全角括弧を含む路線名でも name_ipa / name_tts_segments が null / 空にならない
+        let mut line = create_test_line(TransportType::Rail, None);
+        line.line_name_k = "トウキョウサクラトラム（トデンアラカワセン）".to_string();
+        line.line_name_r = None;
+        let grpc_line: GrpcLine = line.into();
+
+        assert!(grpc_line.name_ipa.is_some());
+        assert!(!grpc_line.name_ipa.as_deref().unwrap().is_empty());
+        assert!(!grpc_line.name_tts_segments.is_empty());
+    }
+
+    #[test]
     fn test_name_ipa_empty_result_is_normalized_to_none() {
         let mut line = create_test_line(TransportType::Rail, None);
         line.line_name_k = "".to_string();


### PR DESCRIPTION
## 概要

路線 (`lines`) の `name_ipa` と `name_tts_segments` が null / 空になる場合がある不具合を修正します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

中黒「・」や全角括弧「（）」を含む路線名（例: `チュウオウ・ソウブセン`、`トウキョウサクラトラム（トデンアラカワセン）`）で、`katakana_to_ipa` がこれらの未対応文字に当たると文字列全体に対して `None` を返していました。その結果、`name_ipa` が null になり、カタカナフォールバック経由の `name_tts_segments` も空になっていました（`data/2!lines.csv` 調査で該当 7 路線を確認）。

- `lookup_single` で `・`・全角/半角括弧 `（）()` を、既存の全角・半角スペースと同様に**語の区切り（空白）**として変換するよう対応。
- `katakana_to_ipa` の末尾で、区切り文字由来の先頭・末尾・連続した空白を 1 つに正規化。
- `ipa.rs` / `line.rs` に回帰テストを追加（`チュウオウ・ソウブセン` → `t͡ɕɯ.ɯ.o.ɯ so.ɯbɯseɴ` など）。

ラテン文字など真に未対応の入力は引き続き `None` を返すため（`test_unknown_characters_returns_none` 維持）、ローマ字フォールバックの挙動には影響ありません。

## テスト

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->
