### PR TITLE
英語音声でら行が t 化するため英語読みIPAのら行を l に置換

### DIFF
--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -158,13 +158,32 @@ pub fn station_name_to_tts_segments(
     name_katakana: &str,
     name_roman: Option<&str>,
 ) -> Vec<TtsNameSegment> {
-    name_roman
+    let mut segments = name_roman
         .map(str::trim)
         .filter(|name| !name.is_empty())
         .and_then(romanized_name_to_tts_segments)
         .filter(|segments| !segments.is_empty())
         .or_else(|| katakana_name_to_tts_segments(name_katakana))
-        .unwrap_or_default()
+        .unwrap_or_default();
+
+    // tts_segments と、これらを連結した name_roman_ipa は英語音声 (Azure Dragon HD 等)
+    // で読み上げる「英語読み」トラック。ら行の弾き音 ɾ は英語ではフラップ /t/・/d/
+    // (water /ˈwɔːɾɚ/ の t) として実現され、「ら行」ではなく「た/だ/ち」に化ける
+    // (にほんおおどおり → にほんおおどおち)。そのためこのトラックに限り ら行を
+    // 側面接近音 l に置換する (例: トリデ toɾide→tolide)。英単語の R は別記号 ɹ を
+    // 使うので影響しない。日本語音声で読む name_ipa (katakana_to_ipa) は honest な ɾ の
+    // まま残し、将来 ja-JP 音声で読む場合に備える。
+    for segment in &mut segments {
+        segment.pronunciation = lateralize_ra_row(&segment.pronunciation);
+    }
+
+    segments
+}
+
+/// 英語読みトラックのら行 ɾ を側面接近音 l に置換する。英単語の R (ɹ) は対象外。
+/// 英語音声では ɾ が英語のフラップ /t/ として鳴り「ら行」に聞こえないため。
+fn lateralize_ra_row(pronunciation: &str) -> String {
+    pronunciation.replace('ɾ', "l")
 }
 
 fn join_tts_segment_pronunciations(segments: &[TtsNameSegment]) -> Option<String> {
@@ -1095,10 +1114,11 @@ fn phonemes_to_raw_ipa(phonemes: &[Phoneme]) -> String {
     while i < len {
         match &phonemes[i] {
             Phoneme::Regular(ipa) => {
-                // ら行は弾き音 ɾ をそのまま使う (語頭も語中も同じ)。ɾ は Azure ja-JP の
-                // `<phoneme alphabet="ipa">` でも発音できるため、聞こえ方の都合で l に
-                // 置換する加工は行わず素直な IPA を出力する。区切り文字 (空白) も
-                // そのまま出力する。
+                // この層は honest な IPA をそのまま出力する (ら行は弾き音 ɾ のまま)。
+                // 出力は日本語音声で読む name_ipa にそのまま使う。英語音声で読む
+                // name_roman_ipa / tts_segments では ɾ が英語のフラップ /t/ に化ける
+                // ため、station_name_to_tts_segments の lateralize_ra_row でら行を l に
+                // 置換する。区切り文字 (空白) もそのまま出力する。
                 output.push_str(ipa);
             }
             Phoneme::MoraicNasal => {
@@ -1428,20 +1448,33 @@ mod tests {
 
     #[test]
     fn test_roppongi_word_initial_r_stays_flap() {
-        // 語頭のら行も弾き音 ɾ のまま。l への置換は行わない。
+        // name_ipa 用の katakana_to_ipa は honest な ɾ を維持する (語頭も同じ)。
+        // 英語読みトラックの l 置換は station_name_to_ipa 側で行う。
         assert_eq!(ipa("ロッポンギ"), "ɾoppongi");
     }
 
     #[test]
     fn test_word_initial_r_after_separator_stays_flap() {
-        // 区切り直後 (= 後続語の語頭) のら行も ɾ のまま。
+        // 区切り直後 (= 後続語の語頭) のら行も katakana_to_ipa では ɾ のまま。
         assert_eq!(ipa("シン・リンカイ"), "ɕin ɾinka.i");
     }
 
     #[test]
     fn test_medial_r_stays_flap() {
-        // 語中のら行も弾き音 ɾ のまま (toɾide / t͡sɯɾɯmi)。
+        // 語中のら行も katakana_to_ipa では弾き音 ɾ のまま (toɾide / t͡sɯɾɯmi)。
         assert_eq!(ipa("トリデ"), "toɾide");
+    }
+
+    #[test]
+    fn test_romanized_track_lateralizes_ra_row() {
+        // 英語読みトラック (station_name_to_ipa = name_roman_ipa / tts_segments) は
+        // 英語音声で読むため、ら行を l に置換する。語頭・語中・語末いずれも対象。
+        assert_eq!(
+            station_name_to_ipa("トリデ", Some("Toride")),
+            Some("tolide".to_string())
+        );
+        // 一方 name_ipa 用の katakana_to_ipa は同じ語でも honest な ɾ を維持する。
+        assert_eq!(katakana_to_ipa("トリデ"), Some("toɾide".to_string()));
     }
 
     #[test]
@@ -1494,8 +1527,8 @@ mod tests {
     fn test_station_name_ipa_uses_official_english_wording() {
         assert_eq!(
             station_name_to_ipa("カサイリンカイコウエン", Some("Kasai-Rinkai Park")),
-            // ら行はそのまま ɾ (Rinkai → ɾinka.i)
-            Some("kasa.i ɾinka.i pɑɹk".to_string())
+            // 英語読みトラックなのでら行は l (Rinkai → linka.i)
+            Some("kasa.i linka.i pɑɹk".to_string())
         );
     }
 
@@ -1503,7 +1536,7 @@ mod tests {
     fn test_station_name_ipa_supports_english_and_digits() {
         assert_eq!(
             station_name_to_ipa("ナリタクウコウ", Some("Narita Airport Terminal 1")),
-            Some("naɾita ɛɚpɔɹt tɚmɪnəl wʌn".to_string())
+            Some("nalita ɛɚpɔɹt tɚmɪnəl wʌn".to_string())
         );
     }
 
@@ -1559,7 +1592,7 @@ mod tests {
     fn test_station_name_ipa_splits_other_compound_kaigan_suffix() {
         assert_eq!(
             station_name_to_ipa("オオモリカイガン", Some("Omorikaigan")),
-            Some("omoɾi ka.igan".to_string())
+            Some("omoli ka.igan".to_string())
         );
     }
 

--- a/stationapi/src/use_case/dto/station.rs
+++ b/stationapi/src/use_case/dto/station.rs
@@ -161,13 +161,15 @@ mod tests {
         let grpc_station: GrpcStation =
             create_test_station("練馬春日町", "ネリマカスガチョウ", None).into();
 
+        // name_ipa は日本語音声用なので honest な ɾ を維持する。
         assert_eq!(grpc_station.name_ipa, Some("neɾimakasɯgat͡ɕoː".to_string()));
-        // カタカナ由来 (ローマ字なし) の ja-JP セグメントも同じ発音になる。
+        // tts_segments は英語音声で読む英語読みトラックなので、同じカタカナ由来でも
+        // ら行は l に置換される (ɾ→l)。
         assert_eq!(grpc_station.name_tts_segments.len(), 1);
         assert_eq!(grpc_station.name_tts_segments[0].lang, "ja-JP");
         assert_eq!(
             grpc_station.name_tts_segments[0].pronunciation,
-            "neɾimakasɯgat͡ɕoː"
+            "nelimakasɯgat͡ɕoː"
         );
     }
 
@@ -209,8 +211,8 @@ mod tests {
         assert_eq!(grpc_station.name_tts_segments[0].separator, " ");
         assert_eq!(grpc_station.name_tts_segments[1].surface, "Rinkai");
         assert_eq!(grpc_station.name_tts_segments[1].fallback_text, "りんかい");
-        // ら行はそのまま ɾ (Rinkai → ɾinka.i)
-        assert_eq!(grpc_station.name_tts_segments[1].pronunciation, "ɾinka.i");
+        // 英語読みトラックなのでら行は l (Rinkai → linka.i)
+        assert_eq!(grpc_station.name_tts_segments[1].pronunciation, "linka.i");
         assert_eq!(grpc_station.name_tts_segments[1].separator, " ");
         assert_eq!(grpc_station.name_tts_segments[2].surface, "Park");
         assert_eq!(grpc_station.name_tts_segments[2].fallback_text, "Park");


### PR DESCRIPTION
## 概要

Azure Dragon HD の英語音声で駅名・路線名を読み上げる際、IPA のら行 `ɾ`（歯茎はじき音）が英語のフラップ /t/・/d/（`water /ˈwɔːɾɚ/` の t）として発音され、「ら行」が「た/だ/ち」に化けていた（例: にほんおおどおり → にほんおおどおち）。英語音声に渡る「英語読みトラック」のら行のみ側面接近音 `l` に置換して修正する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `station_name_to_tts_segments` に `lateralize_ra_row` を追加し、英語音声で読む `name_roman_ipa` と `tts_segments` のら行 `ɾ` を `l` に置換（語頭・語中・語末すべて対象。行 dict 由来の `ɾ` も含む）。
- 日本語音声用の `name_ipa`（`katakana_to_ipa` 直接生成）は honest な `ɾ` のまま維持し、将来 ja-JP 音声で読む場合に備える。
- 英単語の R は別記号 `ɹ` を使うため影響なし（`park` / `zero` 等は変化しない）。
- 英語読みトラックの `l` 置換と `name_ipa` の `ɾ` 維持を検証するテストを追加し、既存テストの期待値を英語読みトラックのみ `l` に更新。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 駅名の英語音声合成における発音精度を向上させました。特にら行音について、より自然な英語対応を実施しています。

* **テスト**
  * 新しい発音仕様に対応するため、関連するテストケースを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->