### PR TITLE
GetTrainRouteのline_group_idをprotoどおりoptional扱いにし未指定時は路線の駅列にフォールバック

### DIFF
--- a/stationapi/src/presentation/controller/grpc.rs
+++ b/stationapi/src/presentation/controller/grpc.rs
@@ -434,9 +434,7 @@ impl StationApi for MyApi {
         let req = request.get_ref();
         let from_id = req.from_station_id;
         let to_id = req.to_station_id;
-        let line_group_id = req
-            .line_group_id
-            .ok_or_else(|| tonic::Status::invalid_argument("line_group_id is required"))?;
+        let line_group_id = req.line_group_id;
 
         match self
             .query_use_case
@@ -909,7 +907,7 @@ mod tests {
             &self,
             _from_station_id: u32,
             _to_station_id: u32,
-            _line_group_id: u32,
+            _line_group_id: Option<u32>,
         ) -> Result<Vec<crate::proto::TrainRouteSegment>, UseCaseError> {
             Ok(vec![])
         }

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -1002,24 +1002,46 @@ where
         &self,
         from_station_id: u32,
         to_station_id: u32,
-        line_group_id: u32,
+        line_group_id: Option<u32>,
     ) -> Result<Vec<proto::TrainRouteSegment>, UseCaseError> {
-        let stations = self
-            .get_stations_by_line_group_id(line_group_id, TransportTypeFilter::RailAndBus)
-            .await?;
+        // line_group_id 未指定は種別なし(各駅停車)の単一路線走行。
+        // from駅の所属路線の駅列をそのまま経路として扱う。
+        let stations = match line_group_id {
+            Some(line_group_id) => {
+                self.get_stations_by_line_group_id(line_group_id, TransportTypeFilter::RailAndBus)
+                    .await?
+            }
+            None => {
+                let from_station = self
+                    .station_repository
+                    .find_by_id(from_station_id)
+                    .await?
+                    .ok_or_else(|| UseCaseError::NotFound {
+                        entity_type: "station",
+                        entity_id: from_station_id.to_string(),
+                    })?;
+                self.get_stations_by_line_id(
+                    from_station.line_cd as u32,
+                    None,
+                    None,
+                    TransportTypeFilter::RailAndBus,
+                )
+                .await?
+            }
+        };
 
         let from_idx = stations
             .iter()
             .position(|s| s.station_cd as u32 == from_station_id)
             .ok_or_else(|| UseCaseError::NotFound {
-                entity_type: "station in line group",
+                entity_type: "station in route",
                 entity_id: from_station_id.to_string(),
             })?;
         let to_idx = stations
             .iter()
             .position(|s| s.station_cd as u32 == to_station_id)
             .ok_or_else(|| UseCaseError::NotFound {
-                entity_type: "station in line group",
+                entity_type: "station in route",
                 entity_id: to_station_id.to_string(),
             })?;
 

--- a/stationapi/src/use_case/traits/query.rs
+++ b/stationapi/src/use_case/traits/query.rs
@@ -115,7 +115,7 @@ pub trait QueryUseCase: Send + Sync + 'static {
         &self,
         from_station_id: u32,
         to_station_id: u32,
-        line_group_id: u32,
+        line_group_id: Option<u32>,
     ) -> Result<Vec<TrainRouteSegment>, UseCaseError>;
     async fn find_line_by_id(&self, line_id: u32) -> Result<Option<Line>, UseCaseError>;
     async fn get_lines_by_id_vec(&self, line_ids: &[u32]) -> Result<Vec<Line>, UseCaseError>;


### PR DESCRIPTION
## 概要

`GetTrainRouteRequest.line_group_id` は proto で `optional` と定義されているにもかかわらず、実装が未指定時に `INVALID_ARGUMENT (line_group_id is required)` を返していた乖離を解消する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- コントローラの `line_group_id is required` ガードを削除し、`Option<u32>` のまま use case へ渡すように変更
- `get_train_route`（trait / interactor / モック）のシグネチャを `line_group_id: Option<u32>` に変更
- `line_group_id` 未指定時は from 駅の所属路線（`line_cd`）の駅列にフォールバックし、種別なし（各駅停車・単一路線走行）の経路を返す。指定時は従来どおり line_group ベースの経路
- 経路スライス時の NotFound エラーの entity_type を両経路で共通の `station in route` に変更

## テスト

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

上記に加え、ローカルDBに対して実機確認済み: `line_group_id` なし（山手線 大崎→渋谷）で segments が正常返却、`line_group_id` あり（363）で従来どおり返却されることを grpcurl で確認。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 路線検索で、路線グループIDが未指定でもルートを取得できるようになりました。
  * 未指定時は出発駅の路線情報をもとに経路を判定し、より自然な検索結果を返します。
  * ルートに含まれない駅がある場合のエラー表示も、より適切な内容に改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->