### PR TITLE
DockerビルドのOOM(exit 137)をrelease codegen-units=1で回避

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -5,6 +5,12 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY . .
+# jpreprocess の naist-jdic 辞書(約77MB)が include_bytes! でバイナリに埋め込まれるため、
+# 最終クレートのコンパイル/リンク時のピークメモリが大きい。release 既定の
+# codegen-units=16 だと 77MB の定数を含むモジュールと他ユニットが並列展開されメモリが
+# 跳ね上がり、メモリ制約のある self-hosted ランナーで OOM (exit 137) する。
+# codegen-units=1 で並列度を落としピークメモリを抑える (ビルドは遅くなるが安定する)。
+ENV CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
 RUN cargo build -p stationapi --release
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## 概要

ステージング/本番デプロイの Docker ビルドが `cargo build -p stationapi --release` の段階で OOM（exit 137）し失敗していたのを修正します。原因は #1534 で追加した jpreprocess の `naist-jdic` 辞書（約77MB）が `include_bytes!` でバイナリに埋め込まれ、release 既定の `codegen-units = 16` だと大容量定数を含むモジュールと他ユニットが並列展開されてピークメモリが急増し、メモリ制約のある self-hosted ランナーで OOM するためです。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `docker/api/Dockerfile` のビルダーステージに `ENV CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1` を追加。最終クレートのコード生成を直列化し、77MB 定数を含むモジュールが他ユニットと同時展開されないようにしてピークメモリを抑える（ビルドは遅くなるが安定する）。
- アプリのコード・依存・データは変更なし。生成されるバイナリの内容・挙動は同一（最適化単位の分割のみが変わる）。

## テスト

- [ ] `cargo fmt --all -- --check` が通ること
- [ ] `cargo clippy -- -D warnings` が通ること
- [ ] `cargo test`（`SQLX_OFFLINE=true`）が通ること

省略: Rust コード・データの変更なし（`docker/api/Dockerfile` のビルド設定のみ）。アプリ本体は #1534 / PR #1535 で検証済み。デプロイ Docker ビルドの成否はマージ後の staging デプロイで確認します。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->
