### PR TITLE
GetTrainRouteRequestの駅指定をグループIDから単一IDに変更

### DIFF
--- a/stationapi/src/presentation/controller/grpc.rs
+++ b/stationapi/src/presentation/controller/grpc.rs
@@ -432,8 +432,8 @@ impl StationApi for MyApi {
         request: tonic::Request<GetTrainRouteRequest>,
     ) -> Result<tonic::Response<TrainRouteResponse>, tonic::Status> {
         let req = request.get_ref();
-        let from_id = req.from_station_group_id;
-        let to_id = req.to_station_group_id;
+        let from_id = req.from_station_id;
+        let to_id = req.to_station_id;
         let line_group_id = req
             .line_group_id
             .ok_or_else(|| tonic::Status::invalid_argument("line_group_id is required"))?;
@@ -907,8 +907,8 @@ mod tests {
 
         async fn get_train_route(
             &self,
-            _from_station_group_id: u32,
-            _to_station_group_id: u32,
+            _from_station_id: u32,
+            _to_station_id: u32,
             _line_group_id: u32,
         ) -> Result<Vec<crate::proto::TrainRouteSegment>, UseCaseError> {
             Ok(vec![])

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -1000,8 +1000,8 @@ where
 
     async fn get_train_route(
         &self,
-        from_station_group_id: u32,
-        to_station_group_id: u32,
+        from_station_id: u32,
+        to_station_id: u32,
         line_group_id: u32,
     ) -> Result<Vec<proto::TrainRouteSegment>, UseCaseError> {
         let stations = self
@@ -1010,17 +1010,17 @@ where
 
         let from_idx = stations
             .iter()
-            .position(|s| s.station_g_cd as u32 == from_station_group_id)
+            .position(|s| s.station_cd as u32 == from_station_id)
             .ok_or_else(|| UseCaseError::NotFound {
                 entity_type: "station in line group",
-                entity_id: from_station_group_id.to_string(),
+                entity_id: from_station_id.to_string(),
             })?;
         let to_idx = stations
             .iter()
-            .position(|s| s.station_g_cd as u32 == to_station_group_id)
+            .position(|s| s.station_cd as u32 == to_station_id)
             .ok_or_else(|| UseCaseError::NotFound {
                 entity_type: "station in line group",
-                entity_id: to_station_group_id.to_string(),
+                entity_id: to_station_id.to_string(),
             })?;
 
         let sliced: Vec<Station> = if from_idx <= to_idx {

--- a/stationapi/src/use_case/traits/query.rs
+++ b/stationapi/src/use_case/traits/query.rs
@@ -113,8 +113,8 @@ pub trait QueryUseCase: Send + Sync + 'static {
     ) -> Result<Vec<TrainType>, UseCaseError>;
     async fn get_train_route(
         &self,
-        from_station_group_id: u32,
-        to_station_group_id: u32,
+        from_station_id: u32,
+        to_station_id: u32,
         line_group_id: u32,
     ) -> Result<Vec<TrainRouteSegment>, UseCaseError>;
     async fn find_line_by_id(&self, line_id: u32) -> Result<Option<Line>, UseCaseError>;


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- proto側で `GetTrainRouteRequest` の `from_station_group_id` / `to_station_group_id` が `from_station_id` / `to_station_id` に変更されたことに合わせ、実装を単一駅ID基準に修正
- `grpc.rs` の `get_train_route` ハンドラで新フィールド名を参照するよう変更
- `QueryUseCase::get_train_route` / `QueryInteractor::get_train_route` の引数名を `from_station_id` / `to_station_id` にリネームし、駅の絞り込みを `station_g_cd`（グループID）ではなく `station_cd`（単一駅ID）でマッチするよう修正（`estimate_route_arrival_times` と同じ方式）
- 対応するテスト用モック実装の引数名も追随

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `cargo fmt --all -- --check` が通ること
- [ ] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

注: `cargo clippy -- -D warnings` は `query.rs` のテストコードに既存の `useless_vec` 警告があり失敗しますが、`dev` 最新コミット時点でも再現する本PRとは無関係の既存issueです。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 駅間ルート取得で、出発駅・到着駅の判定基準が駅グループIDから駅IDに統一されました。
  * ルート検索時に、指定した駅IDに基づいて正しく区間が切り出されるようになりました。
  * 見つからない駅がある場合のエラー表示も、指定した駅IDに対応する内容へ更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->