### PR TITLE
到着時間推定に運転余裕率を導入し実ダイヤとの系統誤差を補正する

### DIFF
--- a/stationapi/src/domain/arrival_estimation.rs
+++ b/stationapi/src/domain/arrival_estimation.rs
@@ -12,7 +12,10 @@
 //!    路線種別ベースの固定値にフォールバックする。
 //! 3. 停車駅間ごとに「加速→巡航→減速」の運動学モデルで走行時間を算出する。
 //!    停車が多いほど巡航しきれず平均速度が落ちる(各停が速達より遅い)現象が
-//!    加減速ペナルティとして自然に表現される。
+//!    加減速ペナルティとして自然に表現される。運動学モデルは理想走行
+//!    (最大加速→最高速度で巡航→最大減速)を仮定するため、実ダイヤに含まれる
+//!    途中の速度制限・惰行・回復余裕のぶん系統的に速すぎる。これを走行時間への
+//!    運転余裕率 `run_margin` として補正する(実路線の時刻表との較正で約 1.15)。
 //! 4. 中間停車駅に停車時間 `dwell` を加算して累積する。
 //!
 //! 入力経路は運用上 `line_group_cd` を跨がない(=単一の列車・直通サービス)ため
@@ -49,8 +52,12 @@ pub struct EstimationParams {
     pub accel: f64,
     /// 減速度 (m/s^2)。
     pub decel: f64,
-    /// 中間停車駅 1 駅あたりの停車時間(分)。
+    /// 中間停車駅 1 駅あたりの停車時間(分)。ドア開閉・乗降に加え、
+    /// 出発までの余裕時分も含む実効値。
     pub dwell_minutes: f64,
+    /// 走行時間に掛ける運転余裕率。運動学モデルの理想走行と実ダイヤの差
+    /// (途中の速度制限・惰行・回復余裕)を包括する補正係数。
+    pub run_margin: f64,
     /// 迂回係数 `α` のクランプ下限。
     pub detour_min: f64,
     /// 迂回係数 `α` のクランプ上限。
@@ -62,7 +69,8 @@ impl Default for EstimationParams {
         Self {
             accel: 0.7,
             decel: 0.9,
-            dwell_minutes: 0.4,
+            dwell_minutes: 0.6,
+            run_margin: 1.15,
             detour_min: 1.0,
             detour_max: 1.6,
         }
@@ -135,7 +143,7 @@ fn base_speed_kmh(line_type: Option<i32>) -> f64 {
         Some(LINE_TYPE_TRAM) => 40.0,
         Some(LINE_TYPE_AGT) => 60.0,
         Some(LINE_TYPE_CABLE) => 12.0,
-        _ => 85.0,
+        _ => 80.0,
     }
 }
 
@@ -155,6 +163,7 @@ fn max_speed_kmh(line_type: Option<i32>, kind: Option<i32>) -> f64 {
 ///
 /// 列車は 0→v_max 加速 → 巡航 → v_max→0 減速すると仮定する。
 /// 区間距離が短く v_max に到達できない場合は三角形プロファイルで頂点速度を解く。
+/// 理想走行と実ダイヤの差を埋めるため、結果に運転余裕率 `run_margin` を掛ける。
 pub fn segment_run_minutes(distance_m: f64, v_max_kmh: f64, params: &EstimationParams) -> f64 {
     if distance_m <= 0.0 || v_max_kmh <= 0.0 {
         return 0.0;
@@ -173,7 +182,7 @@ pub fn segment_run_minutes(distance_m: f64, v_max_kmh: f64, params: &EstimationP
         let v_peak = (2.0 * distance_m * a * b / (a + b)).sqrt();
         v_peak / a + v_peak / b
     };
-    seconds / 60.0
+    seconds * params.run_margin / 60.0
 }
 
 /// その駅に列車が停車するか判定する。端点(始点・終点)は常に停車扱い。
@@ -269,7 +278,7 @@ fn assign_segment_times(
             // 通過駅: 加速 + ここまでの巡航(減速はまだ)。
             accel_penalty_sec + cruise_sec
         };
-        result[idx].cumulative_minutes = departure_minutes + seconds / 60.0;
+        result[idx].cumulative_minutes = departure_minutes + seconds * params.run_margin / 60.0;
     }
 }
 
@@ -462,8 +471,18 @@ mod tests {
         let p = EstimationParams::default();
         // 10km を 80km/h で。巡航支配。
         let t = segment_run_minutes(10_000.0, 80.0, &p);
-        // 巡航のみなら 10km / 80km/h = 7.5 分。加減速分だけ少し増える。
-        assert!(t > 7.5 && t < 9.0, "got {t}");
+        // 巡航のみなら 10km / 80km/h × 余裕率 1.15 = 8.625 分。加減速分だけ少し増える。
+        assert!(t > 8.6 && t < 10.0, "got {t}");
+    }
+
+    #[test]
+    fn run_margin_scales_run_time_but_not_dwell() {
+        let mut p = EstimationParams::default();
+        p.run_margin = 1.0;
+        let base = segment_run_minutes(5_000.0, 80.0, &p);
+        p.run_margin = 1.15;
+        let with_margin = segment_run_minutes(5_000.0, 80.0, &p);
+        approx(with_margin, base * 1.15);
     }
 
     #[test]
@@ -616,14 +635,53 @@ mod tests {
         // km 換算後は α = 4.8668 / 5.65 < 1 → detour_min の 1.0 でクランプされ、
         // みなし走行距離は直線距離そのものになる。
         let straight_m = haversine_distance(36.326849, 139.193704, 36.359018, 139.242463);
-        let v_kmh = 85.0; // 在来線・普通(kind=None)
+        let v_kmh = 80.0; // 在来線・普通(kind=None)
         let expected = segment_run_minutes(straight_m, v_kmh, &p);
         approx(est[1].cumulative_minutes, expected);
+        // 実乗車時間は 5〜6 分。
         assert!(
-            est[1].cumulative_minutes < 6.0,
+            est[1].cumulative_minutes > 4.5 && est[1].cumulative_minutes < 6.5,
             "got {}",
             est[1].cumulative_minutes
         );
+    }
+
+    #[test]
+    fn oedo_line_segment_matches_real_travel_time() {
+        let p = EstimationParams::default();
+        // 都営大江戸線 落合南長崎→光が丘(各駅停車のみの区間)。
+        // 実座標・実データ値(average_distance = 1066.84m、地下鉄 line_type=3)。
+        // 実乗車時間: 新江古田 2分 / 練馬 5分 / 豊島園 7分 / 練馬春日町 9分 / 光が丘 11分。
+        let coords = [
+            (35.723608, 139.683303),            // 落合南長崎
+            (35.732538, 139.670653),            // 新江古田
+            (35.737404, 139.65477),             // 練馬
+            (35.742567043044, 139.64894845621), // 豊島園
+            (35.751452, 139.640236),            // 練馬春日町
+            (35.758526, 139.628603),            // 光が丘
+        ];
+        let stations: Vec<Station> = coords
+            .iter()
+            .enumerate()
+            .map(|(i, &(lat, lon))| {
+                let mut s = station(i as i32 + 1, 99301, lat, lon, Some(1066.84));
+                s.line_type = Some(LINE_TYPE_SUBWAY);
+                s
+            })
+            .collect();
+        let refs: Vec<&Station> = stations.iter().collect();
+        let est = estimate_arrival_minutes(&refs, &p);
+
+        let real = [2.0, 5.0, 7.0, 9.0, 11.0];
+        for (e, r) in est[1..].iter().zip(real.iter()) {
+            assert!(
+                (e.cumulative_minutes - r).abs() < 1.0,
+                "station_cd {}: est {} vs real {}",
+                e.station_cd,
+                e.cumulative_minutes,
+                r
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 概要

EstimateArrivalTimes の運動学モデルが理想走行（最大加速→最高速度で巡航→最大減速）を仮定しているため、実ダイヤに含まれる途中の速度制限・惰行・回復余裕のぶん全路線で所要時間を13〜25%過小に見積もっていた問題を、実時刻表との較正で補正する。

#1576 以前は迂回係数が上限1.6に張り付くバグによる距離水増しが偶然この過小評価を相殺していたため、バグ修正後に過小評価が顕在化していた（例: 都営大江戸線 落合南長崎→光が丘 実車11分に対し8.9分）。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 走行時間に運転余裕率 `run_margin`（既定 1.15）を導入。`segment_run_minutes` と `assign_segment_times` の両経路で走行時間のみに乗算し、停車時間には掛けない
- 中間停車駅の停車時間 `dwell_minutes` を 0.4分 → 0.6分（出発余裕込みの実効値）に変更
- 在来線の基本最高速度を 85km/h → 80km/h に変更（地下鉄75・新幹線250などは据え置き）
- パラメータは実時刻表が既知の6区間（都営大江戸線 落合南長崎→光が丘、銀座線 浅草→渋谷、丸ノ内線 池袋→荻窪、山手線 池袋→東京、中央・総武線各停 三鷹→新宿、両毛線 伊勢崎→国定）とのグリッドサーチで較正。検証セットの平均絶対誤差は 16.7% → 約3%
- 大江戸線 落合南長崎→光が丘 の実座標・実測時刻（2/5/7/9/11分）を使い、各駅の推定が±1分以内に収まることを検証する回帰テストを追加
- 代表値: 大江戸線 落合南長崎→光が丘 8.9分 → 10.8分（実車11分）、両毛線 伊勢崎→国定 4.5分 → 5.4分（実車5〜6分）

## テスト

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvuzKrssremkx9vuHTu7BZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvuzKrssremkx9vuHTu7BZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 列車の到着予測で、走行時間に補正係数を適用できるようになりました。
  * 予測の既定値が見直され、より実運行に近い見積もりになりました。

* **バグ修正**
  * 区間ごとの時刻割り当てで、走行時間の算出がより一貫するよう改善しました。
  * 一部路線の予測精度を調整し、回帰の起きやすい区間の挙動を安定化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->