### PR TITLE
EstimateArrivalTimesに進行方向の指定を追加しデフォルトでfrom→to方向に整列

### DIFF
--- a/stationapi/src/domain/repository/station_repository.rs
+++ b/stationapi/src/domain/repository/station_repository.rs
@@ -67,6 +67,7 @@ pub trait StationRepository: Send + Sync + 'static {
         from_station_cd: u32,
         to_station_cd: u32,
         via_line_ids: &[u32],
+        direction_id: Option<u32>,
     ) -> Result<Vec<Station>, DomainError>;
 }
 
@@ -340,6 +341,7 @@ mod tests {
             from_station_cd: u32,
             to_station_cd: u32,
             via_line_ids: &[u32],
+            _direction_id: Option<u32>,
         ) -> Result<Vec<Station>, DomainError> {
             self.get_route_stops(from_station_cd, to_station_cd, via_line_ids)
                 .await

--- a/stationapi/src/infrastructure/station_repository.rs
+++ b/stationapi/src/infrastructure/station_repository.rs
@@ -2868,4 +2868,16 @@ mod tests {
     async fn test_get_by_line_group_id_station_order() {
         // 返される駅がsst.idの順序でソートされていることを確認
     }
+
+    #[tokio::test]
+    #[ignore] // Requires actual database setup
+    async fn test_get_route_stops_by_station_cd_default_order() {
+        // direction_id未指定時にデフォルト(ASC)順で駅が返されることを確認
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires actual database setup
+    async fn test_get_route_stops_by_station_cd_reverse_order() {
+        // direction_id=1または2で駅の並び順がDESCに反転されることを確認
+    }
 }

--- a/stationapi/src/infrastructure/station_repository.rs
+++ b/stationapi/src/infrastructure/station_repository.rs
@@ -2241,6 +2241,7 @@ impl InternalStationRepository {
         direction_id: Option<u32>,
         conn: &mut PgConnection,
     ) -> Result<Vec<Station>, DomainError> {
+        // direction_id = 1 (上り) または 2 (下り) の場合、並び順を反転する
         let reverse = matches!(direction_id, Some(1) | Some(2));
         let via_line_ids_i32: Vec<i32> = via_line_ids.iter().map(|&id| id as i32).collect();
         let untyped_order = if reverse {

--- a/stationapi/src/infrastructure/station_repository.rs
+++ b/stationapi/src/infrastructure/station_repository.rs
@@ -464,12 +464,14 @@ impl StationRepository for MyStationRepository {
         from_station_cd: u32,
         to_station_cd: u32,
         via_line_ids: &[u32],
+        direction_id: Option<u32>,
     ) -> Result<Vec<Station>, DomainError> {
         let mut conn = self.pool.acquire().await?;
         InternalStationRepository::get_route_stops_by_station_cd(
             from_station_cd,
             to_station_cd,
             via_line_ids,
+            direction_id,
             &mut conn,
         )
         .await
@@ -2236,11 +2238,18 @@ impl InternalStationRepository {
         from_station_cd: u32,
         to_station_cd: u32,
         via_line_ids: &[u32],
+        direction_id: Option<u32>,
         conn: &mut PgConnection,
     ) -> Result<Vec<Station>, DomainError> {
+        let reverse = matches!(direction_id, Some(1) | Some(2));
         let via_line_ids_i32: Vec<i32> = via_line_ids.iter().map(|&id| id as i32).collect();
-        let mut rows = sqlx::query_as!(
-            StationRow,
+        let untyped_order = if reverse {
+            "ORDER BY sta.e_sort DESC, sta.station_cd DESC"
+        } else {
+            "ORDER BY sta.e_sort ASC, sta.station_cd ASC"
+        };
+
+        let untyped_query = format!(
             r#"WITH
                 from_cte AS (
                     SELECT
@@ -2366,8 +2375,8 @@ impl InternalStationRepository {
             sta.transport_type
             FROM
                 stations AS sta
-				JOIN common_lines AS cl ON sta.line_cd = cl.line_cd
-				JOIN lines AS lin ON lin.line_cd = cl.line_cd
+                JOIN common_lines AS cl ON sta.line_cd = cl.line_cd
+                JOIN lines AS lin ON lin.line_cd = cl.line_cd
                 LEFT JOIN sst_cte AS sst ON sst.station_cd = sta.station_cd
                 LEFT JOIN types AS tt ON tt.type_cd = sst.type_cd
                 LEFT JOIN line_aliases AS la ON la.station_cd = sta.station_cd
@@ -2376,18 +2385,25 @@ impl InternalStationRepository {
                 sst.line_group_cd IS NULL
                 AND lin.e_status = 0
                 AND sta.e_status = 0
-                ORDER BY sta.e_sort, sta.station_cd"#,
-            from_station_cd as i32,
-            to_station_cd as i32,
-            from_station_cd as i32,
-            to_station_cd as i32,
-            &via_line_ids_i32,
-        )
-        .fetch_all(&mut *conn)
-        .await?;
+                {untyped_order}"#
+        );
 
-        let mut typed_rows = sqlx::query_as!(
-            StationRow,
+        let mut rows = sqlx::query_as::<_, StationRow>(&untyped_query)
+            .bind(from_station_cd as i32)
+            .bind(to_station_cd as i32)
+            .bind(from_station_cd as i32)
+            .bind(to_station_cd as i32)
+            .bind(&via_line_ids_i32)
+            .fetch_all(&mut *conn)
+            .await?;
+
+        let typed_order = if reverse {
+            "ORDER BY sst.id DESC"
+        } else {
+            "ORDER BY sst.id ASC"
+        };
+
+        let typed_query = format!(
             r#"WITH
                 from_cte AS (
                     SELECT
@@ -2509,13 +2525,15 @@ impl InternalStationRepository {
             WHERE
                 sta.e_status = 0
                 AND (array_length($3::int[], 1) IS NULL OR sta.line_cd = ANY($3))
-            ORDER BY sst.id"#,
-            from_station_cd as i32,
-            to_station_cd as i32,
-            &via_line_ids_i32,
-        )
-        .fetch_all(conn)
-        .await?;
+            {typed_order}"#
+        );
+
+        let mut typed_rows = sqlx::query_as::<_, StationRow>(&typed_query)
+            .bind(from_station_cd as i32)
+            .bind(to_station_cd as i32)
+            .bind(&via_line_ids_i32)
+            .fetch_all(conn)
+            .await?;
 
         rows.append(&mut typed_rows);
         let stations: Vec<Station> = rows.into_iter().map(|row| row.into()).collect();

--- a/stationapi/src/infrastructure/station_repository.rs
+++ b/stationapi/src/infrastructure/station_repository.rs
@@ -2241,8 +2241,8 @@ impl InternalStationRepository {
         direction_id: Option<u32>,
         conn: &mut PgConnection,
     ) -> Result<Vec<Station>, DomainError> {
-        // direction_id = 1 (上り) または 2 (下り) の場合、並び順を反転する
-        let reverse = matches!(direction_id, Some(1) | Some(2));
+        // direction_id = 1 (上り) の場合、並び順を反転する
+        let reverse = matches!(direction_id, Some(1));
         let via_line_ids_i32: Vec<i32> = via_line_ids.iter().map(|&id| id as i32).collect();
         let untyped_order = if reverse {
             "ORDER BY sta.e_sort DESC, sta.station_cd DESC"

--- a/stationapi/src/presentation/controller/grpc.rs
+++ b/stationapi/src/presentation/controller/grpc.rs
@@ -455,10 +455,11 @@ impl StationApi for MyApi {
         let from_id = request.get_ref().from_station_id;
         let to_id = request.get_ref().to_station_id;
         let via_line_ids = &request.get_ref().via_line_ids;
+        let direction_id = request.get_ref().direction_id;
 
         match self
             .query_use_case
-            .estimate_route_arrival_times(from_id, to_id, via_line_ids)
+            .estimate_route_arrival_times(from_id, to_id, via_line_ids, direction_id)
             .await
         {
             Ok(estimated_stops) => {
@@ -941,6 +942,7 @@ mod tests {
             _from_station_id: u32,
             _to_station_id: u32,
             _via_line_ids: &[u32],
+            _direction_id: Option<u32>,
         ) -> Result<Vec<EstimatedStop>, UseCaseError> {
             Ok(vec![])
         }

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -1126,7 +1126,7 @@ where
                     .position(|s| s.station_cd as u32 == to_station_id);
                 if let (Some(fi), Some(ti)) = (from_pos, to_pos) {
                     if fi > ti {
-                        let mut reversed: Vec<&Station> = group_stops.iter().copied().collect();
+                        let mut reversed: Vec<&Station> = group_stops.to_vec();
                         reversed.reverse();
                         result.extend(estimate_arrival_minutes(&reversed, &params));
                         continue;

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -1117,6 +1117,23 @@ where
                 continue;
             }
 
+            if direction_id.is_none() {
+                let from_pos = group_stops
+                    .iter()
+                    .position(|s| s.station_cd as u32 == from_station_id);
+                let to_pos = group_stops
+                    .iter()
+                    .position(|s| s.station_cd as u32 == to_station_id);
+                if let (Some(fi), Some(ti)) = (from_pos, to_pos) {
+                    if fi > ti {
+                        let mut reversed: Vec<&Station> = group_stops.iter().copied().collect();
+                        reversed.reverse();
+                        result.extend(estimate_arrival_minutes(&reversed, &params));
+                        continue;
+                    }
+                }
+            }
+
             result.extend(estimate_arrival_minutes(group_stops, &params));
         }
 

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -1093,10 +1093,16 @@ where
         from_station_id: u32,
         to_station_id: u32,
         via_line_ids: &[u32],
+        direction_id: Option<u32>,
     ) -> Result<Vec<EstimatedStop>, UseCaseError> {
         let stops = self
             .station_repository
-            .get_route_stops_by_station_cd(from_station_id, to_station_id, via_line_ids)
+            .get_route_stops_by_station_cd(
+                from_station_id,
+                to_station_id,
+                via_line_ids,
+                direction_id,
+            )
             .await?;
 
         let route_row_tree_map = self.build_route_tree_map(&stops);
@@ -1989,6 +1995,7 @@ mod tests {
                 from: u32,
                 to: u32,
                 via: &[u32],
+                _direction_id: Option<u32>,
             ) -> Result<Vec<Station>, DomainError> {
                 self.get_route_stops(from, to, via).await
             }
@@ -2327,7 +2334,7 @@ mod tests {
 
             let interactor = build_interactor(stops, vec![], vec![], vec![]);
             let est = interactor
-                .estimate_route_arrival_times(1, 4, &[])
+                .estimate_route_arrival_times(1, 4, &[], None)
                 .await
                 .unwrap();
 
@@ -2365,7 +2372,7 @@ mod tests {
 
             let interactor = build_interactor(stops, vec![], vec![], vec![]);
             let est = interactor
-                .estimate_route_arrival_times(1, 4, &[])
+                .estimate_route_arrival_times(1, 4, &[], None)
                 .await
                 .unwrap();
 
@@ -2491,6 +2498,7 @@ mod tests {
                 _: u32,
                 _: u32,
                 _: &[u32],
+                _: Option<u32>,
             ) -> Result<Vec<Station>, DomainError> {
                 Ok(vec![])
             }
@@ -2972,6 +2980,7 @@ mod tests {
                 _: u32,
                 _: u32,
                 _: &[u32],
+                _: Option<u32>,
             ) -> Result<Vec<Station>, DomainError> {
                 Ok(vec![])
             }

--- a/stationapi/src/use_case/traits/query.rs
+++ b/stationapi/src/use_case/traits/query.rs
@@ -134,5 +134,6 @@ pub trait QueryUseCase: Send + Sync + 'static {
         from_station_id: u32,
         to_station_id: u32,
         via_line_ids: &[u32],
+        direction_id: Option<u32>,
     ) -> Result<Vec<EstimatedStop>, UseCaseError>;
 }


### PR DESCRIPTION
## 概要

`EstimateArrivalTimes` RPCに進行方向(`direction_id`)の指定を追加し、駅の並び順を制御可能にする。未指定時は`from_station_id`から`to_station_id`に向かう方向で自動整列する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `EstimateArrivalTimesRequest`に`optional uint32 direction_id = 4`フィールドを追加（proto: TrainLCD/gRPCProto#27）
- `StationRepository::get_route_stops_by_station_cd`に`direction_id`パラメータを追加
- `direction_id`が1(上り)の場合、SQLの`ORDER BY`を`DESC`に切り替えて駅の並び順を反転
- `direction_id`未指定時、各経路グループ内で`from_station_id`が`to_station_id`より後方にある場合は駅リストを反転し、from→to方向の到着時間を計算
- `QueryUseCase::estimate_route_arrival_times`に`direction_id`を追加し、gRPCハンドラからリポジトリまで一貫してパラメータを伝搬

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->
