### PR TITLE
経路検索のN+1クエリ解消・IPAキャッシュのArc化などクエリ処理のパフォーマンスを改善

### DIFF
--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{LazyLock, RwLock};
+use std::sync::{Arc, LazyLock, RwLock};
 
 /// Cached IPA computation result for a single name.
 #[derive(Clone, Debug)]
@@ -11,10 +11,10 @@ pub struct IpaResult {
 
 type IpaCacheKey = (String, Option<String>);
 
-static STATION_IPA_CACHE: LazyLock<RwLock<HashMap<IpaCacheKey, IpaResult>>> =
+static STATION_IPA_CACHE: LazyLock<RwLock<HashMap<IpaCacheKey, Arc<IpaResult>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
-static LINE_IPA_CACHE: LazyLock<RwLock<HashMap<IpaCacheKey, IpaResult>>> =
+static LINE_IPA_CACHE: LazyLock<RwLock<HashMap<IpaCacheKey, Arc<IpaResult>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
 /// Compute all three IPA outputs in a single pass, eliminating the redundant
@@ -45,22 +45,26 @@ fn compute_line_ipa(name_katakana: &str, name_roman: Option<&str>) -> IpaResult 
 }
 
 fn cached_lookup(
-    cache: &LazyLock<RwLock<HashMap<IpaCacheKey, IpaResult>>>,
+    cache: &LazyLock<RwLock<HashMap<IpaCacheKey, Arc<IpaResult>>>>,
     key: &IpaCacheKey,
     compute: impl FnOnce() -> IpaResult,
-) -> IpaResult {
+) -> Arc<IpaResult> {
     // Fast path: read lock
     if let Some(result) = cache.read().unwrap().get(key) {
-        return result.clone();
+        return Arc::clone(result);
     }
     // Slow path: compute and insert
-    let result = compute();
-    cache.write().unwrap().insert(key.clone(), result.clone());
+    let result = Arc::new(compute());
+    cache
+        .write()
+        .unwrap()
+        .insert(key.clone(), Arc::clone(&result));
     result
 }
 
 /// Compute IPA for station/train-type names with memoization.
