### PR TITLE
京王バスGTFSのダウンロード404を修正

### DIFF
--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -331,7 +331,11 @@ fn gtfs_download_url(feed: &GtfsFeed) -> Result<String, Box<dyn std::error::Erro
     Ok(append_consumer_key(feed.url, &token))
 }
 
-/// Download and extract GTFS data from ODPT API
+/// Download and extract GTFS data from ODPT API.
+///
+/// If the download or extraction fails partway, the (possibly partial) target
+/// directory is removed so a later run does not treat the incomplete extraction
+/// as a valid, importable feed.
 fn download_gtfs(feed: GtfsFeed) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let gtfs_path = Path::new(feed.path);
 
@@ -344,11 +348,33 @@ fn download_gtfs(feed: GtfsFeed) -> Result<(), Box<dyn std::error::Error + Send 
         return Ok(());
     }
 
+    match download_and_extract_gtfs(&feed, gtfs_path) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            if gtfs_path.exists() {
+                if let Err(cleanup_err) = fs::remove_dir_all(gtfs_path) {
+                    warn!(
+                        "Failed to remove partial {} GTFS directory after error: {}",
+                        feed.name, cleanup_err
+                    );
+                }
+            }
+            Err(e)
+        }
+    }
+}
+
+fn download_and_extract_gtfs(
+    feed: &GtfsFeed,
+    gtfs_path: &Path,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     info!("Downloading {} GTFS data from ODPT API...", feed.name);
 
-    // Download the ZIP file
+    // Download the ZIP file. `without_url()` strips the request URL (which carries
+    // the `acl:consumerKey` token) from any transport error so the token cannot
+    // leak into logs or propagated error messages.
     let request_start = std::time::Instant::now();
-    let response = reqwest::blocking::get(gtfs_download_url(&feed)?)?;
+    let response = reqwest::blocking::get(gtfs_download_url(feed)?).map_err(|e| e.without_url())?;
     info!(
         "[gtfs-download:{}] response received in {:?} (status={})",
         feed.id,
@@ -366,7 +392,7 @@ fn download_gtfs(feed: GtfsFeed) -> Result<(), Box<dyn std::error::Error + Send 
     }
 
     let body_start = std::time::Instant::now();
-    let bytes = response.bytes()?;
+    let bytes = response.bytes().map_err(|e| e.without_url())?;
     info!(
         "[gtfs-download:{}] body read in {:?} ({} bytes), extracting...",
         feed.id,
@@ -440,14 +466,22 @@ pub async fn import_gtfs() -> Result<(), Box<dyn std::error::Error>> {
     // import. The per-feed import loop below skips any feed whose directory is missing.
     let download_start = std::time::Instant::now();
     for feed in enabled_feeds.iter().copied() {
-        let result = tokio::task::spawn_blocking(move || download_gtfs(feed))
-            .await
-            .map_err(|e| format!("Failed to spawn blocking task: {}", e))?;
-        if let Err(e) = result {
-            warn!(
-                "Failed to download {} GTFS: {}. Skipping this feed; other feeds continue.",
-                feed.name, e
-            );
+        match tokio::task::spawn_blocking(move || download_gtfs(feed)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                warn!(
+                    "Failed to download {} GTFS: {}. Skipping this feed; other feeds continue.",
+                    feed.name, e
+                );
+            }
+            // A panic or cancellation of the blocking task must not abort the whole
+            // pipeline either: log it and let the remaining feeds proceed.
+            Err(join_err) => {
+                warn!(
+                    "{} GTFS download task did not complete ({}). Skipping this feed; other feeds continue.",
+                    feed.name, join_err
+                );
+            }
         }
     }
     info!(

--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -287,10 +287,12 @@ const GTFS_FEEDS: &[GtfsFeed] = &[
         requires_consumer_key: true,
     },
     GtfsFeed {
+        // ODPT's versioned files endpoint requires a `date` selector; `current`
+        // always resolves to the timetable in effect today (omitting it 404s).
         id: "keio",
         name: "Keio Bus",
         path: "data/KeioBus-GTFS",
-        url: "https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip",
+        url: "https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=current",
         requires_consumer_key: true,
     },
 ];
@@ -306,6 +308,14 @@ fn scoped_gtfs_id_opt(feed: &GtfsFeed, id: Option<&str>) -> Option<String> {
         .map(|s| scoped_gtfs_id(feed, s))
 }
 
+/// Append the ODPT `acl:consumerKey` query parameter to a feed URL, using the
+/// correct separator (`?` for the first parameter, `&` when the URL already
+/// carries a query string such as `?date=current`).
+fn append_consumer_key(url: &str, token: &str) -> String {
+    let separator = if url.contains('?') { '&' } else { '?' };
+    format!("{}{}acl:consumerKey={}", url, separator, token)
+}
+
 fn gtfs_download_url(feed: &GtfsFeed) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     if !feed.requires_consumer_key {
         return Ok(feed.url.to_string());
@@ -318,7 +328,7 @@ fn gtfs_download_url(feed: &GtfsFeed) -> Result<String, Box<dyn std::error::Erro
         )
     })?;
 
-    Ok(format!("{}?acl:consumerKey={}", feed.url, token))
+    Ok(append_consumer_key(feed.url, &token))
 }
 
 /// Download and extract GTFS data from ODPT API
