### PR TITLE
EstimatedArrivalStopに累積出発時刻を追加しクライアントが発車基準ETAを計算できるようにする

### DIFF
--- a/stationapi/src/domain/arrival_estimation.rs
+++ b/stationapi/src/domain/arrival_estimation.rs
@@ -40,6 +40,11 @@ pub struct EstimatedStop {
     /// 始点からの累積到着時間(分)。通過駅は停車駅間を速度プロファイル別に分割した
     /// 走行時間の積み上げで求めた通過時刻。
     pub cumulative_minutes: f64,
+    /// 始点からの累積出発時刻(分)。中間停車駅では「到着 + 停車時間(dwell)」、
+    /// 通過駅では通過時刻(= `cumulative_minutes`)、終点では到着時刻と同じ
+    /// (以降の出発が無いため)。クライアントは基準駅 k0 と任意の駅 k について
+    /// 「到着(k) − 出発(k0)」で基準駅発の正確な残り時間(発車基準 ETA)を計算できる。
+    pub departure_cumulative_minutes: f64,
     /// その駅に停車するか(false = 通過)。
     pub stops_here: bool,
 }
@@ -254,8 +259,10 @@ fn assign_segment_times(
     }
     if seg.len() == 1 {
         let (track_m, v_kmh, idx, _) = seg[0];
-        result[idx].cumulative_minutes =
-            departure_minutes + segment_run_minutes(track_m, v_kmh, params);
+        let arrival = departure_minutes + segment_run_minutes(track_m, v_kmh, params);
+        result[idx].cumulative_minutes = arrival;
+        // 停車駅の出発時刻(dwell 加算)は呼び出し側が上書きする。
+        result[idx].departure_cumulative_minutes = arrival;
         return;
     }
 
@@ -278,7 +285,11 @@ fn assign_segment_times(
             // 通過駅: 加速 + ここまでの巡航(減速はまだ)。
             accel_penalty_sec + cruise_sec
         };
-        result[idx].cumulative_minutes = departure_minutes + seconds * params.run_margin / 60.0;
+        let arrival = departure_minutes + seconds * params.run_margin / 60.0;
+        result[idx].cumulative_minutes = arrival;
+        // 通過駅は停車しないので出発 = 通過時刻。末尾の停車駅は呼び出し側が
+        // dwell を加味した出発時刻で上書きする。
+        result[idx].departure_cumulative_minutes = arrival;
     }
 }
 
@@ -326,12 +337,13 @@ pub fn estimate_arrival_minutes(
 
     let mut result: Vec<EstimatedStop> = Vec::with_capacity(n);
 
-    // 始点。
+    // 始点。即時出発とみなすので到着・出発とも 0 分。
     result.push(EstimatedStop {
         station_cd: stops[0].station_cd,
         station_g_cd: stops[0].station_g_cd,
         line_group_cd: line_group_of(stops[0]),
         cumulative_minutes: 0.0,
+        departure_cumulative_minutes: 0.0,
         stops_here: stops_here[0],
     });
 
@@ -351,6 +363,7 @@ pub fn estimate_arrival_minutes(
             station_g_cd: stops[i].station_g_cd,
             line_group_cd: line_group_of(stops[i]),
             cumulative_minutes: 0.0,
+            departure_cumulative_minutes: 0.0,
             stops_here: stops_here[i],
         });
         seg.push((track_m, v_kmh, idx, stops_here[i]));
@@ -367,6 +380,7 @@ pub fn estimate_arrival_minutes(
             } else {
                 arrival + params.dwell_minutes
             };
+            result[idx].departure_cumulative_minutes = last_departure;
 
             seg.clear();
         }
