### PR TITLE
clippyの警告(useless_vec/unnecessary_map_or/clone_on_copy等)を解消

### DIFF
--- a/stationapi/src/domain/arrival_estimation.rs
+++ b/stationapi/src/domain/arrival_estimation.rs
@@ -626,8 +626,10 @@ mod tests {
 
     #[test]
     fn run_margin_scales_run_time_but_not_dwell() {
-        let mut p = EstimationParams::default();
-        p.run_margin = 1.0;
+        let mut p = EstimationParams {
+            run_margin: 1.0,
+            ..Default::default()
+        };
         let base = segment_run_minutes(5_000.0, 80.0, &p);
         p.run_margin = 1.15;
         let with_margin = segment_run_minutes(5_000.0, 80.0, &p);
@@ -838,7 +840,7 @@ mod tests {
         // 実乗車時間(5〜6分)より大幅に長い約 6.9 分と推定されてしまう。
         let a = station(1, 11341, 36.326849, 139.193704, Some(4866.8));
         let b = station(2, 11341, 36.359018, 139.242463, Some(4866.8));
-        let stations = vec![a, b];
+        let stations = [a, b];
         let refs: Vec<&Station> = stations.iter().collect();
         let est = estimate_arrival_minutes(&refs, &p);
 
@@ -924,7 +926,7 @@ mod tests {
         let p = EstimationParams::default();
         // 停留所間隔 3km の直行区間。地下鉄扱い(75km/h × 1.2 = 90km/h)のままだと
         // 約 3.4 分と過小評価される。バス上限 50km/h では約 5.7 分。
-        let stations = vec![
+        let stations = [
             bus_station(1, 100_000_001, 35.72, 139.69),
             bus_station(2, 100_000_001, 35.747, 139.69), // 0.027 度 ≈ 3km
         ];
@@ -944,7 +946,7 @@ mod tests {
             let mut b = bus_station(2, 100_000_001, 35.747, 139.69);
             a.kind = kind;
             b.kind = kind;
-            let stations = vec![a, b];
+            let stations = [a, b];
             let refs: Vec<&Station> = stations.iter().collect();
             estimate_arrival_minutes(&refs, &p)[1].cumulative_minutes
         };

--- a/stationapi/src/domain/entity/line.rs
+++ b/stationapi/src/domain/entity/line.rs
@@ -389,7 +389,7 @@ mod tests {
             None,
             None,
             None,
-            symbols.clone(),
+            symbols,
             Some("JY".to_string()),
             Some("JR".to_string()),
             None,

--- a/stationapi/src/domain/repository/line_repository.rs
+++ b/stationapi/src/domain/repository/line_repository.rs
@@ -129,7 +129,7 @@ mod tests {
             let keihin_line = Line::new(
                 11303,
                 1,
-                Some(company_jr_east.clone()),
+                Some(company_jr_east),
                 "京浜東北線".to_string(),
                 "ケイヒントウホクセン".to_string(),
                 "京浜東北線".to_string(),
@@ -176,8 +176,8 @@ mod tests {
             lines_by_line_group_id.insert(1, vec![yamanote_line.clone()]);
             lines_by_line_group_id.insert(2, vec![keihin_line.clone()]);
 
-            lines_by_name.insert("山手線".to_string(), vec![yamanote_line.clone()]);
-            lines_by_name.insert("京浜東北線".to_string(), vec![keihin_line.clone()]);
+            lines_by_name.insert("山手線".to_string(), vec![yamanote_line]);
+            lines_by_name.insert("京浜東北線".to_string(), vec![keihin_line]);
 
             Self {
                 lines,

--- a/stationapi/src/domain/repository/station_repository.rs
+++ b/stationapi/src/domain/repository/station_repository.rs
@@ -207,7 +207,7 @@ mod tests {
                 .filter(|station| {
                     transport_type
                         .as_ref()
-                        .map_or(true, |tt| station.transport_type == *tt)
+                        .is_none_or(|tt| station.transport_type == *tt)
                 })
                 .map(|station| {
                     let mut s = station.clone();
@@ -261,7 +261,7 @@ mod tests {
                     station.station_name.contains(&station_name)
                         && transport_type
                             .as_ref()
-                            .map_or(true, |tt| station.transport_type == *tt)
+                            .is_none_or(|tt| station.transport_type == *tt)
                 })
                 .cloned()
                 .collect();
@@ -317,8 +317,7 @@ mod tests {
 
             if !via_line_ids.is_empty() {
                 let line_match = |s: &Station| via_line_ids.contains(&(s.line_cd as u32));
-                if !from_station.map_or(false, line_match) || !to_station.map_or(false, line_match)
-                {
+                if !from_station.is_some_and(line_match) || !to_station.is_some_and(line_match) {
                     return Ok(result);
                 }
             }

--- a/stationapi/src/presentation/controller/grpc.rs
+++ b/stationapi/src/presentation/controller/grpc.rs
@@ -591,14 +591,11 @@ mod tests {
         }
 
         fn get_captured_coordinates_transport_type(&self) -> Option<TransportTypeFilter> {
-            self.captured_coordinates_transport_type
-                .lock()
-                .unwrap()
-                .clone()
+            *self.captured_coordinates_transport_type.lock().unwrap()
         }
 
         fn get_captured_name_transport_type(&self) -> Option<TransportTypeFilter> {
-            self.captured_name_transport_type.lock().unwrap().clone()
+            *self.captured_name_transport_type.lock().unwrap()
         }
     }
 

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -357,14 +357,14 @@ where
         for station in stations.iter_mut() {
             station.train_type = train_type_map
                 .get(&station.station_cd)
-                .cloned()
+                .copied()
                 .cloned()
                 .map(Box::new);
             if let Some(ref mut line) = station.line {
                 if let Some(ref mut nested_station) = line.station {
                     nested_station.train_type = train_type_map
                         .get(&nested_station.station_cd)
-                        .cloned()
+                        .copied()
                         .cloned()
                         .map(Box::new);
                 }
@@ -373,7 +373,7 @@ where
                 if let Some(ref mut nested_station) = line.station {
                     nested_station.train_type = train_type_map
                         .get(&nested_station.station_cd)
-                        .cloned()
+                        .copied()
                         .cloned()
                         .map(Box::new);
                 }
@@ -589,14 +589,14 @@ where
                     .collect::<Vec<Line>>();
 
                 for line in lines.iter_mut() {
-                    line.company = company_map.get(&line.company_cd).cloned().cloned();
+                    line.company = company_map.get(&line.company_cd).copied().cloned();
                     line.line_symbols = self.get_line_symbols(line);
                     line.train_type = tt_by_pair
                         .get(&(line_group_cd as u32, line.line_cd as u32))
                         .cloned();
                 }
 
-                line.company = company_map.get(&line.company_cd).cloned().cloned();
+                line.company = company_map.get(&line.company_cd).copied().cloned();
                 line.line_symbols = self.get_line_symbols(&line);
 
                 tt.lines = lines;
@@ -1379,7 +1379,7 @@ where
             station.station_numbers = station_numbers;
             if let Some(tt) = train_type_map
                 .get(&station.station_cd)
-                .cloned()
+                .copied()
                 .cloned()
                 .map(Box::new)
             {
@@ -1485,7 +1485,7 @@ where
                     station_copy.station_numbers = station_numbers;
                     if let Some(tt) = train_type_map
                         .get(&station_copy.station_cd)
-                        .cloned()
+                        .copied()
                         .cloned()
                         .map(Box::new)
                     {

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -1807,13 +1807,13 @@ mod tests {
     #[test]
     fn test_segment_stop_signature_identical_stops_match() {
         // Two line groups that stop at exactly the same stations between 1 and 4.
-        let local_stops = vec![
+        let local_stops = [
             create_stop(1, 100, Some(0)),
             create_stop(2, 100, Some(0)),
             create_stop(3, 100, Some(0)),
             create_stop(4, 100, Some(0)),
         ];
-        let express_stops = vec![
+        let express_stops = [
             create_stop(1, 200, Some(0)),
             create_stop(2, 200, Some(0)),
             create_stop(3, 200, Some(0)),
@@ -1832,7 +1832,7 @@ mod tests {
     #[test]
     fn test_segment_stop_signature_excludes_pass_through() {
         // Station 3 is passed through (pass == 1) and must not be part of the signature.
-        let stops = vec![
+        let stops = [
             create_stop(1, 100, Some(0)),
             create_stop(2, 100, Some(0)),
             create_stop(3, 100, Some(1)),
@@ -1847,14 +1847,14 @@ mod tests {
     #[test]
     fn test_segment_stop_signature_differs_when_stops_differ() {
         // Skips station 2.
-        let express_stops = vec![
+        let express_stops = [
             create_stop(1, 100, Some(0)),
             create_stop(2, 100, Some(1)),
             create_stop(3, 100, Some(0)),
             create_stop(4, 100, Some(0)),
         ];
         // Stops everywhere.
-        let local_stops = vec![
+        let local_stops = [
             create_stop(1, 200, Some(0)),
             create_stop(2, 200, Some(0)),
             create_stop(3, 200, Some(0)),
@@ -1872,13 +1872,13 @@ mod tests {
     #[test]
     fn test_segment_stop_signature_restricted_to_segment() {
         // Differences outside the 2→3 segment must be ignored.
-        let stops_a = vec![
+        let stops_a = [
             create_stop(1, 100, Some(0)),
             create_stop(2, 100, Some(0)),
             create_stop(3, 100, Some(0)),
             create_stop(4, 100, Some(0)),
         ];
-        let stops_b = vec![
+        let stops_b = [
             create_stop(1, 200, Some(1)),
             create_stop(2, 200, Some(0)),
             create_stop(3, 200, Some(0)),
@@ -1895,7 +1895,7 @@ mod tests {
 
     #[test]
     fn test_segment_stop_signature_direction_independent() {
-        let stops = vec![
+        let stops = [
             create_stop(1, 100, Some(0)),
             create_stop(2, 100, Some(0)),
             create_stop(3, 100, Some(0)),
@@ -1911,7 +1911,7 @@ mod tests {
 
     #[test]
     fn test_segment_stop_signature_missing_endpoint_returns_none() {
-        let stops = vec![create_stop(1, 100, Some(0)), create_stop(2, 100, Some(0))];
+        let stops = [create_stop(1, 100, Some(0)), create_stop(2, 100, Some(0))];
         let refs: Vec<&Station> = stops.iter().collect();
 
         assert!(segment_stop_signature(&refs, 1, 99).is_none());


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

`dev` に既存だった `cargo clippy -D warnings` の警告19件をすべて解消します。[#1583](https://github.com/TrainLCD/StationAPI/pull/1583) のレビュー時に発覚した既存issueへの対応です。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `arrival_estimation.rs` / `query.rs`: テストコード内の `vec![...]` を配列リテラルに置換（`useless_vec`）
- `arrival_estimation.rs`: `EstimationParams::default()` 直後のフィールド代入を構造体更新構文にまとめた（`field_reassign_with_default`）
- `station_repository.rs`: `Option::map_or(true, ...)` を `is_none_or(...)` に、`map_or(false, ...)` を `is_some_and(...)` に置換（`unnecessary_map_or`）
- `grpc.rs`: `Copy` を実装する `Option<TransportTypeFilter>` への `.clone()` をデリファレンスに変更（`clone_on_copy`）

いずれも挙動を変えないリント対応のみです。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 内部実装を整理し、データの受け渡しや条件判定をより簡潔な形に改善しました。
* **Tests**
  * テストデータの作成方法を見直し、既存の検証内容はそのままに、テストの保守性を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->