### PR TITLE
make ipa-auditが旧IPA関数名の参照でコンパイルできない問題を修正

### DIFF
--- a/tools/ipa_audit.rs
+++ b/tools/ipa_audit.rs
@@ -65,12 +65,13 @@ fn audit_dataset(dataset: &Dataset) -> Result<(), Box<dyn std::error::Error>> {
         }
 
         total_names += 1;
-        if romanized_name_to_ipa(name_roman).is_none() {
+        // カタカナ側にフォールバックさせず、ローマ字表記だけで IPA を解決できるか判定する。
+        if station_name_to_ipa("", Some(name_roman)).is_none() {
             unresolved_names += 1;
         }
 
         for token in extract_tokens(name_roman) {
-            if word_to_ipa(&token).is_some() {
+            if word_to_tts_segments(&token).is_some() {
                 continue;
             }
             let entry = unresolved_tokens.entry(token).or_default();


### PR DESCRIPTION
## 概要

`make ipa-audit` が旧 IPA 関数名を参照したままでコンパイルエラーになり実行できなくなっていたため、現行 API に追従させる。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `tools/ipa_audit.rs` の `romanized_name_to_ipa()` を `station_name_to_ipa("", Some(name_roman))` に置換。カタカナ引数を空にすることでカタカナへのフォールバックを抑止し、「ローマ字表記だけで IPA を解決できるか」という元の判定意図を保つ。
- 同じく `word_to_ipa()` を後継の `word_to_tts_segments()` に置換。

`tools/ipa_audit.rs` は `stationapi/src/domain/ipa.rs` を `include!` して単独の `rustc` でビルドする構成のため cargo のターゲットに含まれず、`ipa.rs` が TTS セグメント方式へリファクタされた際の関数リネーム（`romanized_name_to_ipa` 廃止 / `word_to_ipa` → `word_to_tts_segments`）に追従できていなかった。CSV のカラム位置（`line_name_r`=5、`station_name_r`=4、`type_name_r`=4）は現行ヘッダと一致していたため変更していない。

修正後の `make ipa-audit` 実行結果（読み取り専用レポート、これまで通り検証は失敗させない）:

```
[lines]       names:   624 total /  1 unresolved
[stations]    names: 11147 total / 59 unresolved
[train_types] names:   321 total /  1 unresolved
```

## テスト

`make ipa-audit` がビルド・実行され、3 データセット分のレポートを出力することを確認。

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ローマ字で入力された駅名の発音判定を改善しました。
  * カタカナ表記へ誤ってフォールバックせず、ローマ字表記に基づいてIPA発音を解決するようになりました。
  * 単語単位の音声分割判定も改善し、音声読み上げの精度向上を図りました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->