@@ -424,13 +434,21 @@ pub async fn import_gtfs() -> Result<(), Box<dyn std::error::Error>> {
             .join(", ")
     );
 
-    // Download GTFS data if not present (use spawn_blocking to avoid blocking async runtime)
+    // Download GTFS data if not present (use spawn_blocking to avoid blocking async runtime).
+    // A single feed's download failure (e.g. an operator's ODPT outage or a moved URL)
+    // must not abort the whole pipeline: log it and continue so the other feeds still
+    // import. The per-feed import loop below skips any feed whose directory is missing.
     let download_start = std::time::Instant::now();
     for feed in enabled_feeds.iter().copied() {
-        tokio::task::spawn_blocking(move || download_gtfs(feed))
+        let result = tokio::task::spawn_blocking(move || download_gtfs(feed))
             .await
-            .map_err(|e| format!("Failed to spawn blocking task: {}", e))?
-            .map_err(|e| -> Box<dyn std::error::Error> { e })?;
+            .map_err(|e| format!("Failed to spawn blocking task: {}", e))?;
+        if let Err(e) = result {
+            warn!(
+                "Failed to download {} GTFS: {}. Skipping this feed; other feeds continue.",
+                feed.name, e
+            );
+        }
     }
     info!(
         "[gtfs] download/extract finished in {:?}",
@@ -3144,11 +3162,34 @@ mod tests {
         let keio = GTFS_FEEDS.iter().find(|feed| feed.id == "keio").unwrap();
         assert_eq!(keio.name, "Keio Bus");
         assert_eq!(keio.path, "data/KeioBus-GTFS");
+        // ODPT's versioned files endpoint 404s without a `date` selector; `current`
+        // keeps the URL pinned to the timetable in effect today.
         assert_eq!(
             keio.url,
-            "https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip"
+            "https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=current"
         );
         assert!(keio.requires_consumer_key);
+    }
+
+    #[test]
+    fn test_append_consumer_key() {
+        // URL without an existing query string uses `?`.
+        assert_eq!(
+            append_consumer_key(
+                "https://api.odpt.org/api/v4/files/SeibuBus/data/SeibuBus-GTFS.zip",
+                "TOKEN"
+            ),
+            "https://api.odpt.org/api/v4/files/SeibuBus/data/SeibuBus-GTFS.zip?acl:consumerKey=TOKEN"
+        );
+        // URL that already carries a query string (e.g. `?date=current`) uses `&`
+        // so the consumer key does not clobber the existing parameter.
+        assert_eq!(
+            append_consumer_key(
+                "https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=current",
+                "TOKEN"
+            ),
+            "https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=current&acl:consumerKey=TOKEN"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 概要

京王バス GTFS の起動時ダウンロードが HTTP 404 で失敗していた問題を修正します。

原因は、ODPT のバージョン付きファイルエンドポイント `files/odpt/KeioBus/AllLines.zip` が `date` セレクタを**必須**とする点でした。#1601 で登録した URL には `date` が無く、有効な `ODPT_ACCESS_TOKEN` を付けても 404 になっていました。フィード URL に `?date=current`（本日有効なダイヤ）を付与して解消します。

同一形式のエンドポイントを無認証で提供する宇野バスで挙動を実証済みです。

| URL | 結果 |
| --- | --- |
| `.../odpt/UnoBus/AllLines.zip?date=current` | HTTP 200・約 533KB の正常な GTFS zip |
| `.../odpt/UnoBus/AllLines.zip`（date なし） | HTTP 404 `not found`（京王と同症状） |

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- 京王バスのフィード URL に `?date=current` を付与し、常に現行ダイヤの GTFS を取得するよう修正（`date` 省略時は 404）
- `gtfs_download_url` のクエリ結合バグを修正。URL に既存のクエリ文字列がある場合は `&` で `acl:consumerKey` を連結する（純粋関数 `append_consumer_key` に切り出し、`?` / `&` 双方のユニットテストを追加）。修正前は `...?date=current?acl:consumerKey=...` と不正な URL になる
- 1 フィードのダウンロード失敗を非致命化。従来は京王の 404 が Toei / 西武を含む**全フィードのインポートを巻き添えで中断**させていたが、該当フィードのみスキップして他フィードは継続するよう変更（ディレクトリ欠落フィードは後続の取り込みループが元々スキップする）
- `test_gtfs_feeds` の URL 期待値を更新

## テスト

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

補足: 本環境に有効な `ODPT_ACCESS_TOKEN` が無いため、京王の認証付き実ダウンロード自体は未検証です。エンドポイント形式・`date=current` の挙動・URL 整形は上記の宇野バスでの実証とユニットテストで確認しています。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01SfBspXi8MZnEjwrAxvbBzz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * GTFS取得URLのクエリ生成を見直し、日付指定やトークン付きクエリをURL形式に応じて適切に付与できるよう改善しました。

* **不具合修正**
  * 取得・展開に失敗した場合でも、対象フィードのみスキップして他のフィードの取り込みを継続します。
  * 失敗時に部分的に作成されたデータを後片付けし、エラー情報へのトークン混入を防ぎます。

* **テスト**
  * 期待値とクエリ有無の動作確認を追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->