### PR TITLE
GetTrainRouteの仕様変更・クエリ性能改善・新幹線速度プロファイル修正をmasterへ反映

### DIFF
--- a/stationapi/src/domain/arrival_estimation.rs
+++ b/stationapi/src/domain/arrival_estimation.rs
@@ -626,8 +626,10 @@ mod tests {
 
     #[test]
     fn run_margin_scales_run_time_but_not_dwell() {
-        let mut p = EstimationParams::default();
-        p.run_margin = 1.0;
+        let mut p = EstimationParams {
+            run_margin: 1.0,
+            ..Default::default()
+        };
         let base = segment_run_minutes(5_000.0, 80.0, &p);
         p.run_margin = 1.15;
         let with_margin = segment_run_minutes(5_000.0, 80.0, &p);
@@ -838,7 +840,7 @@ mod tests {
         // 実乗車時間(5〜6分)より大幅に長い約 6.9 分と推定されてしまう。
         let a = station(1, 11341, 36.326849, 139.193704, Some(4866.8));
         let b = station(2, 11341, 36.359018, 139.242463, Some(4866.8));
-        let stations = vec![a, b];
+        let stations = [a, b];
         let refs: Vec<&Station> = stations.iter().collect();
         let est = estimate_arrival_minutes(&refs, &p);
 
@@ -924,7 +926,7 @@ mod tests {
         let p = EstimationParams::default();
         // 停留所間隔 3km の直行区間。地下鉄扱い(75km/h × 1.2 = 90km/h)のままだと
         // 約 3.4 分と過小評価される。バス上限 50km/h では約 5.7 分。
-        let stations = vec![
+        let stations = [
             bus_station(1, 100_000_001, 35.72, 139.69),
             bus_station(2, 100_000_001, 35.747, 139.69), // 0.027 度 ≈ 3km
         ];
@@ -944,7 +946,7 @@ mod tests {
             let mut b = bus_station(2, 100_000_001, 35.747, 139.69);
             a.kind = kind;
             b.kind = kind;
-            let stations = vec![a, b];
+            let stations = [a, b];
             let refs: Vec<&Station> = stations.iter().collect();
             estimate_arrival_minutes(&refs, &p)[1].cumulative_minutes
         };

--- a/stationapi/src/domain/entity/line.rs
+++ b/stationapi/src/domain/entity/line.rs
@@ -389,7 +389,7 @@ mod tests {
             None,
             None,
             None,
-            symbols.clone(),
+            symbols,
             Some("JY".to_string()),
             Some("JR".to_string()),
             None,

--- a/stationapi/src/domain/ipa.rs
+++ b/stationapi/src/domain/ipa.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{LazyLock, RwLock};
+use std::sync::{Arc, LazyLock, RwLock};
 
 /// Cached IPA computation result for a single name.
 #[derive(Clone, Debug)]
@@ -11,10 +11,10 @@ pub struct IpaResult {
 
 type IpaCacheKey = (String, Option<String>);
 
-static STATION_IPA_CACHE: LazyLock<RwLock<HashMap<IpaCacheKey, IpaResult>>> =
+static STATION_IPA_CACHE: LazyLock<RwLock<HashMap<IpaCacheKey, Arc<IpaResult>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
-static LINE_IPA_CACHE: LazyLock<RwLock<HashMap<IpaCacheKey, IpaResult>>> =
+static LINE_IPA_CACHE: LazyLock<RwLock<HashMap<IpaCacheKey, Arc<IpaResult>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
 /// Compute all three IPA outputs in a single pass, eliminating the redundant
@@ -45,22 +45,26 @@ fn compute_line_ipa(name_katakana: &str, name_roman: Option<&str>) -> IpaResult 
 }
 
 fn cached_lookup(
-    cache: &LazyLock<RwLock<HashMap<IpaCacheKey, IpaResult>>>,
+    cache: &LazyLock<RwLock<HashMap<IpaCacheKey, Arc<IpaResult>>>>,
     key: &IpaCacheKey,
     compute: impl FnOnce() -> IpaResult,
-) -> IpaResult {
+) -> Arc<IpaResult> {
     // Fast path: read lock
     if let Some(result) = cache.read().unwrap().get(key) {
-        return result.clone();
+        return Arc::clone(result);
     }
     // Slow path: compute and insert
-    let result = compute();
-    cache.write().unwrap().insert(key.clone(), result.clone());
+    let result = Arc::new(compute());
+    cache
+        .write()
+        .unwrap()
+        .insert(key.clone(), Arc::clone(&result));
     result
 }
 
 /// Compute IPA for station/train-type names with memoization.
-pub fn compute_ipa_cached(name_katakana: &str, name_roman: Option<&str>) -> IpaResult {
+/// Arcで返すことでキャッシュヒット時にTTSセグメントのディープクローンを避ける。
+pub fn compute_ipa_cached(name_katakana: &str, name_roman: Option<&str>) -> Arc<IpaResult> {
     let key = (name_katakana.to_string(), name_roman.map(str::to_string));
     cached_lookup(&STATION_IPA_CACHE, &key, || {
         compute_ipa(name_katakana, name_roman)
@@ -68,7 +72,8 @@ pub fn compute_ipa_cached(name_katakana: &str, name_roman: Option<&str>) -> IpaR
 }
 
 /// Compute IPA for line names (with suffix replacement) with memoization.
-pub fn compute_line_ipa_cached(name_katakana: &str, name_roman: Option<&str>) -> IpaResult {
+/// Arcで返すことでキャッシュヒット時にTTSセグメントのディープクローンを避ける。
+pub fn compute_line_ipa_cached(name_katakana: &str, name_roman: Option<&str>) -> Arc<IpaResult> {
     let key = (name_katakana.to_string(), name_roman.map(str::to_string));
     cached_lookup(&LINE_IPA_CACHE, &key, || {
         compute_line_ipa(name_katakana, name_roman)

--- a/stationapi/src/domain/repository/line_repository.rs
+++ b/stationapi/src/domain/repository/line_repository.rs
@@ -129,7 +129,7 @@ mod tests {
             let keihin_line = Line::new(
                 11303,
                 1,
-                Some(company_jr_east.clone()),
+                Some(company_jr_east),
                 "京浜東北線".to_string(),
                 "ケイヒントウホクセン".to_string(),
                 "京浜東北線".to_string(),
@@ -176,8 +176,8 @@ mod tests {
             lines_by_line_group_id.insert(1, vec![yamanote_line.clone()]);
             lines_by_line_group_id.insert(2, vec![keihin_line.clone()]);
 
-            lines_by_name.insert("山手線".to_string(), vec![yamanote_line.clone()]);
-            lines_by_name.insert("京浜東北線".to_string(), vec![keihin_line.clone()]);
+            lines_by_name.insert("山手線".to_string(), vec![yamanote_line]);
+            lines_by_name.insert("京浜東北線".to_string(), vec![keihin_line]);
 
             Self {
                 lines,

--- a/stationapi/src/domain/repository/station_repository.rs
+++ b/stationapi/src/domain/repository/station_repository.rs
@@ -207,7 +207,7 @@ mod tests {
                 .filter(|station| {
                     transport_type
                         .as_ref()
-                        .map_or(true, |tt| station.transport_type == *tt)
+                        .is_none_or(|tt| station.transport_type == *tt)
                 })
                 .map(|station| {
                     let mut s = station.clone();
@@ -261,7 +261,7 @@ mod tests {
                     station.station_name.contains(&station_name)
                         && transport_type
                             .as_ref()
-                            .map_or(true, |tt| station.transport_type == *tt)
+                            .is_none_or(|tt| station.transport_type == *tt)
                 })
                 .cloned()
                 .collect();
@@ -317,8 +317,7 @@ mod tests {
 
             if !via_line_ids.is_empty() {
                 let line_match = |s: &Station| via_line_ids.contains(&(s.line_cd as u32));
-                if !from_station.map_or(false, line_match) || !to_station.map_or(false, line_match)
-                {
+                if !from_station.is_some_and(line_match) || !to_station.is_some_and(line_match) {
                     return Ok(result);
                 }
             }

--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -38,6 +38,55 @@ type StopTimeBatchRow = (
     Option<i32>,
 );
 
+/// 検索性能に直結するインデックス。create_table.sql内のDOブロックは
+/// 拡張が使えない環境向けに例外をNOTICEで握り潰すため、作成に失敗しても
+/// 起動ログからは分からない(実際に稼働DBでtrigramインデックスだけが
+/// 欠落する事例があった)。必要な拡張はcreate_schemaの冒頭で必須として
+/// 作成しているので、ここに列挙したインデックスは明示的に作成し直し、
+/// 欠落があればERRORログで可視化する。
+const PERFORMANCE_INDEXES: &[(&str, &str)] = &[
+    (
+        "idx_performance_stations_point",
+        "CREATE INDEX IF NOT EXISTS idx_performance_stations_point ON public.stations USING gist ((point(lat, lon)))",
+    ),
+    (
+        "idx_performance_stations_bus_point",
+        "CREATE INDEX IF NOT EXISTS idx_performance_stations_bus_point ON public.stations USING gist ((point(lat, lon))) WHERE e_status = 0 AND transport_type = 1",
+    ),
+    (
+        "idx_performance_station_name_trgm",
+        "CREATE INDEX IF NOT EXISTS idx_performance_station_name_trgm ON public.stations USING gin (station_name gin_trgm_ops)",
+    ),
+    (
+        "idx_performance_station_name_k_trgm",
+        "CREATE INDEX IF NOT EXISTS idx_performance_station_name_k_trgm ON public.stations USING gin (station_name_k gin_trgm_ops)",
+    ),
+    (
+        "idx_performance_station_name_rn_trgm",
+        "CREATE INDEX IF NOT EXISTS idx_performance_station_name_rn_trgm ON public.stations USING gin (station_name_rn gin_trgm_ops)",
+    ),
+    (
+        "idx_performance_station_name_zh_trgm",
+        "CREATE INDEX IF NOT EXISTS idx_performance_station_name_zh_trgm ON public.stations USING gin (station_name_zh gin_trgm_ops)",
+    ),
+    (
+        "idx_performance_station_name_ko_trgm",
+        "CREATE INDEX IF NOT EXISTS idx_performance_station_name_ko_trgm ON public.stations USING gin (station_name_ko gin_trgm_ops)",
+    ),
+    (
+        "idx_gtfs_stops_point",
+        "CREATE INDEX IF NOT EXISTS idx_gtfs_stops_point ON public.gtfs_stops USING gist ((point(stop_lat, stop_lon)))",
+    ),
+    (
+        "idx_gtfs_stops_name_trgm",
+        "CREATE INDEX IF NOT EXISTS idx_gtfs_stops_name_trgm ON public.gtfs_stops USING gin (stop_name gin_trgm_ops)",
+    ),
+    (
+        "idx_gtfs_stops_name_k_trgm",
+        "CREATE INDEX IF NOT EXISTS idx_gtfs_stops_name_k_trgm ON public.gtfs_stops USING gin (stop_name_k gin_trgm_ops)",
+    ),
+];
+
 /// Create required extensions and tables before running data imports.
 /// Must be called before `import_csv` and `import_gtfs` can run in parallel.
 pub async fn create_schema() -> Result<(), Box<dyn std::error::Error>> {
@@ -61,7 +110,39 @@ pub async fn create_schema() -> Result<(), Box<dyn std::error::Error>> {
     let create_sql: String = String::from_utf8_lossy(&create_sql_content).parse()?;
     sqlx::raw_sql(&create_sql).execute(&mut conn).await?;
 
-    info!("Schema creation completed.");
+    for (name, ddl) in PERFORMANCE_INDEXES {
+        if let Err(e) = sqlx::query(ddl).execute(&mut conn).await {
+            tracing::error!("Failed to create performance index {}: {}", name, e);
+        }
+    }
+
+    // 作成結果を検証し、欠落があれば起動ログに残す
+    let expected: Vec<String> = PERFORMANCE_INDEXES
+        .iter()
+        .map(|(name, _)| name.to_string())
+        .collect();
+    let existing: Vec<String> = sqlx::query_scalar::<_, String>(
+        "SELECT indexname FROM pg_indexes WHERE indexname = ANY($1)",
+    )
+    .bind(&expected)
+    .fetch_all(&mut conn)
+    .await?;
+    let missing: Vec<&str> = PERFORMANCE_INDEXES
+        .iter()
+        .map(|(name, _)| *name)
+        .filter(|name| !existing.iter().any(|e| e == name))
+        .collect();
+    if missing.is_empty() {
+        info!(
+            "Schema creation completed. All {} performance indexes are present.",
+            expected.len()
+        );
+    } else {
+        tracing::error!(
+            "Schema creation completed, but performance indexes are missing: {:?}",
+            missing
+        );
+    }
 
     Ok(())
 }

--- a/stationapi/src/presentation/controller/grpc.rs
+++ b/stationapi/src/presentation/controller/grpc.rs
@@ -432,8 +432,8 @@ impl StationApi for MyApi {
         request: tonic::Request<GetTrainRouteRequest>,
     ) -> Result<tonic::Response<TrainRouteResponse>, tonic::Status> {
         let req = request.get_ref();
-        let from_id = req.from_station_group_id;
-        let to_id = req.to_station_group_id;
+        let from_id = req.from_station_id;
+        let to_id = req.to_station_id;
         let line_group_id = req
             .line_group_id
             .ok_or_else(|| tonic::Status::invalid_argument("line_group_id is required"))?;
@@ -907,8 +907,8 @@ mod tests {
 
         async fn get_train_route(
             &self,
-            _from_station_group_id: u32,
-            _to_station_group_id: u32,
+            _from_station_id: u32,
+            _to_station_id: u32,
             _line_group_id: u32,
         ) -> Result<Vec<crate::proto::TrainRouteSegment>, UseCaseError> {
             Ok(vec![])

--- a/stationapi/src/presentation/controller/grpc.rs
+++ b/stationapi/src/presentation/controller/grpc.rs
@@ -434,9 +434,7 @@ impl StationApi for MyApi {
         let req = request.get_ref();
         let from_id = req.from_station_id;
         let to_id = req.to_station_id;
-        let line_group_id = req
-            .line_group_id
-            .ok_or_else(|| tonic::Status::invalid_argument("line_group_id is required"))?;
+        let line_group_id = req.line_group_id;
 
         match self
             .query_use_case
@@ -909,7 +907,7 @@ mod tests {
             &self,
             _from_station_id: u32,
             _to_station_id: u32,
-            _line_group_id: u32,
+            _line_group_id: Option<u32>,
         ) -> Result<Vec<crate::proto::TrainRouteSegment>, UseCaseError> {
             Ok(vec![])
         }

--- a/stationapi/src/presentation/controller/grpc.rs
+++ b/stationapi/src/presentation/controller/grpc.rs
@@ -589,14 +589,11 @@ mod tests {
         }
 
         fn get_captured_coordinates_transport_type(&self) -> Option<TransportTypeFilter> {
-            self.captured_coordinates_transport_type
-                .lock()
-                .unwrap()
-                .clone()
+            *self.captured_coordinates_transport_type.lock().unwrap()
         }
 
         fn get_captured_name_transport_type(&self) -> Option<TransportTypeFilter> {
-            self.captured_name_transport_type.lock().unwrap().clone()
+            *self.captured_name_transport_type.lock().unwrap()
         }
     }
 

--- a/stationapi/src/use_case/dto/line.rs
+++ b/stationapi/src/use_case/dto/line.rs
@@ -10,9 +10,9 @@ use crate::{
 impl From<Line> for GrpcLine {
     fn from(line: Line) -> Self {
         let ipa = compute_line_ipa_cached(&line.line_name_k, line.line_name_r.as_deref());
-        let name_ipa = ipa.name_ipa;
-        let name_roman_ipa = ipa.name_roman_ipa;
-        let name_tts_segments = to_proto_tts_segments(ipa.tts_segments);
+        let name_ipa = ipa.name_ipa.clone();
+        let name_roman_ipa = ipa.name_roman_ipa.clone();
+        let name_tts_segments = to_proto_tts_segments(&ipa.tts_segments);
         // バス路線の場合は line_type を OtherLineType (0) に強制
         // (鉄道用の line_type が誤って設定されている可能性があるため)
         let line_type = if line.transport_type == TransportType::Bus {

--- a/stationapi/src/use_case/dto/simulation.rs
+++ b/stationapi/src/use_case/dto/simulation.rs
@@ -17,7 +17,7 @@ const SUBWAY_MAX_SPEED: f64 = 22.222_222_222_22; // 80 km/h
 const NORMAL_MAX_SPEED: f64 = 25.0; // 90 km/h
 const TRAM_MAX_SPEED: f64 = 11.111_111_111_11; // 40 km/h
 
-const LIMITED_EXPRESS_KIND_MAX_SPEED: f64 = 36.111_111_111_1; // 130 km/h
+const LIMITED_EXPRESS_KIND_FLOOR_SPEED: f64 = 36.111_111_111_1; // 130 km/h
 
 pub fn resolve_speed_profile(
     line_type: Option<i32>,
@@ -40,9 +40,12 @@ pub fn resolve_speed_profile(
         _ => (NORMAL_MAX_SPEED, 0.83, 0.69),
     };
 
+    // 種別による 130km/h は在来線の速達種別を底上げするための下限値。
+    // 新幹線(のぞみ等は kind=LimitedExpress)では路線種別の上限の方が速いため、
+    // 種別値で引き下げない。
     let max_speed = match kind.and_then(|v| TrainTypeKind::try_from(v).ok()) {
         Some(TrainTypeKind::LimitedExpress) | Some(TrainTypeKind::HighSpeedRapid) => {
-            LIMITED_EXPRESS_KIND_MAX_SPEED
+            line_max_speed.max(LIMITED_EXPRESS_KIND_FLOOR_SPEED)
         }
         _ => line_max_speed,
     };
@@ -90,25 +93,39 @@ mod tests {
     }
 
     #[test]
-    fn limited_express_kind_caps_speed_over_line_type() {
+    fn limited_express_kind_raises_speed_over_line_type() {
         let p = resolve_speed_profile(
             Some(LineType::Normal as i32),
             false,
             Some(TrainTypeKind::LimitedExpress as i32),
         );
-        assert_eq!(p.max_speed, LIMITED_EXPRESS_KIND_MAX_SPEED);
+        assert_eq!(p.max_speed, LIMITED_EXPRESS_KIND_FLOOR_SPEED);
         assert_eq!(p.max_acceleration, 0.83);
         assert_eq!(p.max_deceleration, 0.69);
     }
 
     #[test]
-    fn high_speed_rapid_kind_caps_speed() {
+    fn limited_express_kind_does_not_slow_down_bullet_train() {
+        // のぞみ等は kind=LimitedExpress で登録されているが、
+        // 新幹線の路線上限(320km/h)を 130km/h に引き下げてはいけない。
+        let p = resolve_speed_profile(
+            Some(LineType::BulletTrain as i32),
+            false,
+            Some(TrainTypeKind::LimitedExpress as i32),
+        );
+        assert_eq!(p.max_speed, BULLET_TRAIN_MAX_SPEED);
+        assert_eq!(p.max_acceleration, 0.72);
+        assert_eq!(p.max_deceleration, 0.56);
+    }
+
+    #[test]
+    fn high_speed_rapid_kind_raises_speed() {
         let p = resolve_speed_profile(
             Some(LineType::Normal as i32),
             false,
             Some(TrainTypeKind::HighSpeedRapid as i32),
         );
-        assert_eq!(p.max_speed, LIMITED_EXPRESS_KIND_MAX_SPEED);
+        assert_eq!(p.max_speed, LIMITED_EXPRESS_KIND_FLOOR_SPEED);
     }
 
     #[test]

--- a/stationapi/src/use_case/dto/station.rs
+++ b/stationapi/src/use_case/dto/station.rs
@@ -19,9 +19,9 @@ impl From<TransportType> for i32 {
 impl From<Station> for GrpcStation {
     fn from(station: Station) -> Self {
         let ipa = compute_ipa_cached(&station.station_name_k, station.station_name_r.as_deref());
-        let name_ipa = ipa.name_ipa;
-        let name_roman_ipa = ipa.name_roman_ipa;
-        let name_tts_segments = to_proto_tts_segments(ipa.tts_segments);
+        let name_ipa = ipa.name_ipa.clone();
+        let name_roman_ipa = ipa.name_roman_ipa.clone();
+        let name_tts_segments = to_proto_tts_segments(&ipa.tts_segments);
         Self {
             id: station.station_cd as u32,
             group_id: station.station_g_cd as u32,

--- a/stationapi/src/use_case/dto/train_type.rs
+++ b/stationapi/src/use_case/dto/train_type.rs
@@ -24,9 +24,9 @@ impl From<TrainType> for GrpcTrainType {
             kind,
         } = train_type;
         let ipa = compute_ipa_cached(&type_name_k, type_name_r.as_deref());
-        let name_ipa = ipa.name_ipa;
-        let name_roman_ipa = ipa.name_roman_ipa;
-        let name_tts_segments = to_proto_tts_segments(ipa.tts_segments);
+        let name_ipa = ipa.name_ipa.clone();
+        let name_roman_ipa = ipa.name_roman_ipa.clone();
+        let name_tts_segments = to_proto_tts_segments(&ipa.tts_segments);
         Self {
             id: id.map(|id| id as u32).unwrap_or(0),
             type_id: type_cd.map(|id| id as u32).unwrap_or(0),

--- a/stationapi/src/use_case/dto/tts.rs
+++ b/stationapi/src/use_case/dto/tts.rs
@@ -3,20 +3,20 @@ use crate::{
     proto::{TtsAlphabet, TtsSegment},
 };
 
-pub fn to_proto_tts_segments(segments: Vec<TtsNameSegment>) -> Vec<TtsSegment> {
+pub fn to_proto_tts_segments(segments: &[TtsNameSegment]) -> Vec<TtsSegment> {
     segments
-        .into_iter()
+        .iter()
         .map(|segment| TtsSegment {
-            surface: segment.surface,
-            fallback_text: segment.fallback_text,
-            pronunciation: segment.pronunciation,
+            surface: segment.surface.clone(),
+            fallback_text: segment.fallback_text.clone(),
+            pronunciation: segment.pronunciation.clone(),
             alphabet: match segment.alphabet {
                 TtsAlphabetKind::Ipa => TtsAlphabet::Ipa as i32,
                 TtsAlphabetKind::Yomigana => TtsAlphabet::Yomigana as i32,
                 TtsAlphabetKind::Plain => TtsAlphabet::Plain as i32,
             },
             lang: segment.lang.to_string(),
-            separator: segment.separator,
+            separator: segment.separator.clone(),
         })
         .collect()
 }

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -1002,24 +1002,46 @@ where
         &self,
         from_station_id: u32,
         to_station_id: u32,
-        line_group_id: u32,
+        line_group_id: Option<u32>,
     ) -> Result<Vec<proto::TrainRouteSegment>, UseCaseError> {
-        let stations = self
-            .get_stations_by_line_group_id(line_group_id, TransportTypeFilter::RailAndBus)
-            .await?;
+        // line_group_id 未指定は種別なし(各駅停車)の単一路線走行。
+        // from駅の所属路線の駅列をそのまま経路として扱う。
+        let stations = match line_group_id {
+            Some(line_group_id) => {
+                self.get_stations_by_line_group_id(line_group_id, TransportTypeFilter::RailAndBus)
+                    .await?
+            }
+            None => {
+                let from_station = self
+                    .station_repository
+                    .find_by_id(from_station_id)
+                    .await?
+                    .ok_or_else(|| UseCaseError::NotFound {
+                        entity_type: "station",
+                        entity_id: from_station_id.to_string(),
+                    })?;
+                self.get_stations_by_line_id(
+                    from_station.line_cd as u32,
+                    None,
+                    None,
+                    TransportTypeFilter::RailAndBus,
+                )
+                .await?
+            }
+        };
 
         let from_idx = stations
             .iter()
             .position(|s| s.station_cd as u32 == from_station_id)
             .ok_or_else(|| UseCaseError::NotFound {
-                entity_type: "station in line group",
+                entity_type: "station in route",
                 entity_id: from_station_id.to_string(),
             })?;
         let to_idx = stations
             .iter()
             .position(|s| s.station_cd as u32 == to_station_id)
             .ok_or_else(|| UseCaseError::NotFound {
-                entity_type: "station in line group",
+                entity_type: "station in route",
                 entity_id: to_station_id.to_string(),
             })?;
 

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -637,27 +637,75 @@ where
 
         let route_row_tree_map = self.build_route_tree_map(&stops);
 
-        let mut routes: Vec<Route> = Vec::new();
+        // TODO: SQLで同等の処理を行う
+        // 発着駅を含まない経路候補はレスポンスに含まれないため、
+        // 路線の取得やproto変換を行う前にここで除外する
+        let route_groups: Vec<(&i32, &Vec<&Station>)> = route_row_tree_map
+            .iter()
+            .filter(|(_, stops)| {
+                stops.iter().any(|row| {
+                    row.station_g_cd as u32 == from_station_id
+                        || row.station_g_cd as u32 == to_station_id
+                })
+            })
+            .collect();
 
-        for (id, stops) in route_row_tree_map.iter() {
-            let line_group_id_vec = stops
-                .iter()
-                .filter_map(|row| row.line_group_cd.map(|id| id as u32))
-                .collect::<Vec<u32>>();
+        // 経路候補ごとに個別クエリを発行せず、全line_group_cdの路線を一括取得する
+        let line_group_id_vec: Vec<u32> = route_groups
+            .iter()
+            .flat_map(|(_, stops)| {
+                stops
+                    .iter()
+                    .filter_map(|row| row.line_group_cd.map(|id| id as u32))
+            })
+            .collect::<HashSet<u32>>()
+            .into_iter()
+            .collect();
 
-            let mut tt_lines = self
-                .line_repository
-                .get_by_line_group_id_vec_for_routes(&line_group_id_vec)
-                .await?;
+        let mut all_tt_lines = self
+            .line_repository
+            .get_by_line_group_id_vec_for_routes(&line_group_id_vec)
+            .await?;
 
-            // Add line_symbols to all lines first
-            for line in tt_lines.iter_mut() {
-                line.line_symbols = self.get_line_symbols(line);
+        // Add line_symbols to all lines first
+        for line in all_tt_lines.iter_mut() {
+            line.line_symbols = self.get_line_symbols(line);
+        }
+
+        // line_group_cdごとにパーティションする。クエリはsst.id順で返すため、
+        // グループ内の相対順序は単発取得した場合と変わらない
+        let mut tt_lines_by_group: std::collections::HashMap<i32, Vec<&Line>> =
+            std::collections::HashMap::new();
+        for line in &all_tt_lines {
+            if let Some(lgc) = line.line_group_cd {
+                tt_lines_by_group.entry(lgc).or_default().push(line);
             }
+        }
+
+        let mut routes: Vec<Route> = Vec::with_capacity(route_groups.len());
+
+        for (id, stops) in route_groups {
+            let tt_lines: &[&Line] = stops
+                .iter()
+                .find_map(|row| row.line_group_cd)
+                .and_then(|lgc| tt_lines_by_group.get(&lgc))
+                .map(|lines| lines.as_slice())
+                .unwrap_or(&[]);
 
             // Build HashMap for O(1) line lookup by line_cd instead of O(n) linear search
             let tt_line_map: std::collections::HashMap<i32, &Line> =
-                tt_lines.iter().map(|line| (line.line_cd, line)).collect();
+                tt_lines.iter().map(|line| (line.line_cd, *line)).collect();
+
+            // Filter lines to only include those with matching line_group_cd
+            // and remove duplicates by line_cd.
+            // グループ内の停車駅はline_group_cdを共有するため、TrainTypeに
+            // 埋め込むlinesは停車駅ごとではなくグループごとに一度だけ構築する
+            let mut seen_line_cds = std::collections::HashSet::new();
+            let group_filtered_lines: Vec<Line> = tt_lines
+                .iter()
+                .filter(|line| seen_line_cds.insert(line.line_cd))
+                .map(|&line| line.clone())
+                .collect();
 
             let stops = stops
                 .iter()
@@ -667,18 +715,10 @@ where
                     if let Some(tt_line) = tt_line_map.get(&row.line_cd).copied() {
                         let train_type = match row.type_id.is_some() {
                             true => {
-                                // Filter lines to only include those with matching line_group_cd
-                                // and remove duplicates by line_cd
-                                let mut seen_line_cds = std::collections::HashSet::new();
-                                let filtered_lines: Vec<Line> = tt_lines
-                                    .iter()
-                                    .filter(|line| {
-                                        row.line_group_cd.is_some()
-                                            && line.line_group_cd == row.line_group_cd
-                                            && seen_line_cds.insert(line.line_cd)
-                                    })
-                                    .cloned()
-                                    .collect();
+                                let filtered_lines = match row.line_group_cd.is_some() {
+                                    true => group_filtered_lines.clone(),
+                                    false => vec![],
+                                };
 
                                 Some(Box::new(TrainType {
                                     id: row.type_id,
@@ -711,14 +751,6 @@ where
                     stop.into()
                 })
                 .collect::<Vec<proto::Station>>();
-
-            // TODO: SQLで同等の処理を行う
-            let includes_requested_station = stops
-                .iter()
-                .any(|stop| stop.group_id == from_station_id || stop.group_id == to_station_id);
-            if !includes_requested_station {
-                continue;
-            }
 
             routes.push(Route {
                 id: *id as u32,
@@ -800,10 +832,10 @@ where
                         &row.station_name_k,
                         row.station_name_r.as_deref(),
                     );
-                    let name_ipa = ipa.name_ipa;
-                    let name_roman_ipa = ipa.name_roman_ipa;
+                    let name_ipa = ipa.name_ipa.clone();
+                    let name_roman_ipa = ipa.name_roman_ipa.clone();
                     let name_tts_segments =
-                        crate::use_case::dto::tts::to_proto_tts_segments(ipa.tts_segments);
+                        crate::use_case::dto::tts::to_proto_tts_segments(&ipa.tts_segments);
                     proto::StationMinimal {
                         id: row.station_cd as u32,
                         group_id: row.station_g_cd as u32,
@@ -1329,7 +1361,10 @@ where
             .collect::<Vec<u32>>();
 
         // Collect company IDs from rail lines
+        // 路線ごとに重複した会社IDをそのままIN句に並べないよう先に一意化する
         let mut company_ids: Vec<u32> = lines.iter().map(|l| l.company_cd as u32).collect();
+        company_ids.sort_unstable();
+        company_ids.dedup();
 
         // Phase 2: dependent queries in parallel
         // Fetch companies, train types, and all bus lines in one batch
@@ -1516,8 +1551,6 @@ where
                     line.station = Some(station_copy);
                 }
             }
-            let station_numbers: Vec<StationNumber> = self.get_station_numbers(station);
-            station.station_numbers = station_numbers;
             station.lines = station_lines;
         }
 
@@ -4356,6 +4389,368 @@ mod tests {
         #[test]
         fn test_rail_and_bus_filter_returns_none() {
             assert_eq!(filter_to_db_type(TransportTypeFilter::RailAndBus), None);
+        }
+    }
+
+    // ========================================
+    // get_routes tests
+    // ========================================
+
+    mod get_routes_tests {
+        use super::*;
+        use crate::domain::{
+            entity::company::Company,
+            error::DomainError,
+            repository::{
+                company_repository::CompanyRepository, line_repository::LineRepository,
+                station_repository::StationRepository, train_type_repository::TrainTypeRepository,
+            },
+        };
+        use crate::use_case::traits::query::QueryUseCase;
+        use std::sync::Mutex;
+
+        struct RouteMockStationRepository {
+            stops: Vec<Station>,
+        }
+
+        #[async_trait::async_trait]
+        impl StationRepository for RouteMockStationRepository {
+            async fn get_route_stops(
+                &self,
+                _: u32,
+                _: u32,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(self.stops.clone())
+            }
+            async fn find_by_id(&self, _: u32) -> Result<Option<Station>, DomainError> {
+                Ok(None)
+            }
+            async fn get_by_id_vec(&self, _: &[u32]) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_id(
+                &self,
+                _: u32,
+                _: Option<u32>,
+                _: Option<u32>,
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_id_vec(&self, _: &[u32]) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_id_vec_with_group_stations(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id(&self, _: u32) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id_vec_no_types(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_coordinates(
+                &self,
+                _: f64,
+                _: f64,
+                _: Option<u32>,
+                _: Option<TransportType>,
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_bus_stops_near_stations(
+                &self,
+                _: &[(u32, f64, f64)],
+                _: u32,
+            ) -> Result<Vec<(u32, Station)>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_name(
+                &self,
+                _: String,
+                _: Option<u32>,
+                _: Option<u32>,
+                _: Option<TransportType>,
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_group_id(&self, _: u32) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Station>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_route_stops_by_station_cd(
+                &self,
+                from: u32,
+                to: u32,
+                via: &[u32],
+                _direction_id: Option<u32>,
+            ) -> Result<Vec<Station>, DomainError> {
+                self.get_route_stops(from, to, via).await
+            }
+        }
+
+        /// `get_by_line_group_id_vec_for_routes`の呼び出し引数を記録し、
+        /// 要求されたline_group_cdに属する路線だけを返すモック
+        struct RouteMockLineRepository {
+            lines: Vec<Line>,
+            for_routes_calls: Mutex<Vec<Vec<u32>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl LineRepository for RouteMockLineRepository {
+            async fn get_by_line_group_id_vec_for_routes(
+                &self,
+                line_group_id_vec: &[u32],
+            ) -> Result<Vec<Line>, DomainError> {
+                self.for_routes_calls
+                    .lock()
+                    .unwrap()
+                    .push(line_group_id_vec.to_vec());
+                Ok(self
+                    .lines
+                    .iter()
+                    .filter(|line| {
+                        line.line_group_cd
+                            .is_some_and(|lgc| line_group_id_vec.contains(&(lgc as u32)))
+                    })
+                    .cloned()
+                    .collect())
+            }
+            async fn get_by_line_group_id_vec(&self, _: &[u32]) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn find_by_id(&self, _: u32) -> Result<Option<Line>, DomainError> {
+                Ok(None)
+            }
+            async fn find_by_station_id(&self, _: u32) -> Result<Option<Line>, DomainError> {
+                Ok(None)
+            }
+            async fn get_by_ids(&self, _: &[u32]) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_name(
+                &self,
+                _: String,
+                _: Option<u32>,
+            ) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_line_group_id(&self, _: u32) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id(&self, _: u32) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_group_id_vec_no_types(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<Line>, DomainError> {
+                Ok(vec![])
+            }
+        }
+
+        struct RouteMockTrainTypeRepository;
+
+        #[async_trait::async_trait]
+        impl TrainTypeRepository for RouteMockTrainTypeRepository {
+            async fn get_by_line_group_id_vec(
+                &self,
+                _: &[u32],
+            ) -> Result<Vec<TrainType>, DomainError> {
+                Ok(vec![])
+            }
+            async fn find_by_line_group_id_and_line_id(
+                &self,
+                _: u32,
+                _: u32,
+            ) -> Result<Option<TrainType>, DomainError> {
+                Ok(None)
+            }
+            async fn find_by_line_group_id_and_line_id_vec(
+                &self,
+                _: &[(u32, u32)],
+            ) -> Result<std::collections::HashMap<(u32, u32), TrainType>, DomainError> {
+                Ok(std::collections::HashMap::new())
+            }
+            async fn get_by_line_group_id(&self, _: u32) -> Result<Vec<TrainType>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_id(&self, _: u32) -> Result<Vec<TrainType>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_by_station_id_vec(
+                &self,
+                _: &[u32],
+                _: Option<u32>,
+            ) -> Result<Vec<TrainType>, DomainError> {
+                Ok(vec![])
+            }
+            async fn get_types_by_station_id_vec(
+                &self,
+                _: &[u32],
+                _: Option<u32>,
+            ) -> Result<Vec<TrainType>, DomainError> {
+                Ok(vec![])
+            }
+        }
+
+        struct RouteMockCompanyRepository;
+
+        #[async_trait::async_trait]
+        impl CompanyRepository for RouteMockCompanyRepository {
+            async fn find_by_id_vec(&self, _: &[u32]) -> Result<Vec<Company>, DomainError> {
+                Ok(vec![])
+            }
+        }
+
+        /// 経路検索の停車駅行を作る。line_group_cdがある行は種別付き
+        /// (type_idあり)として扱われる
+        fn create_route_stop(
+            station_cd: i32,
+            station_g_cd: i32,
+            line_cd: i32,
+            line_group_cd: Option<i32>,
+        ) -> Station {
+            let mut stop = create_test_station(station_cd, station_g_cd, line_cd, line_group_cd);
+            if line_group_cd.is_some() {
+                stop.type_id = Some(station_cd);
+                stop.type_cd = Some(1);
+                stop.type_name = Some("急行".to_string());
+                stop.type_name_k = Some("キュウコウ".to_string());
+                stop.color = Some("#FF0000".to_string());
+            }
+            stop
+        }
+
+        fn create_route_line(line_cd: i32, line_group_cd: i32) -> Line {
+            let mut line = create_test_line(line_cd);
+            line.line_group_cd = Some(line_group_cd);
+            line
+        }
+
+        fn build_interactor(
+            stops: Vec<Station>,
+            lines: Vec<Line>,
+        ) -> QueryInteractor<
+            RouteMockStationRepository,
+            RouteMockLineRepository,
+            RouteMockTrainTypeRepository,
+            RouteMockCompanyRepository,
+        > {
+            QueryInteractor {
+                station_repository: RouteMockStationRepository { stops },
+                line_repository: RouteMockLineRepository {
+                    lines,
+                    for_routes_calls: Mutex::new(vec![]),
+                },
+                train_type_repository: RouteMockTrainTypeRepository,
+                company_repository: RouteMockCompanyRepository,
+            }
+        }
+
+        #[tokio::test]
+        async fn test_get_routes_batches_line_fetch_and_filters_groups() {
+            let stops = vec![
+                // line_group 100: 発着駅(1, 3)を含む → 採用
+                create_route_stop(1101, 1, 11, Some(100)),
+                create_route_stop(1102, 2, 11, Some(100)),
+                create_route_stop(1103, 3, 11, Some(100)),
+                // line_group 200: 発着駅を含む → 採用
+                create_route_stop(2101, 1, 22, Some(200)),
+                create_route_stop(2103, 3, 22, Some(200)),
+                // line_group 300: 発着駅を含まない → 除外
+                create_route_stop(3105, 5, 33, Some(300)),
+                create_route_stop(3106, 6, 33, Some(300)),
+                // line_group_cdなし: line_cd(44)でグループ化され種別なし
+                create_route_stop(4101, 1, 44, None),
+                create_route_stop(4103, 3, 44, None),
+            ];
+            let lines = vec![
+                create_route_line(11, 100),
+                create_route_line(12, 100),
+                create_route_line(22, 200),
+                create_route_line(33, 300),
+            ];
+            let interactor = build_interactor(stops, lines);
+
+            let routes = interactor.get_routes(1, 3, None).await.unwrap();
+
+            // 発着駅を含まないline_group 300は除外され、BTreeMapのキー順に並ぶ
+            let route_ids: Vec<u32> = routes.iter().map(|r| r.id).collect();
+            assert_eq!(route_ids, vec![44, 100, 200]);
+
+            // 路線の取得は経路候補ごとではなく一括1回で、
+            // 除外されたグループ(300)のIDは要求されない
+            {
+                let calls = interactor.line_repository.for_routes_calls.lock().unwrap();
+                assert_eq!(calls.len(), 1);
+                let mut requested = calls[0].clone();
+                requested.sort_unstable();
+                assert_eq!(requested, vec![100, 200]);
+            }
+
+            // line_group 100の停車駅は種別を持ち、グループ内の路線(11, 12)が入る
+            let route100 = routes.iter().find(|r| r.id == 100).unwrap();
+            assert_eq!(route100.stops.len(), 3);
+            for stop in &route100.stops {
+                let tt = stop.train_type.as_ref().unwrap();
+                assert_eq!(tt.group_id, 100);
+                let mut line_ids: Vec<u32> = tt.lines.iter().map(|l| l.id).collect();
+                line_ids.sort_unstable();
+                assert_eq!(line_ids, vec![11, 12]);
+            }
+
+            // line_group 200の停車駅の種別にはグループ内の路線(22)だけが入る
+            let route200 = routes.iter().find(|r| r.id == 200).unwrap();
+            assert_eq!(route200.stops.len(), 2);
+            for stop in &route200.stops {
+                let tt = stop.train_type.as_ref().unwrap();
+                assert_eq!(tt.group_id, 200);
+                let line_ids: Vec<u32> = tt.lines.iter().map(|l| l.id).collect();
+                assert_eq!(line_ids, vec![22]);
+            }
+
+            // line_group_cdなしのグループは種別を持たない
+            let route44 = routes.iter().find(|r| r.id == 44).unwrap();
+            assert_eq!(route44.stops.len(), 2);
+            assert!(route44.stops.iter().all(|s| s.train_type.is_none()));
+        }
+
+        #[tokio::test]
+        async fn test_get_routes_returns_empty_when_no_group_includes_endpoints() {
+            let stops = vec![
+                create_route_stop(3105, 5, 33, Some(300)),
+                create_route_stop(3106, 6, 33, Some(300)),
+            ];
+            let lines = vec![create_route_line(33, 300)];
+            let interactor = build_interactor(stops, lines);
+
+            let routes = interactor.get_routes(1, 3, None).await.unwrap();
+
+            assert!(routes.is_empty());
         }
     }
 }

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -1000,8 +1000,8 @@ where
 
     async fn get_train_route(
         &self,
-        from_station_group_id: u32,
-        to_station_group_id: u32,
+        from_station_id: u32,
+        to_station_id: u32,
         line_group_id: u32,
     ) -> Result<Vec<proto::TrainRouteSegment>, UseCaseError> {
         let stations = self
@@ -1010,17 +1010,17 @@ where
 
         let from_idx = stations
             .iter()
-            .position(|s| s.station_g_cd as u32 == from_station_group_id)
+            .position(|s| s.station_cd as u32 == from_station_id)
             .ok_or_else(|| UseCaseError::NotFound {
                 entity_type: "station in line group",
-                entity_id: from_station_group_id.to_string(),
+                entity_id: from_station_id.to_string(),
             })?;
         let to_idx = stations
             .iter()
-            .position(|s| s.station_g_cd as u32 == to_station_group_id)
+            .position(|s| s.station_cd as u32 == to_station_id)
             .ok_or_else(|| UseCaseError::NotFound {
                 entity_type: "station in line group",
-                entity_id: to_station_group_id.to_string(),
+                entity_id: to_station_id.to_string(),
             })?;
 
         let sliced: Vec<Station> = if from_idx <= to_idx {

--- a/stationapi/src/use_case/interactor/query.rs
+++ b/stationapi/src/use_case/interactor/query.rs
@@ -357,14 +357,14 @@ where
         for station in stations.iter_mut() {
             station.train_type = train_type_map
                 .get(&station.station_cd)
-                .cloned()
+                .copied()
                 .cloned()
                 .map(Box::new);
             if let Some(ref mut line) = station.line {
                 if let Some(ref mut nested_station) = line.station {
                     nested_station.train_type = train_type_map
                         .get(&nested_station.station_cd)
-                        .cloned()
+                        .copied()
                         .cloned()
                         .map(Box::new);
                 }
@@ -373,7 +373,7 @@ where
                 if let Some(ref mut nested_station) = line.station {
                     nested_station.train_type = train_type_map
                         .get(&nested_station.station_cd)
-                        .cloned()
+                        .copied()
                         .cloned()
                         .map(Box::new);
                 }
@@ -589,14 +589,14 @@ where
                     .collect::<Vec<Line>>();
 
                 for line in lines.iter_mut() {
-                    line.company = company_map.get(&line.company_cd).cloned().cloned();
+                    line.company = company_map.get(&line.company_cd).copied().cloned();
                     line.line_symbols = self.get_line_symbols(line);
                     line.train_type = tt_by_pair
                         .get(&(line_group_cd as u32, line.line_cd as u32))
                         .cloned();
                 }
 
-                line.company = company_map.get(&line.company_cd).cloned().cloned();
+                line.company = company_map.get(&line.company_cd).copied().cloned();
                 line.line_symbols = self.get_line_symbols(&line);
 
                 tt.lines = lines;
@@ -1436,7 +1436,7 @@ where
             station.station_numbers = station_numbers;
             if let Some(tt) = train_type_map
                 .get(&station.station_cd)
-                .cloned()
+                .copied()
                 .cloned()
                 .map(Box::new)
             {
@@ -1542,7 +1542,7 @@ where
                     station_copy.station_numbers = station_numbers;
                     if let Some(tt) = train_type_map
                         .get(&station_copy.station_cd)
-                        .cloned()
+                        .copied()
                         .cloned()
                         .map(Box::new)
                     {
@@ -1862,13 +1862,13 @@ mod tests {
     #[test]
     fn test_segment_stop_signature_identical_stops_match() {
         // Two line groups that stop at exactly the same stations between 1 and 4.
-        let local_stops = vec![
+        let local_stops = [
             create_stop(1, 100, Some(0)),
             create_stop(2, 100, Some(0)),
             create_stop(3, 100, Some(0)),
             create_stop(4, 100, Some(0)),
         ];
-        let express_stops = vec![
+        let express_stops = [
             create_stop(1, 200, Some(0)),
             create_stop(2, 200, Some(0)),
             create_stop(3, 200, Some(0)),
@@ -1887,7 +1887,7 @@ mod tests {
     #[test]
     fn test_segment_stop_signature_excludes_pass_through() {
         // Station 3 is passed through (pass == 1) and must not be part of the signature.
-        let stops = vec![
+        let stops = [
             create_stop(1, 100, Some(0)),
             create_stop(2, 100, Some(0)),
             create_stop(3, 100, Some(1)),
@@ -1902,14 +1902,14 @@ mod tests {
     #[test]
     fn test_segment_stop_signature_differs_when_stops_differ() {
         // Skips station 2.
-        let express_stops = vec![
+        let express_stops = [
             create_stop(1, 100, Some(0)),
             create_stop(2, 100, Some(1)),
             create_stop(3, 100, Some(0)),
             create_stop(4, 100, Some(0)),
         ];
         // Stops everywhere.
-        let local_stops = vec![
+        let local_stops = [
             create_stop(1, 200, Some(0)),
             create_stop(2, 200, Some(0)),
             create_stop(3, 200, Some(0)),
@@ -1927,13 +1927,13 @@ mod tests {
     #[test]
     fn test_segment_stop_signature_restricted_to_segment() {
         // Differences outside the 2→3 segment must be ignored.
-        let stops_a = vec![
+        let stops_a = [
             create_stop(1, 100, Some(0)),
             create_stop(2, 100, Some(0)),
             create_stop(3, 100, Some(0)),
             create_stop(4, 100, Some(0)),
         ];
-        let stops_b = vec![
+        let stops_b = [
             create_stop(1, 200, Some(1)),
             create_stop(2, 200, Some(0)),
             create_stop(3, 200, Some(0)),
@@ -1950,7 +1950,7 @@ mod tests {
 
     #[test]
     fn test_segment_stop_signature_direction_independent() {
-        let stops = vec![
+        let stops = [
             create_stop(1, 100, Some(0)),
             create_stop(2, 100, Some(0)),
             create_stop(3, 100, Some(0)),
@@ -1966,7 +1966,7 @@ mod tests {
 
     #[test]
     fn test_segment_stop_signature_missing_endpoint_returns_none() {
-        let stops = vec![create_stop(1, 100, Some(0)), create_stop(2, 100, Some(0))];
+        let stops = [create_stop(1, 100, Some(0)), create_stop(2, 100, Some(0))];
         let refs: Vec<&Station> = stops.iter().collect();
 
         assert!(segment_stop_signature(&refs, 1, 99).is_none());

--- a/stationapi/src/use_case/traits/query.rs
+++ b/stationapi/src/use_case/traits/query.rs
@@ -113,8 +113,8 @@ pub trait QueryUseCase: Send + Sync + 'static {
     ) -> Result<Vec<TrainType>, UseCaseError>;
     async fn get_train_route(
         &self,
-        from_station_group_id: u32,
-        to_station_group_id: u32,
+        from_station_id: u32,
+        to_station_id: u32,
         line_group_id: u32,
     ) -> Result<Vec<TrainRouteSegment>, UseCaseError>;
     async fn find_line_by_id(&self, line_id: u32) -> Result<Option<Line>, UseCaseError>;

--- a/stationapi/src/use_case/traits/query.rs
+++ b/stationapi/src/use_case/traits/query.rs
@@ -115,7 +115,7 @@ pub trait QueryUseCase: Send + Sync + 'static {
         &self,
         from_station_id: u32,
         to_station_id: u32,
-        line_group_id: u32,
+        line_group_id: Option<u32>,
     ) -> Result<Vec<TrainRouteSegment>, UseCaseError>;
     async fn find_line_by_id(&self, line_id: u32) -> Result<Option<Line>, UseCaseError>;
     async fn get_lines_by_id_vec(&self, line_ids: &[u32]) -> Result<Vec<Line>, UseCaseError>;


### PR DESCRIPTION
## 概要

`dev` に溜まっていた `GetTrainRoute` まわりの仕様変更・クエリ処理のパフォーマンス改善・新幹線の速度プロファイル修正（#1583〜#1587）を `master` へ反映する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

**GetTrainRoute 関連**

- `GetTrainRouteRequest` の駅指定をグループIDから単一IDに変更（protoサブモジュール更新を含む） (#1583)
- `GetTrainRoute` の `line_group_id` をprotoどおりoptional扱いにし未指定時は路線の駅列にフォールバック (#1586)

**パフォーマンス・コード品質**

- 経路検索のN+1クエリ解消・IPAキャッシュのArc化などクエリ処理のパフォーマンスを改善 (#1585)
- clippyの警告（useless_vec/unnecessary_map_or/clone_on_copy等）を解消 (#1584)

**到着時間推定(ETA)**

- 新幹線の速度プロファイルが種別上限130km/hに引き下げられる問題を修正 (#1587)

## テスト

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->
