### PR TITLE
get_train_types の重複排除で kind が異なる列車種別を排除しないよう修正

### DIFF
--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -911,8 +911,12 @@ where
 
         // Track seen line_group_cds to avoid duplicates
         let mut seen_line_group_cds = HashSet::new();
-        // Track seen stop signatures to drop locally redundant train types
-        let mut seen_segment_signatures: HashSet<Vec<i32>> = HashSet::new();
+        // Track seen (kind, stop signature) pairs to drop locally redundant train types.
+        // Two train types are redundant only when they share both the same `kind` and the
+        // same stops across the segment. A local and a limited express that happen to stop
+        // at the same stations have different kinds and are still distinct services, so
+        // both are kept.
+        let mut seen_segment_signatures: HashSet<(Option<i32>, Vec<i32>)> = HashSet::new();
 
         for mut train_type in train_types {
             let Some(lgc) = train_type.line_group_cd else {
@@ -921,11 +925,11 @@ where
             if !seen_line_group_cds.insert(lgc) {
                 continue;
             }
-            // Skip train types whose stops within the requested segment are identical to
-            // a train type we've already emitted.
+            // Skip train types whose stops within the requested segment are identical to a
+            // train type of the same kind we've already emitted.
             if let Some(group_stops) = stops_by_line_group.get(&lgc) {
                 if let Some(signature) = segment_stop_signature(group_stops, from_g_cd, to_g_cd) {
-                    if !seen_segment_signatures.insert(signature) {
+                    if !seen_segment_signatures.insert((train_type.kind, signature)) {
                         continue;
                     }
                 }
@@ -2005,6 +2009,11 @@ mod tests {
 
         /// Build a train type bound to a line group (type_cd unique per group).
         fn create_train_type(line_group_cd: i32) -> TrainType {
+            create_train_type_with_kind(line_group_cd, 0)
+        }
+
+        /// Build a train type bound to a line group with an explicit `kind`.
+        fn create_train_type_with_kind(line_group_cd: i32, kind: i32) -> TrainType {
             TrainType::new(
                 Some(line_group_cd),
                 None,
@@ -2018,7 +2027,7 @@ mod tests {
                 None,
                 "#000000".to_string(),
                 Some(0),
-                Some(0),
+                Some(kind),
             )
         }
 
@@ -2138,6 +2147,57 @@ mod tests {
             );
 
             let result = interactor.get_train_types(1, 4, Some(99)).await.unwrap();
+
+            assert_eq!(result.len(), 2);
+            assert_eq!(line_group_cds(&result), vec![100, 300]);
+        }
+
+        #[tokio::test]
+        async fn test_get_train_types_keeps_both_when_kind_differs() {
+            // 100 (limited express, kind=4) and 200 (local, kind=0) stop at exactly the
+            // same stations over the segment but have different kinds, so they are distinct
+            // services and both must be kept. 300 has a distinct stopping pattern → kept.
+            let interactor = build_interactor(
+                full_route_stops(),
+                vec![],
+                vec![
+                    create_train_type_with_kind(100, 4),
+                    create_train_type_with_kind(200, 0),
+                    create_train_type_with_kind(300, 0),
+                ],
+                vec![
+                    create_line_for_group(100),
+                    create_line_for_group(200),
+                    create_line_for_group(300),
+                ],
+            );
+
+            let result = interactor.get_train_types(1, 4, None).await.unwrap();
+
+            assert_eq!(result.len(), 3);
+            assert_eq!(line_group_cds(&result), vec![100, 200, 300]);
+        }
+
+        #[tokio::test]
+        async fn test_get_train_types_dedupes_identical_stops_and_kind() {
+            // When the stops AND the kind are identical, the first encountered survives
+            // (here 100), matching the pre-existing "keep first" behavior.
+            let interactor = build_interactor(
+                full_route_stops(),
+                vec![],
+                vec![
+                    create_train_type_with_kind(100, 2),
+                    create_train_type_with_kind(200, 2),
+                    create_train_type_with_kind(300, 0),
+                ],
+                vec![
+                    create_line_for_group(100),
+                    create_line_for_group(200),
+                    create_line_for_group(300),
+                ],
+            );
+
+            let result = interactor.get_train_types(1, 4, None).await.unwrap();
 
             assert_eq!(result.len(), 2);
             assert_eq!(line_group_cds(&result), vec![100, 300]);


### PR DESCRIPTION
## 概要

#1540 で実装した `get_train_types` の重複排除を調整し、停車駅が同一でも `kind`（列車種別カテゴリ）が異なる列車種別は別物として残すようにしました。

特急と普通など停車駅が同じでも種別が異なる列車を一方に統合すると、本来別サービスである列車が表示されなくなり混乱が生じるため、これを防ぎます。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 重複判定キーを停車駅シグネチャのみから `(kind, 停車駅シグネチャ)` に変更
- `(kind, 停車駅シグネチャ)` が両方一致する場合のみ排除し、`kind` が異なれば停車駅が同一でも両方出力するよう修正
- `kind` の判定は一致・不一致のみ（大小比較は行わない）
- テストを追加
  - `test_get_train_types_keeps_both_when_kind_differs`: 停車駅同一・`kind` 異なる → 両方残る
  - `test_get_train_types_dedupes_identical_stops_and_kind`: 停車駅・`kind` ともに同一 → 1件に排除

## テスト

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 列車種別の重複排除ロジックを改善。同じ停車駅パターンでも異なる種別の列車は別として表示されるようになりました。

* **テスト**
  * 列車種別の違いに対応したテストケースを追加。種別と停車駅パターンの組み合わせを正確に検証するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->