### PR TITLE
get_train_types で停車駅が同一の列車種別を重複排除

### DIFF
--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -878,16 +878,43 @@ where
             .filter_map(|tt| tt.type_cd.map(|cd| (cd, tt.clone())))
             .collect();
 
+        // Build the set of stops (excluding pass-through stations) for each line group
+        // within the requested from→to segment. This lets us drop train types that are
+        // locally redundant, i.e. that stop at exactly the same stations between the two
+        // endpoints even though they are distinct services across their full route.
+        let from_g_cd = from_station_id as i32;
+        let to_g_cd = to_station_id as i32;
+
+        let mut stops_by_line_group: std::collections::HashMap<i32, Vec<&Station>> =
+            std::collections::HashMap::new();
+        for stop in &stops {
+            if let Some(lgc) = stop.line_group_cd {
+                stops_by_line_group.entry(lgc).or_default().push(stop);
+            }
+        }
+
         // Track seen line_group_cds to avoid duplicates
         let mut seen_line_group_cds = HashSet::new();
+        // Track seen stop signatures to drop locally redundant train types
+        let mut seen_segment_signatures: HashSet<Vec<i32>> = HashSet::new();
 
         for mut train_type in train_types {
-            if let Some(lgc) = train_type.line_group_cd {
-                if !seen_line_group_cds.insert(lgc) {
-                    continue;
-                }
-            } else {
+            let Some(lgc) = train_type.line_group_cd else {
                 continue;
+            };
+            if !seen_line_group_cds.insert(lgc) {
+                continue;
+            }
+            // Skip train types whose stops within the requested segment are identical to
+            // a train type we've already emitted.
+            if let Some(group_stops) = stops_by_line_group.get(&lgc) {
+                if let Some(signature) =
+                    segment_stop_signature(group_stops, from_g_cd, to_g_cd)
+                {
+                    if !seen_segment_signatures.insert(signature) {
+                        continue;
+                    }
+                }
             }
 
             let mut seen_line_cds = HashSet::new();
@@ -1408,6 +1435,38 @@ where
     }
 }
 
