### PR TITLE
速度較正テーブルのデータソースのライセンス表記を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,5 @@ We follow Rust best practices for testing:
 
 - Bus-related data provided by [Tokyo Metropolitan Bureau of Transportation (Toei)](https://www.kotsu.metro.tokyo.jp/), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
 - Station data provided by [駅データ.jp](https://www.ekidata.jp/)
+- Speed calibration data (`speed_table.rs`) derived from GTFS timetables provided by Kyoto City Transportation Bureau (京都市交通局) and Yokohama City Transportation Bureau (横浜市交通局) via the [Public Transportation Open Data Center](https://ckan.odpt.org/), licensed under the [Public Transportation Open Data Basic License](https://developer.odpt.org/terms), and by Hakodate City Enterprise Bureau Transportation Department (函館市企業局交通部), licensed under [GTFS-RUL (ODPT)](https://gtfs-jp.org/GTFS-RUL(ODPT).pdf)
+- Average inter-station distances (`average_distance`) computed from railway track geometry © [OpenStreetMap contributors](https://www.openstreetmap.org/copyright), licensed under [ODbL](https://opendatacommons.org/licenses/odbl/)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ We follow Rust best practices for testing:
 ## Data Sources
 
 - Bus-related data provided by [Tokyo Metropolitan Bureau of Transportation (Toei)](https://www.kotsu.metro.tokyo.jp/), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+- Bus-related data (experimental feed) provided by [Seibu Bus Co., Ltd. (西武バス)](https://www.seibubus.co.jp/) via the [Public Transportation Open Data Center](https://ckan.odpt.org/), licensed under the [Public Transportation Open Data Basic License](https://developer.odpt.org/terms)
 - Station data provided by [駅データ.jp](https://www.ekidata.jp/)
 - Speed calibration data (`speed_table.rs`) derived from GTFS timetables provided by Kyoto City Transportation Bureau (京都市交通局) and Yokohama City Transportation Bureau (横浜市交通局) via the [Public Transportation Open Data Center](https://ckan.odpt.org/), licensed under the [Public Transportation Open Data Basic License](https://developer.odpt.org/terms), and by Hakodate City Enterprise Bureau Transportation Department (函館市企業局交通部), licensed under [GTFS-RUL (ODPT)](https://gtfs-jp.org/GTFS-RUL(ODPT).pdf)
 - Average inter-station distances (`average_distance`) computed from railway track geometry © [OpenStreetMap contributors](https://www.openstreetmap.org/copyright), licensed under [ODbL](https://opendatacommons.org/licenses/odbl/)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -44,3 +44,41 @@ python3 scripts/compute_average_distance.py --apply
 地理データは OpenStreetMap (© OpenStreetMap contributors) を Overpass API 経由で取得しています。
 OSM データは [Open Database License (ODbL)](https://www.openstreetmap.org/copyright) の下で
 提供されています。算出した距離値を再配布する際は出典表示にご留意ください。
+
+## compute_speed_table.py
+
+`stationapi/src/domain/speed_table.rs` の自動生成ブロック(路線 × 列車種別ごとの
+実効最高速度の較正テーブル)を、公開 GTFS 時刻表から再計算します。
+到着時間推定(`arrival_estimation.rs`)の運動学モデルを Python で再現し、
+実ダイヤの所要時間を再現する実効最高速度を二分探索でフィッティングして、
+一般則(路線種別の基本速度 × 種別倍率)から ±10% 以上乖離した路線だけを出力します。
+
+### 使い方
+
+```bash
+# フィードを取得して較正結果を表示する(ファイルは書き換えない)
+python3 scripts/compute_speed_table.py --validate
+
+# speed_table.rs の自動生成ブロックを書き換える
+python3 scripts/compute_speed_table.py --apply
+```
+
+認証が必要なフィード(公共交通オープンデータセンターの大半)を使うには、
+[developer.odpt.org](https://developer.odpt.org/) で発行した無料のアクセストークンを
+環境変数 `ODPT_ACCESS_TOKEN` に設定します。未設定の場合、該当フィードはスキップされます。
+取得した GTFS は `scripts/.gtfs_cache/` にキャッシュされます(Git 管理対象外)。
+
+### データソース・ライセンス
+
+GTFS 時刻表は[公共交通オープンデータセンター](https://ckan.odpt.org/)から取得しています。
+
+| フィード | 提供事業者 | ライセンス |
+| ---- | ---- | ---- |
+| 京都市営地下鉄 | 京都市交通局 | [公共交通オープンデータ基本ライセンス](https://developer.odpt.org/terms)(要出典明示) |
+| 横浜市営地下鉄 | 横浜市交通局 | 同上 |
+| 函館市電 | 函館市企業局交通部 | [GTFS-RUL (ODPT)](https://gtfs-jp.org/GTFS-RUL(ODPT).pdf) |
+
+較正値(派生データ)を含むサービスを提供する場合は、リポジトリ直下 README の
+「Data Sources」に記載の出典表示をアプリ側のクレジットにも反映してください。
+なお、東武鉄道・京王電鉄などの「公共交通オープンデータチャレンジ限定ライセンス」の
+フィードは本番利用できないため、意図的に対象へ含めていません。


### PR DESCRIPTION
## 概要

速度較正パイプライン(#1591, #1592)で利用しているデータソースの出典・ライセンス表記を、既存の東京都交通局(CC BY 4.0)・駅データ.jp の記載に倣って README に追記する。あわせて従来から記載が漏れていた `average_distance` の元データ(OpenStreetMap)と西武バスGTFS(experimental フィード)も明記する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- **`README.md` (Data Sources)**:
  - 速度較正テーブル(`speed_table.rs`)の元データとして、京都市交通局・横浜市交通局([公共交通オープンデータ基本ライセンス](https://developer.odpt.org/terms))および函館市企業局交通部([GTFS-RUL (ODPT)](https://gtfs-jp.org/GTFS-RUL(ODPT).pdf))を追記
  - `average_distance` の元データとして © OpenStreetMap contributors([ODbL](https://opendatacommons.org/licenses/odbl/))を追記
  - `import.rs` の experimental フィードとして取り込んでいる**西武バスGTFS**(公共交通オープンデータ基本ライセンス)の出典を追記(従来未記載)
- **`scripts/README.md`**: `compute_speed_table.py` の使い方(validate/apply、`ODPT_ACCESS_TOKEN`)と、フィードごとの提供事業者×ライセンス一覧表を追加。アプリ側クレジットへの反映が必要な旨と、東武・京王(チャレンジ限定ライセンス)を対象外にしている理由も記載

いずれのライセンスもCC BYではなく公共交通オープンデータセンター独自のライセンスのため、アプリのクレジット画面には「公共交通オープンデータセンター+提供事業者名」の出典表示を追加してください。

## テスト

- [ ] `cargo fmt --all -- --check` が通ること
- [ ] `cargo clippy -- -D warnings` が通ること
- [ ] `cargo test`(`SQLX_OFFLINE=true`)が通ること

省略: ドキュメント(Markdown)のみの変更のためコードのチェックは実行していません。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsvFBx2rLj486tvj64M9eP