-pub fn compute_ipa_cached(name_katakana: &str, name_roman: Option<&str>) -> IpaResult {
+/// Arcで返すことでキャッシュヒット時にTTSセグメントのディープクローンを避ける。
+pub fn compute_ipa_cached(name_katakana: &str, name_roman: Option<&str>) -> Arc<IpaResult> {
     let key = (name_katakana.to_string(), name_roman.map(str::to_string));
     cached_lookup(&STATION_IPA_CACHE, &key, || {
         compute_ipa(name_katakana, name_roman)
@@ -68,7 +72,8 @@ pub fn compute_ipa_cached(name_katakana: &str, name_roman: Option<&str>) -> IpaR
 }
 
 /// Compute IPA for line names (with suffix replacement) with memoization.
-pub fn compute_line_ipa_cached(name_katakana: &str, name_roman: Option<&str>) -> IpaResult {
+/// Arcで返すことでキャッシュヒット時にTTSセグメントのディープクローンを避ける。
+pub fn compute_line_ipa_cached(name_katakana: &str, name_roman: Option<&str>) -> Arc<IpaResult> {
     let key = (name_katakana.to_string(), name_roman.map(str::to_string));
     cached_lookup(&LINE_IPA_CACHE, &key, || {
         compute_line_ipa(name_katakana, name_roman)

--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -38,6 +38,55 @@ type StopTimeBatchRow = (
     Option<i32>,
 );
 
+/// 検索性能に直結するインデックス。create_table.sql内のDOブロックは
+/// 拡張が使えない環境向けに例外をNOTICEで握り潰すため、作成に失敗しても
+/// 起動ログからは分からない(実際に稼働DBでtrigramインデックスだけが
+/// 欠落する事例があった)。必要な拡張はcreate_schemaの冒頭で必須として
+/// 作成しているので、ここに列挙したインデックスは明示的に作成し直し、
+/// 欠落があればERRORログで可視化する。
+const PERFORMANCE_INDEXES: &[(&str, &str)] = &[
+    (
+        "idx_performance_stations_point",
+        "CREATE INDEX IF NOT EXISTS idx_performance_stations_point ON public.stations USING gist ((point(lat, lon)))",
+    ),
+    (
+        "idx_performance_stations_bus_point",
+        "CREATE INDEX IF NOT EXISTS idx_performance_stations_bus_point ON public.stations USING gist ((point(lat, lon))) WHERE e_status = 0 AND transport_type = 1",
+    ),
+    (
+        "idx_performance_station_name_trgm",
+        "CREATE INDEX IF NOT EXISTS idx_performance_station_name_trgm ON public.stations USING gin (station_name gin_trgm_ops)",
+    ),
+    (
+        "idx_performance_station_name_k_trgm",
+        "CREATE INDEX IF NOT EXISTS idx_performance_station_name_k_trgm ON public.stations USING gin (station_name_k gin_trgm_ops)",
+    ),
+    (
+        "idx_performance_station_name_rn_trgm",
+        "CREATE INDEX IF NOT EXISTS idx_performance_station_name_rn_trgm ON public.stations USING gin (station_name_rn gin_trgm_ops)",
+    ),
+    (
+        "idx_performance_station_name_zh_trgm",
+        "CREATE INDEX IF NOT EXISTS idx_performance_station_name_zh_trgm ON public.stations USING gin (station_name_zh gin_trgm_ops)",
+    ),
+    (
+        "idx_performance_station_name_ko_trgm",
+        "CREATE INDEX IF NOT EXISTS idx_performance_station_name_ko_trgm ON public.stations USING gin (station_name_ko gin_trgm_ops)",
+    ),
+    (
+        "idx_gtfs_stops_point",
+        "CREATE INDEX IF NOT EXISTS idx_gtfs_stops_point ON public.gtfs_stops USING gist ((point(stop_lat, stop_lon)))",
+    ),
+    (
+        "idx_gtfs_stops_name_trgm",
+        "CREATE INDEX IF NOT EXISTS idx_gtfs_stops_name_trgm ON public.gtfs_stops USING gin (stop_name gin_trgm_ops)",
+    ),
+    (
+        "idx_gtfs_stops_name_k_trgm",
+        "CREATE INDEX IF NOT EXISTS idx_gtfs_stops_name_k_trgm ON public.gtfs_stops USING gin (stop_name_k gin_trgm_ops)",
+    ),
+];
+
 /// Create required extensions and tables before running data imports.
 /// Must be called before `import_csv` and `import_gtfs` can run in parallel.
 pub async fn create_schema() -> Result<(), Box<dyn std::error::Error>> {
@@ -61,7 +110,39 @@ pub async fn create_schema() -> Result<(), Box<dyn std::error::Error>> {
     let create_sql: String = String::from_utf8_lossy(&create_sql_content).parse()?;
     sqlx::raw_sql(&create_sql).execute(&mut conn).await?;
 
-    info!("Schema creation completed.");
+    for (name, ddl) in PERFORMANCE_INDEXES {
+        if let Err(e) = sqlx::query(ddl).execute(&mut conn).await {
+            tracing::error!("Failed to create performance index {}: {}", name, e);
+        }
+    }
+
+    // 作成結果を検証し、欠落があれば起動ログに残す
+    let expected: Vec<String> = PERFORMANCE_INDEXES
+        .iter()
+        .map(|(name, _)| name.to_string())
+        .collect();
+    let existing: Vec<String> = sqlx::query_scalar::<_, String>(
+        "SELECT indexname FROM pg_indexes WHERE indexname = ANY($1)",
+    )
+    .bind(&expected)
+    .fetch_all(&mut conn)
+    .await?;
+    let missing: Vec<&str> = PERFORMANCE_INDEXES
+        .iter()
+        .map(|(name, _)| *name)
+        .filter(|name| !existing.iter().any(|e| e == name))
+        .collect();
+    if missing.is_empty() {
+        info!(
+            "Schema creation completed. All {} performance indexes are present.",
+            expected.len()
+        );
+    } else {
+        tracing::error!(
+            "Schema creation completed, but performance indexes are missing: {:?}",
+            missing
+        );
+    }
 
     Ok(())
 }

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -10,9 +10,9 @@ use crate::{
 impl From<Line> for GrpcLine {
     fn from(line: Line) -> Self {
         let ipa = compute_line_ipa_cached(&line.line_name_k, line.line_name_r.as_deref());
-        let name_ipa = ipa.name_ipa;
-        let name_roman_ipa = ipa.name_roman_ipa;
-        let name_tts_segments = to_proto_tts_segments(ipa.tts_segments);
+        let name_ipa = ipa.name_ipa.clone();
+        let name_roman_ipa = ipa.name_roman_ipa.clone();
+        let name_tts_segments = to_proto_tts_segments(&ipa.tts_segments);
         // バス路線の場合は line_type を OtherLineType (0) に強制
         // (鉄道用の line_type が誤って設定されている可能性があるため)
         let line_type = if line.transport_type == TransportType::Bus {

--- a/stationapi/src/use_case/dto/station.rs
+++ b/stationapi/src/use_case/dto/station.rs
@@ -19,9 +19,9 @@ impl From<TransportType> for i32 {
 impl From<Station> for GrpcStation {
     fn from(station: Station) -> Self {
         let ipa = compute_ipa_cached(&station.station_name_k, station.station_name_r.as_deref());
-        let name_ipa = ipa.name_ipa;
-        let name_roman_ipa = ipa.name_roman_ipa;
-        let name_tts_segments = to_proto_tts_segments(ipa.tts_segments);
+        let name_ipa = ipa.name_ipa.clone();
+        let name_roman_ipa = ipa.name_roman_ipa.clone();
+        let name_tts_segments = to_proto_tts_segments(&ipa.tts_segments);
         Self {
             id: station.station_cd as u32,
             group_id: station.station_g_cd as u32,

--- a/stationapi/src/use_case/dto/train_type.rs
+++ b/stationapi/src/use_case/dto/train_type.rs
@@ -24,9 +24,9 @@ impl From<TrainType> for GrpcTrainType {
             kind,
         } = train_type;
         let ipa = compute_ipa_cached(&type_name_k, type_name_r.as_deref());
-        let name_ipa = ipa.name_ipa;
-        let name_roman_ipa = ipa.name_roman_ipa;
-        let name_tts_segments = to_proto_tts_segments(ipa.tts_segments);
+        let name_ipa = ipa.name_ipa.clone();
+        let name_roman_ipa = ipa.name_roman_ipa.clone();
+        let name_tts_segments = to_proto_tts_segments(&ipa.tts_segments);
         Self {
             id: id.map(|id| id as u32).unwrap_or(0),
             type_id: type_cd.map(|id| id as u32).unwrap_or(0),

--- a/stationapi/src/use_case/dto/tts.rs
+++ b/stationapi/src/use_case/dto/tts.rs
@@ -3,20 +3,20 @@ use crate::{
     proto::{TtsAlphabet, TtsSegment},
 };
 
-pub fn to_proto_tts_segments(segments: Vec<TtsNameSegment>) -> Vec<TtsSegment> {
+pub fn to_proto_tts_segments(segments: &[TtsNameSegment]) -> Vec<TtsSegment> {
     segments
-        .into_iter()
+        .iter()
         .map(|segment| TtsSegment {
-            surface: segment.surface,
-            fallback_text: segment.fallback_text,
-            pronunciation: segment.pronunciation,
+            surface: segment.surface.clone(),
+            fallback_text: segment.fallback_text.clone(),
+            pronunciation: segment.pronunciation.clone(),
             alphabet: match segment.alphabet {
                 TtsAlphabetKind::Ipa => TtsAlphabet::Ipa as i32,
                 TtsAlphabetKind::Yomigana => TtsAlphabet::Yomigana as i32,
                 TtsAlphabetKind::Plain => TtsAlphabet::Plain as i32,
             },
             lang: segment.lang.to_string(),
-            separator: segment.separator,
+            separator: segment.separator.clone(),
         })
         .collect()
 }

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -637,27 +637,75 @@ where
 
         let route_row_tree_map = self.build_route_tree_map(&stops);
 
-        let mut routes: Vec<Route> = Vec::new();
+        // TODO: SQLで同等の処理を行う
+        // 発着駅を含まない経路候補はレスポンスに含まれないため、
+        // 路線の取得やproto変換を行う前にここで除外する
+        let route_groups: Vec<(&i32, &Vec<&Station>)> = route_row_tree_map
+            .iter()
+            .filter(|(_, stops)| {
+                stops.iter().any(|row| {
+                    row.station_g_cd as u32 == from_station_id
+                        || row.station_g_cd as u32 == to_station_id
+                })
+            })
+            .collect();
 
-        for (id, stops) in route_row_tree_map.iter() {
-            let line_group_id_vec = stops
-                .iter()
-                .filter_map(|row| row.line_group_cd.map(|id| id as u32))
-                .collect::<Vec<u32>>();
+        // 経路候補ごとに個別クエリを発行せず、全line_group_cdの路線を一括取得する
+        let line_group_id_vec: Vec<u32> = route_groups
+            .iter()
+            .flat_map(|(_, stops)| {
+                stops
+                    .iter()
+                    .filter_map(|row| row.line_group_cd.map(|id| id as u32))
+            })
+            .collect::<HashSet<u32>>()
+            .into_iter()
+            .collect();
 
-            let mut tt_lines = self
-                .line_repository
-                .get_by_line_group_id_vec_for_routes(&line_group_id_vec)
-                .await?;
+        let mut all_tt_lines = self
+            .line_repository
+            .get_by_line_group_id_vec_for_routes(&line_group_id_vec)
+            .await?;
 
-            // Add line_symbols to all lines first
-            for line in tt_lines.iter_mut() {
-                line.line_symbols = self.get_line_symbols(line);
+        // Add line_symbols to all lines first
+        for line in all_tt_lines.iter_mut() {
+            line.line_symbols = self.get_line_symbols(line);
+        }
+
+        // line_group_cdごとにパーティションする。クエリはsst.id順で返すため、
+        // グループ内の相対順序は単発取得した場合と変わらない
+        let mut tt_lines_by_group: std::collections::HashMap<i32, Vec<&Line>> =
+            std::collections::HashMap::new();
+        for line in &all_tt_lines {
+            if let Some(lgc) = line.line_group_cd {
+                tt_lines_by_group.entry(lgc).or_default().push(line);
             }
+        }
+
+        let mut routes: Vec<Route> = Vec::with_capacity(route_groups.len());
+
+        for (id, stops) in route_groups {
+            let tt_lines: &[&Line] = stops
+                .iter()
+                .find_map(|row| row.line_group_cd)
+                .and_then(|lgc| tt_lines_by_group.get(&lgc))
+                .map(|lines| lines.as_slice())
+                .unwrap_or(&[]);
 
             // Build HashMap for O(1) line lookup by line_cd instead of O(n) linear search
             let tt_line_map: std::collections::HashMap<i32, &Line> =
-                tt_lines.iter().map(|line| (line.line_cd, line)).collect();
+                tt_lines.iter().map(|line| (line.line_cd, *line)).collect();
+
+            // Filter lines to only include those with matching line_group_cd
+            // and remove duplicates by line_cd.
+            // グループ内の停車駅はline_group_cdを共有するため、TrainTypeに
+            // 埋め込むlinesは停車駅ごとではなくグループごとに一度だけ構築する
+            let mut seen_line_cds = std::collections::HashSet::new();
+            let group_filtered_lines: Vec<Line> = tt_lines
+                .iter()
+                .filter(|line| seen_line_cds.insert(line.line_cd))
+                .map(|&line| line.clone())
+                .collect();
 
             let stops = stops
                 .iter()
@@ -667,18 +715,10 @@ where
                     if let Some(tt_line) = tt_line_map.get(&row.line_cd).copied() {
                         let train_type = match row.type_id.is_some() {
                             true => {
-                                // Filter lines to only include those with matching line_group_cd
-                                // and remove duplicates by line_cd
-                                let mut seen_line_cds = std::collections::HashSet::new();
-                                let filtered_lines: Vec<Line> = tt_lines
-                                    .iter()
-                                    .filter(|line| {
-                                        row.line_group_cd.is_some()
-                                            && line.line_group_cd == row.line_group_cd
-                                            && seen_line_cds.insert(line.line_cd)
-                                    })
-                                    .cloned()
-                                    .collect();
+                                let filtered_lines = match row.line_group_cd.is_some() {
+                                    true => group_filtered_lines.clone(),
+                                    false => vec![],
+                                };
 
                                 Some(Box::new(TrainType {
                                     id: row.type_id,
@@ -711,14 +751,6 @@ where
                     stop.into()
                 })
                 .collect::<Vec<proto::Station>>();
-
-            // TODO: SQLで同等の処理を行う
-            let includes_requested_station = stops
-                .iter()
-                .any(|stop| stop.group_id == from_station_id || stop.group_id == to_station_id);
-            if !includes_requested_station {
-                continue;
-            }
 
             routes.push(Route {
                 id: *id as u32,
@@ -1307,7 +1339,10 @@ where
             .collect::<Vec<u32>>();
 
         // Collect company IDs from rail lines
+        // 路線ごとに重複した会社IDをそのままIN句に並べないよう先に一意化する
         let mut company_ids: Vec<u32> = lines.iter().map(|l| l.company_cd as u32).collect();
+        company_ids.sort_unstable();
+        company_ids.dedup();
 
         // Phase 2: dependent queries in parallel
         // Fetch companies, train types, and all bus lines in one batch
@@ -1494,8 +1529,6 @@ where
                     line.station = Some(station_copy);
                 }
             }
-            let station_numbers: Vec<StationNumber> = self.get_station_numbers(station);
-            station.station_numbers = station_numbers;
             station.lines = station_lines;
         }
 
@@ -4334,6 +4367,368 @@ mod tests {
         #[test]
         fn test_rail_and_bus_filter_returns_none() {
             assert_eq!(filter_to_db_type(TransportTypeFilter::RailAndBus), None);
+        }
+    }
+
+    // ========================================
+    // get_routes tests
+    // ========================================
+
+    mod get_routes_tests {
+        use super::*;
+        use crate::domain::{
+            entity::company::Company,
+            error::DomainError,
+            repository::{
+                company_repository::CompanyRepository, line_repository::LineRepository,
+                station_repository::StationRepository, train_type_repository::TrainTypeRepository,
+            },
+        };
+        use crate::use_case::traits::query::QueryUseCase;
+        use std::sync::Mutex;
+
+        struct RouteMockStationRepository {
+            stops: Vec<Station>,
+        }
+
+        #[async_trait::async_trait]
+        impl StationRepository for RouteMockStationRepository {
+            async fn get_route_stops(
+                &self,
+                _: u32,
+                _: u32,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(self.stops.clone())
+            }
+            async fn find_by_id(&self, _: u32) -> Result<Option<Station>, DomainError> {
+                Ok(None)
+            }
+            async fn get_by_id_vec(&self, _: &[u32]) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_id(
+                &self,
+                _: u32,
+                _: Option<u32>,
+                _: Option<u32>,
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_id_vec(&self, _: &[u32]) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_id_vec_with_group_stations(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id(&self, _: u32) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id_vec_no_types(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_coordinates(
+                &self,
+                _: f64,
+                _: f64,
+                _: Option<u32>,
+                _: Option<TransportType>,
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_bus_stops_near_stations(
+                &self,
+                _: &[(u32, f64, f64)],
+                _: u32,
+            ) -> Result<Vec<(u32, Station)>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_name(
+                &self,
+                _: String,
+                _: Option<u32>,
+                _: Option<u32>,
+                _: Option<TransportType>,
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_group_id(&self, _: u32) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_route_stops_by_station_cd(
+                &self,
+                from: u32,
+                to: u32,
+                via: &[u32],
+                _direction_id: Option<u32>,
+            ) -> Result<Vec<Station>, DomainError> {
+                self.get_route_stops(from, to, via).await
+            }
+        }
+
+        /// `get_by_line_group_id_vec_for_routes`の呼び出し引数を記録し、
+        /// 要求されたline_group_cdに属する路線だけを返すモック
+        struct RouteMockLineRepository {
+            lines: Vec<Line>,
+            for_routes_calls: Mutex<Vec<Vec<u32>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl LineRepository for RouteMockLineRepository {
+            async fn get_by_line_group_id_vec_for_routes(
+                &self,
+                line_group_id_vec: &[u32],
+            ) -> Result<Vec<Line>, DomainError> {
+                self.for_routes_calls
+                    .lock()
+                    .unwrap()
+                    .push(line_group_id_vec.to_vec());
+                Ok(self
+                    .lines
+                    .iter()
+                    .filter(|line| {
+                        line.line_group_cd
+                            .is_some_and(|lgc| line_group_id_vec.contains(&(lgc as u32)))
+                    })
+                    .cloned()
+                    .collect())
+            }
+            async fn get_by_line_group_id_vec(&self, _: &[u32]) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn find_by_id(&self, _: u32) -> Result<Option<Line>, DomainError> {
+                Ok(None)
+            }
+            async fn find_by_station_id(&self, _: u32) -> Result<Option<Line>, DomainError> {
+                Ok(None)
+            }
+            async fn get_by_ids(&self, _: &[u32]) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_name(
+                &self,
+                _: String,
+                _: Option<u32>,
+            ) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_group_id(&self, _: u32) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id(&self, _: u32) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id_vec_no_types(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+        }
+
+        struct RouteMockTrainTypeRepository;
+
+        #[async_trait::async_trait]
+        impl TrainTypeRepository for RouteMockTrainTypeRepository {
+            async fn get_by_line_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<TrainType>, DomainError> {
+                Ok(vec![])
+            }
+            async fn find_by_line_group_id_and_line_id(
+                &self,
+                _: u32,
+                _: u32,
+            ) -> Result<Option<TrainType>, DomainError> {
+                Ok(None)
+            }
+            async fn find_by_line_group_id_and_line_id_vec(
+                &self,
+                _: &[(u32, u32)],
+            ) -> Result<std::collections::HashMap<(u32, u32), TrainType>, DomainError> {
+                Ok(std::collections::HashMap::new())
+            }
+            async fn get_by_line_group_id(&self, _: u32) -> Result<Vec<TrainType>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_id(&self, _: u32) -> Result<Vec<TrainType>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_id_vec(
+                &self,
+                _: &[u32],
+                _: Option<u32>,
+            ) -> Result<Vec<TrainType>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_types_by_station_id_vec(
+                &self,
+                _: &[u32],
+                _: Option<u32>,
+            ) -> Result<Vec<TrainType>, DomainError> {
+                Ok(vec![])
+            }
+        }
+
+        struct RouteMockCompanyRepository;
+
+        #[async_trait::async_trait]
+        impl CompanyRepository for RouteMockCompanyRepository {
+            async fn find_by_id_vec(&self, _: &[u32]) -> Result<Vec<Company>, DomainError> {
+                Ok(vec![])
+            }
+        }
+
+        /// 経路検索の停車駅行を作る。line_group_cdがある行は種別付き
+        /// (type_idあり)として扱われる
+        fn create_route_stop(
+            station_cd: i32,
+            station_g_cd: i32,
+            line_cd: i32,
+            line_group_cd: Option<i32>,
+        ) -> Station {
+            let mut stop = create_test_station(station_cd, station_g_cd, line_cd, line_group_cd);
+            if line_group_cd.is_some() {
+                stop.type_id = Some(station_cd);
+                stop.type_cd = Some(1);
+                stop.type_name = Some("急行".to_string());
+                stop.type_name_k = Some("キュウコウ".to_string());
+                stop.color = Some("#FF0000".to_string());
+            }
+            stop
+        }
+
+        fn create_route_line(line_cd: i32, line_group_cd: i32) -> Line {
+            let mut line = create_test_line(line_cd);
+            line.line_group_cd = Some(line_group_cd);
+            line
+        }
+
+        fn build_interactor(
+            stops: Vec<Station>,
+            lines: Vec<Line>,
+        ) -> QueryInteractor<
+            RouteMockStationRepository,
+            RouteMockLineRepository,
+            RouteMockTrainTypeRepository,
+            RouteMockCompanyRepository,
+        > {
+            QueryInteractor {
+                station_repository: RouteMockStationRepository { stops },
+                line_repository: RouteMockLineRepository {
+                    lines,
+                    for_routes_calls: Mutex::new(vec![]),
+                },
+                train_type_repository: RouteMockTrainTypeRepository,
+                company_repository: RouteMockCompanyRepository,
+            }
+        }
+
+        #[tokio::test]
+        async fn test_get_routes_batches_line_fetch_and_filters_groups() {
+            let stops = vec![
+                // line_group 100: 発着駅(1, 3)を含む → 採用
+                create_route_stop(1101, 1, 11, Some(100)),
+                create_route_stop(1102, 2, 11, Some(100)),
+                create_route_stop(1103, 3, 11, Some(100)),
+                // line_group 200: 発着駅を含む → 採用
+                create_route_stop(2101, 1, 22, Some(200)),
+                create_route_stop(2103, 3, 22, Some(200)),
+                // line_group 300: 発着駅を含まない → 除外
+                create_route_stop(3105, 5, 33, Some(300)),
+                create_route_stop(3106, 6, 33, Some(300)),
+                // line_group_cdなし: line_cd(44)でグループ化され種別なし
+                create_route_stop(4101, 1, 44, None),
+                create_route_stop(4103, 3, 44, None),
+            ];
+            let lines = vec![
+                create_route_line(11, 100),
+                create_route_line(12, 100),
+                create_route_line(22, 200),
+                create_route_line(33, 300),
+            ];
+            let interactor = build_interactor(stops, lines);
+
+            let routes = interactor.get_routes(1, 3, None).await.unwrap();
+
+            // 発着駅を含まないline_group 300は除外され、BTreeMapのキー順に並ぶ
+            let route_ids: Vec<u32> = routes.iter().map(|r| r.id).collect();
+            assert_eq!(route_ids, vec![44, 100, 200]);
+
+            // 路線の取得は経路候補ごとではなく一括1回で、
+            // 除外されたグループ(300)のIDは要求されない
+            {
+                let calls = interactor.line_repository.for_routes_calls.lock().unwrap();
+                assert_eq!(calls.len(), 1);
+                let mut requested = calls[0].clone();
+                requested.sort_unstable();
+                assert_eq!(requested, vec![100, 200]);
+            }
+
+            // line_group 100の停車駅は種別を持ち、グループ内の路線(11, 12)が入る
+            let route100 = routes.iter().find(|r| r.id == 100).unwrap();
+            assert_eq!(route100.stops.len(), 3);
+            for stop in &route100.stops {
+                let tt = stop.train_type.as_ref().unwrap();
+                assert_eq!(tt.group_id, 100);
+                let mut line_ids: Vec<u32> = tt.lines.iter().map(|l| l.id).collect();
+                line_ids.sort_unstable();
+                assert_eq!(line_ids, vec![11, 12]);
+            }
+
+            // line_group 200の停車駅の種別にはグループ内の路線(22)だけが入る
+            let route200 = routes.iter().find(|r| r.id == 200).unwrap();
+            assert_eq!(route200.stops.len(), 2);
+            for stop in &route200.stops {
+                let tt = stop.train_type.as_ref().unwrap();
+                assert_eq!(tt.group_id, 200);
+                let line_ids: Vec<u32> = tt.lines.iter().map(|l| l.id).collect();
+                assert_eq!(line_ids, vec![22]);
+            }
+
+            // line_group_cdなしのグループは種別を持たない
+            let route44 = routes.iter().find(|r| r.id == 44).unwrap();
+            assert_eq!(route44.stops.len(), 2);
+            assert!(route44.stops.iter().all(|s| s.train_type.is_none()));
+        }
+
+        #[tokio::test]
+        async fn test_get_routes_returns_empty_when_no_group_includes_endpoints() {
+            let stops = vec![
+                create_route_stop(3105, 5, 33, Some(300)),
+                create_route_stop(3106, 6, 33, Some(300)),
+            ];
+            let lines = vec![create_route_line(33, 300)];
+            let interactor = build_interactor(stops, lines);
+
+            let routes = interactor.get_routes(1, 3, None).await.unwrap();
+
+            assert!(routes.is_empty());
         }
     }
 }

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -832,10 +832,10 @@ where
                         &row.station_name_k,
                         row.station_name_r.as_deref(),
                     );
-                    let name_ipa = ipa.name_ipa;
-                    let name_roman_ipa = ipa.name_roman_ipa;
+                    let name_ipa = ipa.name_ipa.clone();
+                    let name_roman_ipa = ipa.name_roman_ipa.clone();
                     let name_tts_segments =
-                        crate::use_case::dto::tts::to_proto_tts_segments(ipa.tts_segments);
+                        crate::use_case::dto::tts::to_proto_tts_segments(&ipa.tts_segments);
                     proto::StationMinimal {
                         id: row.station_cd as u32,
                         group_id: row.station_g_cd as u32,


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

クエリ処理のパフォーマンス改善。経路検索（`get_routes`）のN+1クエリ解消、IPAキャッシュのヒット時ディープクローン排除、稼働DBで欠落していた性能インデックスへの恒久対策を行う。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `get_routes`: 経路候補グループごとに路線を取得していたN+1クエリを、全`line_group_cd`の一括取得+パーティションに変更。発着駅を含まない候補グループは路線取得・proto変換の前に除外
- `get_routes`: `TrainType`に埋め込む路線リストを停車駅ごとに再フィルタ+cloneせず、グループごとに一度だけ構築
- `update_station_vec_with_attributes_inner`: ループ末尾で同一入力の`get_station_numbers`を再計算していた冗長処理を削除し、会社IDを一意化してからIN句クエリへ渡すように変更
- IPAキャッシュ（`domain/ipa.rs`）を`Arc<IpaResult>`返却に変更し、キャッシュヒットのたびにTTSセグメントを含む結果全体をディープクローンしていたのを解消
- 性能インデックス10本（stationsのtrigram×5・point GiST×2、gtfs_stopsのpoint+trigram×2）を`create_schema`で明示的に作成し、作成後に`pg_indexes`を照合して欠落をERRORログで可視化（`create_table.sql`のDOブロックが例外をNOTICEで握り潰すため、稼働DBでtrigramインデックス5本が欠落し駅名検索が全表スキャンになっていた事例への恒久対策）
- `get_routes`の一括取得・候補除外・種別路線構築を検証するテストを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

`EXPLAIN ANALYZE`で駅名検索がSeq Scan（buffers 625）→Bitmap Index Scan（buffers 36）になることを稼働DBで確認済み。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 路線検索の結果生成が最適化され、関連する路線情報をまとめて扱うことで応答が安定しやすくなりました。
  * 駅・路線・種別の音声読み上げ用データの取り扱いが改善されました。

* **バグ修正**
  * 検索用インデックスの不足を検出できるようになり、スキーマ準備時の抜け漏れに気づきやすくなりました。
  * 一部の経路候補で不要な結果が混ざる問題を抑えました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->