@@ -538,6 +552,50 @@ mod tests {
         // 「1区間の所要 × 2 + dwell」付近になる。
         let leg = est[1].cumulative_minutes;
         approx(est[2].cumulative_minutes, leg * 2.0 + p.dwell_minutes);
+    }
+
+    #[test]
+    fn departure_minutes_add_dwell_at_intermediate_stops_only() {
+        let p = EstimationParams::default();
+        let stations = three_collinear_stations();
+        let refs: Vec<&Station> = stations.iter().collect();
+        let est = estimate_arrival_minutes(&refs, &p);
+
+        // 始点: 即時出発なので到着・出発とも 0 分。
+        approx(est[0].cumulative_minutes, 0.0);
+        approx(est[0].departure_cumulative_minutes, 0.0);
+        // 中間停車駅: 出発 = 到着 + dwell。
+        approx(
+            est[1].departure_cumulative_minutes,
+            est[1].cumulative_minutes + p.dwell_minutes,
+        );
+        // 終点: 以降の出発が無いので出発 = 到着。
+        approx(
+            est[2].departure_cumulative_minutes,
+            est[2].cumulative_minutes,
+        );
+        // クライアント側の発車基準 ETA: 到着(終点) − 出発(中間駅) = 1 区間の走行時間。
+        let leg = est[1].cumulative_minutes;
+        approx(
+            est[2].cumulative_minutes - est[1].departure_cumulative_minutes,
+            leg,
+        );
+    }
+
+    #[test]
+    fn departure_minutes_equal_pass_time_at_passed_stations() {
+        let p = EstimationParams::default();
+        let mut stations = three_collinear_stations();
+        stations[1].pass = Some(1);
+        let refs: Vec<&Station> = stations.iter().collect();
+        let est = estimate_arrival_minutes(&refs, &p);
+
+        // 通過駅は停車しないので出発 = 通過時刻(dwell 加算なし)。
+        assert!(!est[1].stops_here);
+        approx(
+            est[1].departure_cumulative_minutes,
+            est[1].cumulative_minutes,
+        );
     }
 
     #[test]

--- a/stationapi/src/presentation/controller/grpc.rs
+++ b/stationapi/src/presentation/controller/grpc.rs
@@ -470,6 +470,7 @@ impl StationApi for MyApi {
                         station_id: stop.station_cd as u32,
                         station_group_id: stop.station_g_cd as u32,
                         cumulative_minutes: stop.cumulative_minutes,
+                        departure_cumulative_minutes: stop.departure_cumulative_minutes,
                         stops_here: stop.stops_here,
                     };
 


### PR DESCRIPTION
## 概要

ETA計算処理のドメインモデル `EstimatedStop` と gRPC の `EstimatedArrivalStop` に、始点からの累積出発時刻 `departure_cumulative_minutes` を追加します。これによりクライアントは「到着(k) − 出発(基準駅)」で、基準駅の発車を基準とした正確な残り時間(発車基準ETA)を計算できるようになります。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [x] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `domain/arrival_estimation.rs`: `EstimatedStop` に `departure_cumulative_minutes: f64` を追加
  - 始点: 即時出発とみなすため到着・出発とも 0 分
  - 中間停車駅: 出発 = 到着 + 停車時間(`dwell_minutes`)
  - 通過駅: 出発 = 通過時刻(= `cumulative_minutes`、dwell 加算なし)
  - 終点: 以降の出発が無いため出発 = 到着
- `presentation/controller/grpc.rs`: `EstimatedArrivalStop` への詰め替えで新フィールドをマッピング
- 単体テスト2件を追加(中間停車駅の dwell 加算・始点/終点の扱い、通過駅の非加算)

### ⚠️ gRPCProto 側の修正案(要・別リポジトリでの対応)

proto はサブモジュール([TrainLCD/gRPCProto](https://github.com/TrainLCD/gRPCProto))のためこの PR には含められません。以下の修正を gRPCProto 側でマージし、本リポジトリのサブモジュール参照を更新するまで本 PR の CI はビルドできません(マージ順: gRPCProto → サブモジュール更新 → 本PR)。

```proto
message EstimatedArrivalStop {
  uint32 station_id = 1;
  uint32 station_group_id = 2;
  double cumulative_minutes = 3;
  bool stops_here = 4;
  // 始点からの累積出発時刻(分)。中間停車駅では「到着 + 停車時間」、通過駅では
  // 通過時刻(= cumulative_minutes)、終点では到着時刻と同じ。クライアントは
  // 「到着(k) − 出発(基準駅)」で基準駅発の残り時間(発車基準 ETA)を計算できる。
  double departure_cumulative_minutes = 5;
}
```

既存フィールドの番号・型は変更せず、`double departure_cumulative_minutes = 5;` を追加するのみの後方互換な変更です。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`(`SQLX_OFFLINE=true`)が通ること

※ サブモジュール未取得のため、上記 proto 修正案をローカルに適用した状態で全チェックを実行(`cargo test` は 368 passed / 0 failed)。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5CBXke7dskNEHsP8BN8HM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 到着時刻（累積分）に加えて、各停車駅の出発時刻（累積分）も取得できるようになりました（gRPCレスポンスに反映）。
  * 停車駅・通過駅・終点で、到着／出発時刻の整合性が改善されました。
* **テスト**
  * 停車駅では `departure_cumulative_minutes = cumulative_minutes + dwell_minutes`、通過駅では `departure_cumulative_minutes = cumulative_minutes` となることを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->