### PR TITLE
新幹線の速度プロファイルが種別上限130km/hに引き下げられる問題を修正

### DIFF
--- a/stationapi/src/use_case/dto/simulation.rs
+++ b/stationapi/src/use_case/dto/simulation.rs
@@ -40,9 +40,12 @@ pub fn resolve_speed_profile(
         _ => (NORMAL_MAX_SPEED, 0.83, 0.69),
     };
 
+    // 種別による 130km/h は在来線の速達種別を底上げするための値。
+    // 新幹線(のぞみ等は kind=LimitedExpress)では路線種別の上限の方が速いため、
+    // 種別上限で引き下げない。
     let max_speed = match kind.and_then(|v| TrainTypeKind::try_from(v).ok()) {
         Some(TrainTypeKind::LimitedExpress) | Some(TrainTypeKind::HighSpeedRapid) => {
-            LIMITED_EXPRESS_KIND_MAX_SPEED
+            line_max_speed.max(LIMITED_EXPRESS_KIND_MAX_SPEED)
         }
         _ => line_max_speed,
     };
@@ -99,6 +102,20 @@ mod tests {
         assert_eq!(p.max_speed, LIMITED_EXPRESS_KIND_MAX_SPEED);
         assert_eq!(p.max_acceleration, 0.83);
         assert_eq!(p.max_deceleration, 0.69);
+    }
+
+    #[test]
+    fn limited_express_kind_does_not_slow_down_bullet_train() {
+        // のぞみ等は kind=LimitedExpress で登録されているが、
+        // 新幹線の路線上限(320km/h)を 130km/h に引き下げてはいけない。
+        let p = resolve_speed_profile(
+            Some(LineType::BulletTrain as i32),
+            false,
+            Some(TrainTypeKind::LimitedExpress as i32),
+        );
+        assert_eq!(p.max_speed, BULLET_TRAIN_MAX_SPEED);
+        assert_eq!(p.max_acceleration, 0.72);
+        assert_eq!(p.max_deceleration, 0.56);
     }
 
     #[test]

--- a/stationapi/src/use_case/dto/simulation.rs
+++ b/stationapi/src/use_case/dto/simulation.rs
@@ -17,7 +17,7 @@ const SUBWAY_MAX_SPEED: f64 = 22.222_222_222_22; // 80 km/h
 const NORMAL_MAX_SPEED: f64 = 25.0; // 90 km/h
 const TRAM_MAX_SPEED: f64 = 11.111_111_111_11; // 40 km/h
 
-const LIMITED_EXPRESS_KIND_MAX_SPEED: f64 = 36.111_111_111_1; // 130 km/h
+const LIMITED_EXPRESS_KIND_FLOOR_SPEED: f64 = 36.111_111_111_1; // 130 km/h
 
 pub fn resolve_speed_profile(
     line_type: Option<i32>,
@@ -40,12 +40,12 @@ pub fn resolve_speed_profile(
         _ => (NORMAL_MAX_SPEED, 0.83, 0.69),
     };
 
-    // 種別による 130km/h は在来線の速達種別を底上げするための値。
+    // 種別による 130km/h は在来線の速達種別を底上げするための下限値。
     // 新幹線(のぞみ等は kind=LimitedExpress)では路線種別の上限の方が速いため、
-    // 種別上限で引き下げない。
+    // 種別値で引き下げない。
     let max_speed = match kind.and_then(|v| TrainTypeKind::try_from(v).ok()) {
         Some(TrainTypeKind::LimitedExpress) | Some(TrainTypeKind::HighSpeedRapid) => {
-            line_max_speed.max(LIMITED_EXPRESS_KIND_MAX_SPEED)
+            line_max_speed.max(LIMITED_EXPRESS_KIND_FLOOR_SPEED)
         }
         _ => line_max_speed,
     };
@@ -93,13 +93,13 @@ mod tests {
     }
 
     #[test]
-    fn limited_express_kind_caps_speed_over_line_type() {
+    fn limited_express_kind_raises_speed_over_line_type() {
         let p = resolve_speed_profile(
             Some(LineType::Normal as i32),
             false,
             Some(TrainTypeKind::LimitedExpress as i32),
         );
-        assert_eq!(p.max_speed, LIMITED_EXPRESS_KIND_MAX_SPEED);
+        assert_eq!(p.max_speed, LIMITED_EXPRESS_KIND_FLOOR_SPEED);
         assert_eq!(p.max_acceleration, 0.83);
         assert_eq!(p.max_deceleration, 0.69);
     }
@@ -119,13 +119,13 @@ mod tests {
     }
 
     #[test]
-    fn high_speed_rapid_kind_caps_speed() {
+    fn high_speed_rapid_kind_raises_speed() {
         let p = resolve_speed_profile(
             Some(LineType::Normal as i32),
             false,
             Some(TrainTypeKind::HighSpeedRapid as i32),
         );
-        assert_eq!(p.max_speed, LIMITED_EXPRESS_KIND_MAX_SPEED);
+        assert_eq!(p.max_speed, LIMITED_EXPRESS_KIND_FLOOR_SPEED);
     }
 
     #[test]


### PR DESCRIPTION
## 概要

TrainRoute の新幹線区間(例: 東海道新幹線のぞみ 新横浜→名古屋)で最高速度が大幅に過小になる問題を修正しました。のぞみ等の新幹線種別は `kind=LimitedExpress` で登録されているため、`resolve_speed_profile` が路線種別 BulletTrain の 320km/h ではなく種別上限の 130km/h を返してしまっていました。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `resolve_speed_profile` の種別上限(LimitedExpress / HighSpeedRapid → 130km/h)を、路線種別上限との `max` に変更。種別上限は在来線の速達種別を底上げするための値であり、新幹線(320km/h)を引き下げないようにした
- 新幹線 + LimitedExpress 種別で 320km/h が維持されることを確認する回帰テストを追加

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`(`SQLX_OFFLINE=true`)が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット(任意)

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDYiyztD7z8FmDUCEqUHBt

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDYiyztD7z8FmDUCEqUHBt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 特急・高速快速の最高速度判定を見直し、路線本来の上限と種別下限（床）の高い方が反映されるよう修正しました。
  * 新幹線では、列車種別の上限により不要に速度が引き下げられないようになりました。
* **Tests**
  * 上限の期待値（引き上げ／引き下げ有無）に合わせてテストを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->