+/// Build a signature describing the stations a train type actually stops at within the
+/// requested from→to segment.
+///
+/// `group_stops` are the route stops belonging to a single line group, in route order.
+/// The signature is the sorted set of `station_g_cd`s between the two endpoints
+/// (inclusive) that are not passed through (`pass != 1`). Two train types sharing the
+/// same signature stop at exactly the same stations across the segment and are therefore
+/// locally redundant. Returns `None` when either endpoint is not part of the line group.
+fn segment_stop_signature(
+    group_stops: &[&Station],
+    from_g_cd: i32,
+    to_g_cd: i32,
+) -> Option<Vec<i32>> {
+    let from_pos = group_stops
+        .iter()
+        .position(|s| s.station_g_cd == from_g_cd)?;
+    let to_pos = group_stops.iter().position(|s| s.station_g_cd == to_g_cd)?;
+    let (start, end) = if from_pos <= to_pos {
+        (from_pos, to_pos)
+    } else {
+        (to_pos, from_pos)
+    };
+    let mut signature: Vec<i32> = group_stops[start..=end]
+        .iter()
+        .filter(|s| s.pass != Some(1))
+        .map(|s| s.station_g_cd)
+        .collect();
+    signature.sort_unstable();
+    signature.dedup();
+    Some(signature)
+}
+
 /// Calculate the distance between two points on Earth using the Haversine formula.
 /// Returns the distance in meters.
 fn haversine_distance(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
@@ -1585,6 +1644,130 @@ mod tests {
         // Points outside 300m radius
         let distance = haversine_distance(35.6812, 139.7671, 35.6900, 139.7671);
         assert!(distance > NEARBY_BUS_STOP_RADIUS_METERS);
+    }
+
+    // ========================================
+    // segment_stop_signature tests
+    // ========================================
+
+    /// Helper to build a route stop with a stop condition (`pass`) for a line group.
+    fn create_stop(station_g_cd: i32, line_group_cd: i32, pass: Option<i32>) -> Station {
+        let mut station = create_test_station(station_g_cd, station_g_cd, 1, Some(line_group_cd));
+        station.pass = pass;
+        station
+    }
+
+    #[test]
+    fn test_segment_stop_signature_identical_stops_match() {
+        // Two line groups that stop at exactly the same stations between 1 and 4.
+        let local_stops = vec![
+            create_stop(1, 100, Some(0)),
+            create_stop(2, 100, Some(0)),
+            create_stop(3, 100, Some(0)),
+            create_stop(4, 100, Some(0)),
+        ];
+        let express_stops = vec![
+            create_stop(1, 200, Some(0)),
+            create_stop(2, 200, Some(0)),
+            create_stop(3, 200, Some(0)),
+            create_stop(4, 200, Some(0)),
+        ];
+
+        let local_refs: Vec<&Station> = local_stops.iter().collect();
+        let express_refs: Vec<&Station> = express_stops.iter().collect();
+
+        let local_sig = segment_stop_signature(&local_refs, 1, 4).unwrap();
+        let express_sig = segment_stop_signature(&express_refs, 1, 4).unwrap();
+
+        assert_eq!(local_sig, express_sig);
+    }
+
+    #[test]
+    fn test_segment_stop_signature_excludes_pass_through() {
+        // Station 3 is passed through (pass == 1) and must not be part of the signature.
+        let stops = vec![
+            create_stop(1, 100, Some(0)),
+            create_stop(2, 100, Some(0)),
+            create_stop(3, 100, Some(1)),
+            create_stop(4, 100, Some(0)),
+        ];
+        let refs: Vec<&Station> = stops.iter().collect();
+
+        let sig = segment_stop_signature(&refs, 1, 4).unwrap();
+        assert_eq!(sig, vec![1, 2, 4]);
+    }
+
+    #[test]
+    fn test_segment_stop_signature_differs_when_stops_differ() {
+        // Skips station 2.
+        let express_stops = vec![
+            create_stop(1, 100, Some(0)),
+            create_stop(2, 100, Some(1)),
+            create_stop(3, 100, Some(0)),
+            create_stop(4, 100, Some(0)),
+        ];
+        // Stops everywhere.
+        let local_stops = vec![
+            create_stop(1, 200, Some(0)),
+            create_stop(2, 200, Some(0)),
+            create_stop(3, 200, Some(0)),
+            create_stop(4, 200, Some(0)),
+        ];
+        let express_refs: Vec<&Station> = express_stops.iter().collect();
+        let local_refs: Vec<&Station> = local_stops.iter().collect();
+
+        assert_ne!(
+            segment_stop_signature(&express_refs, 1, 4).unwrap(),
+            segment_stop_signature(&local_refs, 1, 4).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_segment_stop_signature_restricted_to_segment() {
+        // Differences outside the 2→3 segment must be ignored.
+        let stops_a = vec![
+            create_stop(1, 100, Some(0)),
+            create_stop(2, 100, Some(0)),
+            create_stop(3, 100, Some(0)),
+            create_stop(4, 100, Some(0)),
+        ];
+        let stops_b = vec![
+            create_stop(1, 200, Some(1)),
+            create_stop(2, 200, Some(0)),
+            create_stop(3, 200, Some(0)),
+            create_stop(5, 200, Some(0)),
+        ];
+        let refs_a: Vec<&Station> = stops_a.iter().collect();
+        let refs_b: Vec<&Station> = stops_b.iter().collect();
+
+        assert_eq!(
+            segment_stop_signature(&refs_a, 2, 3).unwrap(),
+            segment_stop_signature(&refs_b, 2, 3).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_segment_stop_signature_direction_independent() {
+        let stops = vec![
+            create_stop(1, 100, Some(0)),
+            create_stop(2, 100, Some(0)),
+            create_stop(3, 100, Some(0)),
+        ];
+        let refs: Vec<&Station> = stops.iter().collect();
+
+        // Querying from 3→1 yields the same signature as 1→3.
+        assert_eq!(
+            segment_stop_signature(&refs, 1, 3).unwrap(),
+            segment_stop_signature(&refs, 3, 1).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_segment_stop_signature_missing_endpoint_returns_none() {
+        let stops = vec![create_stop(1, 100, Some(0)), create_stop(2, 100, Some(0))];
+        let refs: Vec<&Station> = stops.iter().collect();
+
+        assert!(segment_stop_signature(&refs, 1, 99).is_none());
     }
 
     // ========================================

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -885,9 +885,25 @@ where
         let from_g_cd = from_station_id as i32;
         let to_g_cd = to_station_id as i32;
 
+        // `via_line_id` is only a route filter: when set, `stops` is restricted to the
+        // stations on that line, so each line group's stops would be incomplete and the
+        // dedup comparison (which needs the full from→to stopping pattern) would fall
+        // back to the per-line_group filter. Re-fetch the unrestricted route stops for
+        // the dedup signature so the behavior is identical with or without `via_line_id`.
+        let dedup_stops_storage;
+        let dedup_stops: &[Station] = if via_line_id.is_some() {
+            dedup_stops_storage = self
+                .station_repository
+                .get_route_stops(from_station_id, to_station_id, None)
+                .await?;
+            &dedup_stops_storage
+        } else {
+            &stops
+        };
+
         let mut stops_by_line_group: std::collections::HashMap<i32, Vec<&Station>> =
             std::collections::HashMap::new();
-        for stop in &stops {
+        for stop in dedup_stops {
             if let Some(lgc) = stop.line_group_cd {
                 stops_by_line_group.entry(lgc).or_default().push(stop);
             }

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -1785,6 +1785,366 @@ mod tests {
     }
 
     // ========================================
+    // get_train_types dedup integration tests
+    // ========================================
+
+    mod get_train_types_tests {
+        use super::*;
+        use crate::domain::{
+            entity::company::Company,
+            error::DomainError,
+            repository::{
+                company_repository::CompanyRepository, line_repository::LineRepository,
+                station_repository::StationRepository, train_type_repository::TrainTypeRepository,
+            },
+        };
+        use crate::use_case::traits::query::QueryUseCase;
+
+        /// Station repository whose `get_route_stops` returns different stops depending
+        /// on whether `via_line_id` is set, mirroring the real query that restricts the
+        /// result to the requested line.
+        struct DedupMockStationRepository {
+            stops_unrestricted: Vec<Station>,
+            stops_via: Vec<Station>,
+        }
+
+        #[async_trait::async_trait]
+        impl StationRepository for DedupMockStationRepository {
+            async fn get_route_stops(
+                &self,
+                _: u32,
+                _: u32,
+                via_line_id: Option<u32>,
+            ) -> Result<Vec<Station>, DomainError> {
+                if via_line_id.is_some() {
+                    Ok(self.stops_via.clone())
+                } else {
+                    Ok(self.stops_unrestricted.clone())
+                }
+            }
+            async fn find_by_id(&self, _: u32) -> Result<Option<Station>, DomainError> {
+                Ok(None)
+            }
+            async fn get_by_id_vec(&self, _: &[u32]) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_id(
+                &self,
+                _: u32,
+                _: Option<u32>,
+                _: Option<u32>,
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_id_vec(&self, _: &[u32]) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_id_vec_with_group_stations(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id(&self, _: u32) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id_vec_no_types(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_coordinates(
+                &self,
+                _: f64,
+                _: f64,
+                _: Option<u32>,
+                _: Option<TransportType>,
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_bus_stops_near_stations(
+                &self,
+                _: &[(u32, f64, f64)],
+                _: u32,
+            ) -> Result<Vec<(u32, Station)>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_name(
+                &self,
+                _: String,
+                _: Option<u32>,
+                _: Option<u32>,
+                _: Option<TransportType>,
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_group_id(&self, _: u32) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+        }
+
+        struct DedupMockLineRepository {
+            lines: Vec<Line>,
+        }
+
+        #[async_trait::async_trait]
+        impl LineRepository for DedupMockLineRepository {
+            async fn get_by_line_group_id_vec(&self, _: &[u32]) -> Result<Vec<Line>, DomainError> {
+                Ok(self.lines.clone())
+            }
+            async fn find_by_id(&self, _: u32) -> Result<Option<Line>, DomainError> {
+                Ok(None)
+            }
+            async fn find_by_station_id(&self, _: u32) -> Result<Option<Line>, DomainError> {
+                Ok(None)
+            }
+            async fn get_by_ids(&self, _: &[u32]) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_name(
+                &self,
+                _: String,
+                _: Option<u32>,
+            ) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_group_id(&self, _: u32) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_group_id_vec_for_routes(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id(&self, _: u32) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id_vec_no_types(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+        }
+
+        struct DedupMockTrainTypeRepository {
+            train_types: Vec<TrainType>,
+        }
+
+        #[async_trait::async_trait]
+        impl TrainTypeRepository for DedupMockTrainTypeRepository {
+            async fn get_by_line_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<TrainType>, DomainError> {
+                Ok(self.train_types.clone())
+            }
+            async fn find_by_line_group_id_and_line_id(
+                &self,
+                _: u32,
+                _: u32,
+            ) -> Result<Option<TrainType>, DomainError> {
+                Ok(None)
+            }
+            async fn find_by_line_group_id_and_line_id_vec(
+                &self,
+                _: &[(u32, u32)],
+            ) -> Result<std::collections::HashMap<(u32, u32), TrainType>, DomainError> {
+                Ok(std::collections::HashMap::new())
+            }
+            async fn get_by_line_group_id(&self, _: u32) -> Result<Vec<TrainType>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_id(&self, _: u32) -> Result<Vec<TrainType>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_id_vec(
+                &self,
+                _: &[u32],
+                _: Option<u32>,
+            ) -> Result<Vec<TrainType>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_types_by_station_id_vec(
+                &self,
+                _: &[u32],
+                _: Option<u32>,
+            ) -> Result<Vec<TrainType>, DomainError> {
+                Ok(vec![])
+            }
+        }
+
+        struct DedupMockCompanyRepository;
+
+        #[async_trait::async_trait]
+        impl CompanyRepository for DedupMockCompanyRepository {
+            async fn find_by_id_vec(&self, _: &[u32]) -> Result<Vec<Company>, DomainError> {
+                Ok(vec![])
+            }
+        }
+
+        /// Build a train type bound to a line group (type_cd unique per group).
+        fn create_train_type(line_group_cd: i32) -> TrainType {
+            TrainType::new(
+                Some(line_group_cd),
+                None,
+                Some(line_group_cd),
+                Some(line_group_cd),
+                Some(0),
+                format!("種別{line_group_cd}"),
+                format!("シュベツ{line_group_cd}"),
+                None,
+                None,
+                None,
+                "#000000".to_string(),
+                Some(0),
+                Some(0),
+            )
+        }
+
+        /// Build a line bound to a line group.
+        fn create_line_for_group(line_group_cd: i32) -> Line {
+            let mut line = create_test_line(line_group_cd);
+            line.line_group_cd = Some(line_group_cd);
+            line.type_cd = Some(line_group_cd);
+            line
+        }
+
+        fn build_interactor(
+            stops_unrestricted: Vec<Station>,
+            stops_via: Vec<Station>,
+            train_types: Vec<TrainType>,
+            lines: Vec<Line>,
+        ) -> QueryInteractor<
+            DedupMockStationRepository,
+            DedupMockLineRepository,
+            DedupMockTrainTypeRepository,
+            DedupMockCompanyRepository,
+        > {
+            QueryInteractor {
+                station_repository: DedupMockStationRepository {
+                    stops_unrestricted,
+                    stops_via,
+                },
+                line_repository: DedupMockLineRepository { lines },
+                train_type_repository: DedupMockTrainTypeRepository { train_types },
+                company_repository: DedupMockCompanyRepository,
+            }
+        }
+
+        /// Full route stops (stations 1..=4) for the three line groups used in the tests.
+        /// Line groups 100 and 200 stop at every station (identical pattern); 300 passes
+        /// through station 2, giving it a distinct stopping pattern.
+        fn full_route_stops() -> Vec<Station> {
+            vec![
+                create_stop(1, 100, Some(0)),
+                create_stop(2, 100, Some(0)),
+                create_stop(3, 100, Some(0)),
+                create_stop(4, 100, Some(0)),
+                create_stop(1, 200, Some(0)),
+                create_stop(2, 200, Some(0)),
+                create_stop(3, 200, Some(0)),
+                create_stop(4, 200, Some(0)),
+                create_stop(1, 300, Some(0)),
+                create_stop(2, 300, Some(1)),
+                create_stop(3, 300, Some(0)),
+                create_stop(4, 300, Some(0)),
+            ]
+        }
+
+        fn line_group_cds(train_types: &[TrainType]) -> Vec<i32> {
+            let mut cds: Vec<i32> = train_types
+                .iter()
+                .filter_map(|tt| tt.line_group_cd)
+                .collect();
+            cds.sort_unstable();
+            cds
+        }
+
+        #[tokio::test]
+        async fn test_get_train_types_dedupes_identical_segment_stops() {
+            // 100 and 200 share the same stops over the segment → collapse to one (100,
+            // the first encountered). 300 has a different stopping pattern → kept.
+            let interactor = build_interactor(
+                full_route_stops(),
+                vec![],
+                vec![
+                    create_train_type(100),
+                    create_train_type(200),
+                    create_train_type(300),
+                ],
+                vec![
+                    create_line_for_group(100),
+                    create_line_for_group(200),
+                    create_line_for_group(300),
+                ],
+            );
+
+            let result = interactor.get_train_types(1, 4, None).await.unwrap();
+
+            assert_eq!(result.len(), 2);
+            assert_eq!(line_group_cds(&result), vec![100, 300]);
+        }
+
+        #[tokio::test]
+        async fn test_get_train_types_dedupes_with_via_line_id() {
+            // With via_line_id set, the primary stops are restricted to stations 1 and 2
+            // (station 4, the `to` endpoint, is missing). If dedup used these restricted
+            // stops the signature could not be computed and both 100 and 200 would be
+            // kept. The unrestricted re-fetch must keep dedup working → 100 and 200
+            // collapse, leaving 100 and 300.
+            let restricted_stops = vec![
+                create_stop(1, 100, Some(0)),
+                create_stop(2, 100, Some(0)),
+                create_stop(1, 200, Some(0)),
+                create_stop(2, 200, Some(0)),
+                create_stop(1, 300, Some(0)),
+                create_stop(2, 300, Some(1)),
+            ];
+
+            let interactor = build_interactor(
+                full_route_stops(),
+                restricted_stops,
+                vec![
+                    create_train_type(100),
+                    create_train_type(200),
+                    create_train_type(300),
+                ],
+                vec![
+                    create_line_for_group(100),
+                    create_line_for_group(200),
+                    create_line_for_group(300),
+                ],
+            );
+
+            let result = interactor.get_train_types(1, 4, Some(99)).await.unwrap();
+
+            assert_eq!(result.len(), 2);
+            assert_eq!(line_group_cds(&result), vec![100, 300]);
+        }
+    }
+
+    // ========================================
     // build_route_tree_map tests
     // ========================================
 

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -908,9 +908,7 @@ where
             // Skip train types whose stops within the requested segment are identical to
             // a train type we've already emitted.
             if let Some(group_stops) = stops_by_line_group.get(&lgc) {
-                if let Some(signature) =
-                    segment_stop_signature(group_stops, from_g_cd, to_g_cd)
-                {
+                if let Some(signature) = segment_stop_signature(group_stops, from_g_cd, to_g_cd) {
                     if !seen_segment_signatures.insert(signature) {
                         continue;
                     }


### PR DESCRIPTION
## 概要

`get_train_types` のレスポンスから、要求区間（from→to）内で停車駅が完全に同一の列車種別を重複排除し、冗長なレスポンスを解消する。

例: 渋谷駅→元町・中華街駅の種別を取得する際、区間内の停車駅が全く同じ複数の列車種別が含まれて冗長になっていた。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `get_train_types` で、区間（from→to、両端含む）内で実際に停車する駅（`pass != 1`）の集合が完全に一致する列車種別を、最初の1件に重複排除するように変更。
- 停車駅シグネチャ（区間内の停車駅 `station_g_cd` をソートした集合）を算出する純粋関数 `segment_stop_signature` を追加。方向に依存せず、通過駅は除外する。
- `via_line_id` 指定時は `get_route_stops` の結果が当該路線上の駅だけに絞られ、各 line group の停車駅が不完全になって重複判定が効かなくなる（元の `line_group_cd` ベースのフィルタに戻る）ため、重複判定用には `via_line_id` 制約なしの停車駅を別途取得し、`via_line_id` の有無で挙動が変わらないようにした。
- `segment_stop_signature` のユニットテストを追加（同一停車駅の一致／通過駅の除外／停車駅相違時の不一致／区間外の無視／方向非依存／端点欠落時 `None`）。

## テスト

ローカルで以下を実行し、いずれも通過することを確認。

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01AGZLtVXs6SA5fjTvJJgEB4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 区間内の停車パターンが同一な列車種別の重複を、停車情報に基づいて自動で整理することで、列車情報の表示を最適化
  * 経由指定がある場合も、比較対象が変わらないように調整し、同様の重複整理が有効になるよう改善
* **Tests**
  * 停車パターン署名の生成・一致/不一致、乗車除外、区間差分非依存、方向非依存、端点欠落時の挙動を確認するユニットテストを追加
  * 重複が正しく畳み込まれることの統合テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->